### PR TITLE
アノテーションユーザロールでもできるコマンドを増やす

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ docker run -it -e ANNOFAB_USER_ID=XXXX -e ANNOFAB_PASSWORD=YYYYY annofab-cli a
 |filesystem| write_annotation_image        | アノテーションzip、またはそれを展開したディレクトリから、アノテーションの画像（Semantic Segmentation用）を生成します。 |-|
 |input_data|delete             | 入力データを削除します。                                                            |オーナ|
 |input_data|list             | 入力データ一覧を出力します。                                                            |-|
-|input_data| list_merged_task | タスク一覧と結合した入力データ一覧のCSVを出力します。                                                            |オーナ|
+|input_data| list_merged_task | タスク一覧と結合した入力データ一覧のCSVを出力します。                                                            |オーナ/アノテーションユーザ|
 |input_data|put             | 入力データを登録します。                                                            |オーナ|
 |inspection_comment| list | 検査コメントを出力します。                               |-|
 |inspection_comment| list_unprocessed | 未処置の検査コメントを出力します。                               |-|
@@ -118,18 +118,18 @@ $ docker run -it -e ANNOFAB_USER_ID=XXXX -e ANNOFAB_PASSWORD=YYYYY annofab-cli a
 |statistics| list_by_date_user             | タスク数や作業時間などの情報を、日ごとユーザごとに出力します。                                                   |オーナ/アノテーションユーザ|
 |statistics| list_cumulative_labor_time             |       タスク進捗状況を出力します。                                                    |-|
 |statistics| list_task_progress             | タスクフェーズ別の累積作業時間を出力します。                                                            |-|
-|statistics|summarize_task_count|タスクのフェーズ、ステータス、ステップごとにタスク数を出力します。|オーナ|
-|statistics|summarize_task_count_by_task_id|task_idのプレフィックスごとに、タスク数を出力します。|オーナ|
-|statistics|summarize_task_count_by_user|ユーザごとに担当しているタスク数を出力します。|オーナ|
-|statistics| visualize             | 統計情報を可視化します。                                                            |オーナ|
-|supplementary| list             | 補助情報を出力します。                                                           |オーナ|
+|statistics|summarize_task_count|タスクのフェーズ、ステータス、ステップごとにタスク数を出力します。|オーナ/アノテーションユーザ|
+|statistics|summarize_task_count_by_task_id|task_idのプレフィックスごとに、タスク数を出力します。|オーナ/アノテーションユーザ|
+|statistics|summarize_task_count_by_user|ユーザごとに担当しているタスク数を出力します。|オーナ/アノテーションユーザ|
+|statistics| visualize             | 統計情報を可視化します。                                                            |オーナ/アノテーションユーザ|
+|supplementary| list             | 補助情報を出力します。                                                           |オーナ/アノテーションユーザ|
 |supplementary| put              | 補助情報を登録します。                                                           |オーナ|
 |task| cancel_acceptance             | 受け入れ完了タスクを、受け入れ取り消し状態にします。                                                         |オーナ|
 |task| change_operator             | タスクの担当者を変更します。                                                             |チェッカー/オーナ|
 |task| complete                | タスクを完了状態にして次のフェーズに進めます（教師付の提出、検査/受入の合格）。                                  |チェッカー/オーナ|
 |task| delete                | タスクを削除します。                                 |オーナ|
 |task|list             | タスク一覧を出力します。                                                            |-|
-|task|list_added_task_history             | タスク履歴情報を加えたタスク一覧を出力します。|オーナ|
+|task|list_added_task_history             | タスク履歴情報を加えたタスク一覧を出力します。|オーナ/アノテーションユーザ|
 |task|list_task_history             | タスク履歴の一覧を出力します。|-|
 |task| put                | タスクを作成します。                                 |オーナ|
 |task| reject                  | タスクを強制的に差し戻します。                                                                 |オーナ|

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ $ docker run -it -e ANNOFAB_USER_ID=XXXX -e ANNOFAB_PASSWORD=YYYYY annofab-cli a
 |annotation| list_count | task_idまたはinput_data_idで集約したアノテーションの個数を出力します                              |-|
 |annotation| import | アノテーションをインポートします。                             |オーナ|
 |annotation| restore |'annotation dump'コマンドで保存したファイルから、アノテーション情報をリストアします。                            |オーナ|
