### PR TITLE
ユーザの表示と削除機能を追加。

### DIFF
--- a/annofabcli/__main__.py
+++ b/annofabcli/__main__.py
@@ -5,7 +5,9 @@ from typing import List, Optional, Sequence  # pylint: disable=unused-import
 import annofabcli.cancel_acceptance
 import annofabcli.complete_tasks
 import annofabcli.diff_projects
+import annofabcli.list_users
 import annofabcli.invite_users
+import annofabcli.delete_users
 import annofabcli.print_inspections
 import annofabcli.print_label_color
 import annofabcli.print_unprocessed_inspections
@@ -40,7 +42,11 @@ def main(arguments: Optional[Sequence[str]] = None):
 
     annofabcli.diff_projects.add_parser(subparsers)
 
+    annofabcli.list_users.add_parser(subparsers)
+
     annofabcli.invite_users.add_parser(subparsers)
+
+    annofabcli.delete_users.add_parser(subparsers)
 
     annofabcli.print_inspections.add_parser(subparsers)
 

--- a/annofabcli/delete_users.py
+++ b/annofabcli/delete_users.py
@@ -1,0 +1,106 @@
+"""
+プロジェクトから複数のユーザを削除する。
+"""
+import argparse
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union  # pylint: disable=unused-import
+
+import requests
+
+import annofabapi
+import annofabcli
+from annofabcli import AnnofabApiFacade
+from annofabcli.common.cli import AbstractCommandLineInterface, build_annofabapi_resource_and_login
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DeleteUser(AbstractCommandLineInterface):
+    """
+    ユーザをプロジェクトから削除する
+    """
+
+    def drop_role_with_organization(self, organization_name: str, user_id_list: List[str]):
+
+        # 進行中で自分自身が所属しているプロジェクトの一覧を取得する
+        my_account_id = self.facade.get_my_account_id()
+        projects = self.service.wrapper.get_all_projects_of_organization(
+            organization_name, query_params={
+                "status": "active",
+                "account_id": my_account_id
+            })
+
+        for project in projects:
+            project_id = project["project_id"]
+            project_title = project["title"]
+
+            try:
+                if not self.facade.my_role_is_owner(project_id):
+                    logger.warning(f"オーナではないため、プロジェクトメンバを削除できません。"
+                                   f"project_id = {project_id}, project_tilte = {project_title}")
+                    continue
+
+                self.service.wrapper.drop_role_to_project_members(project_id, user_id_list)
+                logger.info(f"{project_title}から削除成功. project_id = {project_id}")
+
+            except requests.exceptions.HTTPError as e:
+                logger.warning(e)
+                logger.warning(f"エラーのため、{project_title} から削除できなかった。")
+
+    def drop_role_with_project_id(self, project_id_list: List[str], user_id_list: List[str]):
+        for project_id in project_id_list:
+
+            try:
+                if not self.facade.my_role_is_owner(project_id):
+                    logger.warning(f"オーナではないため、プロジェクトメンバを削除できません。" f"project_id = {project_id}")
+                    continue
+
+                project_title = self.service.api.get_project(project_id)[0]["title"]
+                self.service.wrapper.drop_role_to_project_members(project_id, user_id_list)
+                logger.info(f"{project_title}から削除成功. project_id={project_id}")
+
+            except requests.exceptions.HTTPError as e:
+                logger.warning(e)
+                logger.warning(f"エラーのため、{project_title} から削除できなかった。")
+
+    def main(self, args):
+        super().process_common_args(args, __file__, logger)
+
+        user_id_list = annofabcli.common.cli.get_list_from_args(args.user_id)
+
+        if args.organization is not None:
+            self.drop_role_with_organization(args.organization, user_id_list)
+
+        elif args.project_id is not None:
+            project_id_list = annofabcli.common.cli.get_list_from_args(args.project_id)
+            self.drop_role_with_project_id(project_id_list, user_id_list)
+
+
+def main(args):
+    service = build_annofabapi_resource_and_login()
+    facade = AnnofabApiFacade(service)
+    DeleteUser(service, facade).main(args)
+
+
+def parse_args(parser: argparse.ArgumentParser):
+    parser.add_argument('-u', '--user_id', type=str, nargs='+', required=True,
+                        help='削除するユーザのuser_idを指定してください。`file://`を先頭に付けると、一覧が記載されたファイルを指定できます。')
+
+    drop_group = parser.add_mutually_exclusive_group(required=True)
+    drop_group.add_argument('-p', '--project_id', type=str, nargs='+',
+                            help='削除するプロジェクトのproject_idを指定してください。`file://`を先頭に付けると、一覧が記載されたファイルを指定できます。')
+
+    drop_group.add_argument('--organization', type=str, help='組織配下のすべてのプロジェクトから削除したい場合は、組織名を指定してください。')
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def add_parser(subparsers: argparse._SubParsersAction):
+    subcommand_name = "delete_users"
+    subcommand_help = "複数のプロジェクトから、ユーザを削除する。"
+    description = ("複数のプロジェクトから、ユーザを削除する。")
+    epilog = "オーナロールを持つユーザで実行してください。"
+
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
+    parse_args(parser)

