### PR TITLE
[experimental mask visualization_dir] マスク対象外ユーザのbiographyが書き換わってしまった不具合を対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ AnnoFabのCLI(Command Line Interface)ツールです。
 
 ## 廃止予定
 * 2020-10-01以降：Pythonのサポートバージョンを3.6以上から、3.7以上に変更します。
-* 2020-11-01以降：`task list_task_history`コマンドを、`task_history list`コマンドに変更します。
 * 2020-11-01以降：以下のコマンドに全件ファイルJSONを渡せないようにします。替わりになるコマンドが追加されたためです。
     * `input_data list`コマンドから`--input_data_json`引数を削除
     * `inspection_comment list`コマンドから`--inspection_comment_json`引数を削除

--- a/annofabcli/experimental/mask_visualization_dir.py
+++ b/annofabcli/experimental/mask_visualization_dir.py
@@ -10,7 +10,6 @@ from annofabcli.common.cli import get_list_from_args
 from annofabcli.common.utils import print_csv, read_multiheader_csv
 from annofabcli.experimental.mask_user_info import (
     create_masked_user_info_df,
-    create_replacement_dict_by_biography,
     create_replacement_dict_by_user_id,
     replace_by_columns,
 )

--- a/tests/test_local_experimental.py
+++ b/tests/test_local_experimental.py
@@ -1,6 +1,9 @@
 import os
 from pathlib import Path
 
+import pandas
+
+from annofabcli.common.utils import read_multiheader_csv
 from annofabcli.experimental.mask_user_info import create_masked_name, create_masked_user_info_df
 
 # プロジェクトトップに移動する
@@ -16,32 +19,40 @@ class TestMaskUserInfo:
 
     def test_create_masked_user_info_df(self):
         # ヘッダ２行のCSVを読み込む
-        df = create_masked_user_info_df(test_dir / "user2.csv", csv_header=2)
+        df = create_masked_user_info_df(read_multiheader_csv(test_dir / "user2.csv", header_row_count=2))
         print(df)
 
         df = create_masked_user_info_df(
-            test_dir / "user2.csv", csv_header=2, not_masked_biography_set={"China"}, not_masked_user_id_set=None
+            read_multiheader_csv(test_dir / "user2.csv", header_row_count=2),
+            not_masked_biography_set={"China"},
+            not_masked_user_id_set=None,
         )
         print(df)
 
         df = create_masked_user_info_df(
-            test_dir / "user2.csv", csv_header=2, not_masked_biography_set=None, not_masked_user_id_set={"alice"}
+            read_multiheader_csv(test_dir / "user2.csv", header_row_count=2),
+            not_masked_biography_set=None,
+            not_masked_user_id_set={"alice"},
         )
         print(df)
 
         df = create_masked_user_info_df(
-            test_dir / "user2.csv", csv_header=2, not_masked_biography_set={"China"}, not_masked_user_id_set={"chris"}
+            read_multiheader_csv(test_dir / "user2.csv", header_row_count=2),
+            not_masked_biography_set={"China"},
+            not_masked_user_id_set={"chris"},
         )
         print(df)
 
     def test_create_masked_user_info_df2(self):
         # ヘッダ２行のCSVを読み込む。ただし username, biography, account_id がないCSV
         df = create_masked_user_info_df(
-            test_dir / "user2_1.csv", csv_header=2, not_masked_biography_set={"China"}, not_masked_user_id_set={"chris"}
+            read_multiheader_csv(test_dir / "user2_1.csv", header_row_count=2),
+            not_masked_biography_set={"China"},
+            not_masked_user_id_set={"chris"},
         )
         print(df)
 
     def test_create_masked_user_info_df3(self):
         # ヘッダ1行のCSVを読み込む
-        df = create_masked_user_info_df(test_dir / "user1.csv", csv_header=1)
+        df = create_masked_user_info_df(pandas.read_csv(str(test_dir / "user1.csv")))
         print(df)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -850,22 +850,7 @@ class TestTask:
             ]
         )
 
-    def test_list_task_history(self):
-        out_file = str(out_path / "task_history.csv")
-        main(
-            [
-                self.command_name,
-                "list_task_history",
-                "--project_id",
-                project_id,
-                "--task_id",
-                task_id,
-                "--format",
-                "csv",
-                "--output",
-                out_file,
-            ]
-        )
+
 
     def test_list_input_data_merged_task_with_json(self):
         out_file = str(out_path / "task.csv")
@@ -986,6 +971,23 @@ class TestTaskHistory:
                 out_file,
                 "--format",
                 "csv",
+            ]
+        )
+
+    def test_list_task_history(self):
+        out_file = str(out_path / "task_history.csv")
+        main(
+            [
+                self.command_name,
+                "list",
+                "--project_id",
+                project_id,
+                "--task_id",
+                task_id,
+                "--format",
+                "csv",
+                "--output",
+                out_file,
             ]
         )
 


### PR DESCRIPTION
* マスク対象外ユーザのbiographyが書き換わってしまった不具合を対応
     * `experimental  mask_visualization_dir`
     * `experimental  mask_user_info`