-|annotation_specs| history | アノテーション仕様の履歴一覧を出力します。                              |チェッカー/オーナ|
-|annotation_specs| list_label | アノテーション仕様のラベル情報を出力します。                              |チェッカー/オーナ|
-|annotation_specs| list_label_color             | アノテーション仕様から、label_nameとRGBを対応付けたJSONを出力します。                                      |チェッカー/オーナ|
+|annotation_specs| history | アノテーション仕様の履歴一覧を出力します。                              |-|
+|annotation_specs| list_label | アノテーション仕様のラベル情報を出力します。                              |-|
+|annotation_specs| list_label_color             | アノテーション仕様から、label_nameとRGBを対応付けたJSONを出力します。                                      |-|
 |filesystem| write_annotation_image        | アノテーションzip、またはそれを展開したディレクトリから、アノテーションの画像（Semantic Segmentation用）を生成します。 |-|
 |input_data|delete             | 入力データを削除します。                                                            |オーナ|
 |input_data|list             | 入力データ一覧を出力します。                                                            |-|

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -7,8 +7,6 @@ import logging
 import sys
 from typing import Any, Dict, List, Optional
 
-from annofabapi.models import ProjectMemberRole
-
 import annofabcli
 import annofabcli.common.cli
 from annofabcli import AnnofabApiFacade

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -28,8 +28,6 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
     def print_annotation_specs_label(
         self, project_id: str, arg_format: str, output: Optional[str] = None, history_id: Optional[str] = None
     ):
-        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.ACCEPTER])
-
         annotation_specs = self.service.api.get_annotation_specs(project_id, query_params={"history_id": history_id})[0]
         labels = annotation_specs["labels"]
 
@@ -172,7 +170,5 @@ def add_parser(subparsers: argparse._SubParsersAction):
 
     description = "アノテーション仕様のラベル情報を出力する"
 
-    epilog = "チェッカーまたはオーナロールを持つユーザで実行してください。"
-
-    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/print_label_color.py
+++ b/annofabcli/annotation_specs/print_label_color.py
@@ -36,8 +36,6 @@ class PrintLabelColor(AbstractCommandLineInterface):
         今のアノテーション仕様から、label名とRGBを紐付ける
         """
 
-        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.ACCEPTER])
-
         annotation_specs = self.service.api.get_annotation_specs(project_id)[0]
         labels = annotation_specs["labels"]
 
@@ -82,7 +80,6 @@ def add_parser(subparsers: argparse._SubParsersAction):
         "出力内容は`Dict[LabelName, [R,G,B]]`です。"
     )
 
-    epilog = "チェッカーまたはオーナロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/print_label_color.py
+++ b/annofabcli/annotation_specs/print_label_color.py
@@ -6,8 +6,6 @@ import argparse
 import logging
 from typing import Any, Dict, Tuple
 
-from annofabapi.models import ProjectMemberRole
-
 import annofabcli
 import annofabcli.common.cli
 from annofabcli import AnnofabApiFacade
@@ -79,7 +77,6 @@ def add_parser(subparsers: argparse._SubParsersAction):
         "出力された内容は、`write_annotation_image`ツールに利用します。"
         "出力内容は`Dict[LabelName, [R,G,B]]`です。"
     )
-
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
     parse_args(parser)

--- a/annofabcli/input_data/list_input_data_merged_task.py
+++ b/annofabcli/input_data/list_input_data_merged_task.py
@@ -104,7 +104,7 @@ class ListInputDataMergedTask(AbstractCommandLineInterface):
 
         project_id = args.project_id
         if project_id is not None:
-            super().validate_project(project_id, [ProjectMemberRole.OWNER])
+            super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
             wait_options = get_wait_options_from_args(get_json_from_args(args.wait_options), DEFAULT_WAIT_OPTIONS)
             cache_dir = annofabcli.utils.get_cache_dir()
             self.download_json_files(project_id, cache_dir, args.latest, wait_options)
@@ -176,7 +176,7 @@ def add_parser(subparsers: argparse._SubParsersAction):
     subcommand_name = "list_merged_task"
     subcommand_help = "タスク一覧と結合した入力データ一覧のCSVを出力します。"
     description = "タスク一覧と結合した入力データ一覧のCSVを出力します。"
-    epilog = "オーナロールを持つユーザで実行してください。"
+    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
     parse_args(parser)

--- a/annofabcli/statistics/summarize_task_count.py
+++ b/annofabcli/statistics/summarize_task_count.py
@@ -144,7 +144,9 @@ class SummarizeTaskCount(AbstractCommandLineInterface):
     def summarize_task_count(
         self, project_id: str, task_json_path: Optional[Path], is_latest: bool, wait_options: WaitOptions
     ) -> None:
-        super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER])
+        super().validate_project(
+            project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
+        )
 
         task_list = self.get_task_list(project_id, task_json_path, is_latest=is_latest, wait_options=wait_options)
         if len(task_list) == 0:
@@ -222,7 +224,7 @@ def add_parser(subparsers: argparse._SubParsersAction):
     subcommand_name = "summarize_task_count"
     subcommand_help = "タスクのフェーズ、ステータス、ステップごとにタスク数を出力します。"
     description = "タスクのフェーズ、ステータス、ステップごとにタスク数を、CSV形式で出力します。"
-    epilog = "オーナロールを持つユーザで実行してください。"
+    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(
         subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
     )

--- a/annofabcli/statistics/summarize_task_count_by_task_id.py
+++ b/annofabcli/statistics/summarize_task_count_by_task_id.py
@@ -136,7 +136,7 @@ class SummarizeTaskCountByTaskId(AbstractCommandLineInterface):
     def main(self):
         args = self.args
         project_id = args.project_id
-        super().validate_project(project_id, [ProjectMemberRole.OWNER])
+        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         if args.task_json is not None:
             task_json_path = args.task_json
@@ -206,7 +206,7 @@ def add_parser(subparsers: argparse._SubParsersAction):
     subcommand_name = "summarize_task_count_by_task_id"
     subcommand_help = "task_idのプレフィックスごとに、タスク数を出力します。"
     description = "task_idのプレフィックスごとに、タスク数をCSV形式で出力します。"
-    epilog = "オーナロールを持つユーザで実行してください。"
+    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(
         subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
     )

--- a/annofabcli/statistics/summarize_task_count_by_user.py
+++ b/annofabcli/statistics/summarize_task_count_by_user.py
@@ -120,7 +120,7 @@ class SummarizeTaskCountByUser(AbstractCommandLineInterface):
     def main(self):
         args = self.args
         project_id = args.project_id
-        super().validate_project(project_id, [ProjectMemberRole.OWNER])
+        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         if args.task_json is not None:
             task_json_path = args.task_json
@@ -182,7 +182,7 @@ def add_parser(subparsers: argparse._SubParsersAction):
     subcommand_name = "summarize_task_count_by_user"
     subcommand_help = "ユーザごとに、担当しているタスク数を出力します。"
     description = "ユーザごとに、担当しているタスク数をCSV形式で出力します。"
-    epilog = "オーナロールを持つユーザで実行してください。"
+    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(
         subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
     )

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -297,7 +297,9 @@ class VisualizeStatistics(AbstractCommandLineInterface):
 
         """
 