--- a/annofabcli/delete_users.py
+++ b/annofabcli/delete_users.py
@@ -62,7 +62,7 @@ class DeleteUser(AbstractCommandLineInterface):
 
             except requests.exceptions.HTTPError as e:
                 logger.warning(e)
-                logger.warning(f"エラーのため、{project_title} から削除できなかった。")
+                logger.warning(f"エラーのため、project_id = {project_id} のプロジェクトから削除できなかった。")
 
     def main(self, args):
         super().process_common_args(args, __file__, logger)

--- a/annofabcli/list_users.py
+++ b/annofabcli/list_users.py
@@ -1,0 +1,89 @@
+"""
+プロジェクトのユーザを表示する。
+"""
+import argparse
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union  # pylint: disable=unused-import
+
+import requests
+
+import annofabapi
+import annofabcli
+from annofabcli import AnnofabApiFacade
+from annofabcli.common.cli import AbstractCommandLineInterface, build_annofabapi_resource_and_login
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ListUser(AbstractCommandLineInterface):
+    """
+    ユーザを表示する
+    """
+
+    def list_role_with_organization(self, organization_name: str):
+
+        # 進行中で自分自身が所属しているプロジェクトの一覧を取得する
+        my_account_id = self.facade.get_my_account_id()
+        try:
+            for user in self.service.wrapper.get_all_organization_members(organization_name):
+                print(f"{user['project_id']}\t{user['user_id']}\t{user['username']}")
+
+            logger.info(f"{organization_name}のユーザ表示成功。")
+
+        except requests.exceptions.HTTPError as e:
+            logger.warning(e)
+            logger.warning(f"エラーのため、{organization_name} から表示できなかった。")
+
+    def list_role_with_project_id(self, project_id_list: List[str]):
+        for project_id in project_id_list:
+            try:
+                if not self.facade.my_role_is_owner(project_id):
+                    logger.warning(f"オーナではないため、プロジェクトメンバを表示できません。" f"project_id = {project_id}")
+                    continue
+
+                project_title = self.service.api.get_project(project_id)[0]["title"]
+                for user in self.service.wrapper.get_all_project_members(project_id):
+                    print(f"{user['project_id']}\t{user['user_id']}\t{user['username']}")
+
+                logger.info(f"{project_title}から表示成功. project_id={project_id}")
+
+            except requests.exceptions.HTTPError as e:
+                logger.warning(e)
+                logger.warning(f"エラーのため、{project_title} から表示できなかった。")
+
+    def main(self, args):
+        super().process_common_args(args, __file__, logger)
+
+        if args.organization is not None:
+            self.list_role_with_organization(args.organization)
+
+        elif args.project_id is not None:
+            project_id_list = annofabcli.common.cli.get_list_from_args(args.project_id)
+            self.list_role_with_project_id(project_id_list)
+
+
+def main(args):
+    service = build_annofabapi_resource_and_login()
+    facade = AnnofabApiFacade(service)
+    ListUser(service, facade).main(args)
+
+
+def parse_args(parser: argparse.ArgumentParser):
+    list_group = parser.add_mutually_exclusive_group(required=True)
+    list_group.add_argument('-p', '--project_id', type=str, nargs='+',
+                            help='ユーザを表示するプロジェクトのproject_idを指定してください。`file://`を先頭に付けると、一覧が記載されたファイルを指定できます。')
+
+    list_group.add_argument('--organization', type=str, help='組織配下のすべてのプロジェクトのユーザを表示したい場合は、組織名を指定してください。')
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def add_parser(subparsers: argparse._SubParsersAction):
+    subcommand_name = "list_users"
+    subcommand_help = "複数のプロジェクトのユーザを表示する。"
+    description = ("複数のプロジェクトのユーザを表示する。")
+    epilog = "オーナロールを持つユーザで実行してください。"
+
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
+    parse_args(parser)

--- a/annofabcli/list_users.py
+++ b/annofabcli/list_users.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union  # pylint: 
 
 import requests
 
-import annofabapi
 import annofabcli
 from annofabcli import AnnofabApiFacade
 from annofabcli.common.cli import AbstractCommandLineInterface, build_annofabapi_resource_and_login
@@ -27,7 +26,7 @@ class ListUser(AbstractCommandLineInterface):
         my_account_id = self.facade.get_my_account_id()
         try:
             for user in self.service.wrapper.get_all_organization_members(organization_name):
-                print(f"{user['project_id']}\t{user['user_id']}\t{user['username']}")
+                print(f"{user['user_id']}\t{user['username']}")
 
             logger.info(f"{organization_name}のユーザ表示成功。")
 
@@ -50,7 +49,7 @@ class ListUser(AbstractCommandLineInterface):
 
             except requests.exceptions.HTTPError as e:
                 logger.warning(e)
-                logger.warning(f"エラーのため、{project_title} から表示できなかった。")
+                logger.warning(f"エラーのため、project_id = {project_id} のプロジェクトから表示できなかった。")
 
     def main(self, args):
         super().process_common_args(args, __file__, logger)


### PR DESCRIPTION
複数のプロジェクトのユーザを表示して、削除するテストは終わっています。
組織単位の表示・削除テストはまだしてません。