### PR TITLE
リリースビルド時にdev-dependenciesがインストールされている問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Upgrade pip, and install poetry, pyinstaller
         run: |
           python -m pip install --upgrade pip poetry
+          poetry add "pyinstaller==4.5.1" --lock
       - name: poetry install
         run: poetry install --no-dev
 
       - name: create executable file
         run: |
           mv annofabcli\__main__.py annofabcli\annofabcli.py
-          poetry add "pyinstaller==4.5.1"
           poetry run pyinstaller annofabcli\annofabcli.py --add-data "annofabcli/data/logging.yaml;annofabcli/data"
 
       - name: upload


### PR DESCRIPTION
Fix #571 
`poetry add`時にdev-dependenciesがインストールされていた。
`--lock`オプションを追加することでlockfileの更新だけを行い、`poetry install --no-dev`でpyinstallerをインストールする。