-        super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
+        super().validate_project(
+            project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
+        )
 
         checkpoint_dir = work_dir / project_id
         checkpoint_dir.mkdir(exist_ok=True, parents=True)

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -297,7 +297,7 @@ class VisualizeStatistics(AbstractCommandLineInterface):
 
         """
 
-        super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER])
+        super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         checkpoint_dir = work_dir / project_id
         checkpoint_dir.mkdir(exist_ok=True, parents=True)
@@ -436,7 +436,7 @@ def add_parser(subparsers: argparse._SubParsersAction):
     subcommand_name = "visualize"
     subcommand_help = "統計情報を可視化したファイルを出力します。"
     description = "統計情報を可視化したファイルを出力します。毎日 03:00JST頃に更新されます。"
-    epilog = "チェッカーまたはオーナロールを持つユーザで実行してください。"
+    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
     parse_args(parser)

--- a/annofabcli/task/list_tasks_added_task_history.py
+++ b/annofabcli/task/list_tasks_added_task_history.py
@@ -203,7 +203,7 @@ class ListTasksAddedTaskHistory(AbstractCommandLineInterface):
             return
 
         project_id = args.project_id
-        super().validate_project(project_id, [ProjectMemberRole.OWNER])
+        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         if args.task_json is not None and args.task_history_json is not None:
             task_json_path = args.task_json
@@ -280,6 +280,6 @@ def add_parser(subparsers: argparse._SubParsersAction):
     subcommand_name = "list_added_task_history"
     subcommand_help = "タスク履歴情報を加えたタスク一覧を出力します。"
     description = "タスク履歴情報（フェーズごとの作業時間、担当者、開始日時）を加えたタスク一覧をCSV形式で出力します。"
-    epilog = "オーナロールを持つユーザで実行してください。"
+    epilog = "アノテーションユーザ/オーナロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
     parse_args(parser)


### PR DESCRIPTION
close #260

* statistics系のコマンドを、アノテーションユーザロールでも実行できるようにする 
* [supplementary list] コマンドライン引数に`--task_id`も渡せるようにする