### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $ docker run -it -e ANNOFAB_USER_ID=XXXX -e ANNOFAB_PASSWORD=YYYYY annofab-cli a
 ログを無効化にします。
 
 
-### `--endpoint_url
+### `--endpoint_url`
 AnnoFab WebAPIのエンドポイントURLを指定します。デフォルトは https://annofab.com です。
 
 


### PR DESCRIPTION
README.md の Usage で、オプション引数がコードブロックになっていない部分がありました。
たぶんミスな気がするので、PR出します。
ミスじゃなければ無視してください。