### PR TITLE
--start-date で指定した開始日より後に教師付けを開始したタスクが集計対象にならない場合がある問題を修正

### DIFF
--- a/annofabcli/statistics/database.py
+++ b/annofabcli/statistics/database.py
@@ -538,7 +538,12 @@ class Database:
             if task_histories is None or len(task_histories) == 0:
                 return False
 
-            first_started_datetime = task_histories[0]["started_datetime"]
+            has_task_creation = task_histories[0]["account_id"] is None
+            if has_task_creation and len(task_histories) < 2:
+                return False
+
+            # 初回教師付けの開始日時をfirst_started_datetimeとするため「(タスク作成)」の履歴がある場合はスキップする。
+            first_started_datetime = (task_histories[0] if not has_task_creation else task_histories[1])["started_datetime"]
             if first_started_datetime is None:
                 return False
             return dateutil.parser.parse(first_started_datetime) >= dt_start_date

--- a/annofabcli/statistics/database.py
+++ b/annofabcli/statistics/database.py
@@ -543,7 +543,9 @@ class Database:
                 return False
 
             # 初回教師付けの開始日時をfirst_started_datetimeとするため「(タスク作成)」の履歴がある場合はスキップする。
-            first_started_datetime = (task_histories[0] if not has_task_creation else task_histories[1])["started_datetime"]
+            first_started_datetime = (task_histories[0] if not has_task_creation else task_histories[1])[
+                "started_datetime"
+            ]
             if first_started_datetime is None:
                 return False
             return dateutil.parser.parse(first_started_datetime) >= dt_start_date


### PR DESCRIPTION
## 背景
slackの`#triad_tjl3_notice`に出力している集計botについて、4/2の集計にて4/1に着手したタスクが集計対象にならなかった。

## 原因
調査したところ、以下のコマンドのデバッグログの中に表示される対象タスク件数が不足していた。(0件と出た)
```sh
poetry run annofabcli statistics visualize --minimal --project_id triad-133f1aa1-b28dd2b7-7ade-4739-b5dc-464f68b4eb21 --start_date 2021-04-01 --end_date 2021-04-02 --output_dir <out_dir> --task_query '{"status":"complete"}' 
```

デバッグ出力を加えた検証の結果、タスクの登録日時をタスク開始日時としており、--start-dateより前に登録したタスクが除外されているためではないかと考えた。(集計対象からはずれたデータは、3/30および3/31に登録されており辻褄が合った)

AnnoFabのリリースノートを見ると、以下でタスク履歴にかんして修正が入っている。
https://annofab.com/docs/releases/2020.html#v01020
タスク作成時に履歴が入るようになったとのこと。
![image](https://user-images.githubusercontent.com/5271038/113432187-e447c700-9417-11eb-9d7b-7dd4547a90b5.png)

annofab-cliの実装では、必ず最初の (= Litstの0番目の) 履歴からタスク開始日時を取得するようになっているため、最初の履歴が「(タスク作成)」の場合、タスク登録日時がタスク開始日時として取得されてしまう。おそらくこれが原因と思われる。

## 対応
「(タスク作成)」がある場合は、その履歴をスキップするよう実装を修正した。
履歴が「(タスク作成)」であることの判定は、以下のAnnoFabのロジックとあわせて「最初の履歴で、かつ`account_id`が空であること」としている。
https://github.com/kurusugawa-computer/annofab/pull/8115