### PR TITLE
`task update_metadata`コマンドオプションの改善

### DIFF
--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -170,7 +170,7 @@ def parse_args(parser: argparse.ArgumentParser):
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず'--yes'を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import argparse
 import logging
-from typing import Dict, List, Optional, Union
+import multiprocessing
+from functools import partial
+from typing import Any, Collection, Dict, Optional, Union
 
 import annofabapi
 from annofabapi.models import ProjectMemberRole
@@ -21,28 +25,101 @@ Metadata = Dict[str, Union[str, bool, int]]
 
 
 class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
-    def __init__(self, service: annofabapi.Resource, all_yes: bool = False):
+    def __init__(self, service: annofabapi.Resource, is_overwrite_metadata: bool, all_yes: bool = False):
         self.service = service
+        self.is_overwrite_metadata = is_overwrite_metadata
         AbstractCommandLineWithConfirmInterface.__init__(self, all_yes)
 
-    def update_metadata_of_task(
-        self, project_id: str, task_id_list: List[str], metadata: Metadata, batch_size: Optional[int] = None
-    ):
-        if batch_size is None:
-            logger.info(f"{len(task_id_list)} 件のタスクのmetadataを、{metadata} に変更します。")
-            request_body = {task_id: metadata for task_id in task_id_list}
-            self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
+    def set_metadata_to_task(
+        self,
+        project_id: str,
+        task_id: str,
+        metadata: Dict[str, Any],
+        task_index: Optional[int] = None,
+    ) -> bool:
+        logging_prefix = f"{task_index+1} 件目" if task_index is not None else ""
 
+        task = self.service.wrapper.get_task_or_none(project_id, task_id)
+        if task is None:
+            logger.warning(f"{logging_prefix} タスク '{task_id}' は存在しないのでスキップします。")
+            return False
+
+        if not self.confirm_processing(f"タスク '{task_id}' のメタデータを更新しますか？ "):
+            return False
+
+        task["last_updated_datetime"] = task["updated_datetime"]
+        if self.is_overwrite_metadata:
+            task["metadata"] = metadata
         else:
-            logger.info(f"{len(task_id_list)} 件のタスクのmetadataを{metadata} に、{batch_size}個ずつ変更します。")
-            first_index = 0
-            while first_index < len(task_id_list):
-                logger.info(
-                    f"{first_index+1} 〜 {min(first_index+batch_size, len(task_id_list))} 件目のタスクのmetadataを更新します。"
+            task["metadata"].update(metadata)
+
+        self.service.api.put_task(project_id, task_id, request_body=task)
+        logger.debug(f"{logging_prefix} タスク '{task_id}' のメタデータを更新しました。")
+        return True
+
+    def set_metadata_to_task_wrapper(self, tpl: tuple[int, str], project_id: str, metadata: Dict[str, Any]):
+        task_index, task_id = tpl
+        return self.set_metadata_to_task(
+            project_id,
+            task_id,
+            metadata=metadata,
+            task_index=task_index,
+        )
+
+    def update_metadata_of_task2(
+        self,
+        project_id: str,
+        task_ids: Collection[str],
+        metadata: Dict[str, Any],
+        parallelism: Optional[int] = None,
+    ):
+        if self.is_overwrite_metadata:
+            logger.info(f"{len(task_ids)} 件のタスクのmetadataを、{metadata} に変更します（上書き）。")
+        else:
+            logger.info(f"{len(task_ids)} 件のタスクのmetadataに、{metadata} を追加します。")
+
+        if self.is_overwrite_metadata and self.all_yes:
+            self.update_metadata_with_patch_tasks_metadata_api(project_id, task_ids=task_ids, metadata=metadata)
+        else:
+            success_count = 0
+            if parallelism is not None:
+                partial_func = partial(
+                    self.set_metadata_to_task_wrapper,
+                    project_id=project_id,
+                    metadata=metadata,
                 )
-                request_body = {task_id: metadata for task_id in task_id_list[first_index : first_index + batch_size]}
-                self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
-                first_index += batch_size
+                with multiprocessing.Pool(parallelism) as pool:
+                    result_bool_list = pool.map(partial_func, enumerate(task_ids))
+                    success_count = len([e for e in result_bool_list if e])
+
+            else:
+                # 逐次処理
+                for task_index, task_id in enumerate(task_ids):
+                    result = self.set_metadata_to_task_wrapper(
+                        project_id,
+                        task_id,
+                        metadata=metadata,
+                        task_index=task_index,
+                    )
+                    if result:
+                        success_count += 1
+
+            logger.info(f"{success_count} / {len(task_ids)} 件のタスクのmetadataを変更しました。")
+
+    def update_metadata_with_patch_tasks_metadata_api(
+        self, project_id: str, task_ids: Collection[str], metadata: Metadata
+    ):
+        """patch_tasks_metadata webapiを呼び出して、タスクのメタデータを更新します。
+        注意：メタデータは上書きされます。
+        """
+        BATCH_SIZE = 500
+        logger.info(f"{len(task_ids)} 件のタスクのmetadataを{metadata} に、{BATCH_SIZE}個ずつ変更します。")
+        first_index = 0
+        while first_index < len(task_ids):
+            logger.info(f"{first_index+1} 〜 {min(first_index+BATCH_SIZE, len(task_ids))} 件目のタスクのmetadataを更新します。")
+            request_body = {task_id: metadata for task_id in task_ids[first_index : first_index + BATCH_SIZE]}
+            self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
+            first_index += BATCH_SIZE
 
 
 class UpdateMetadataOfTask(AbstractCommandLineInterface):
@@ -51,10 +128,8 @@ class UpdateMetadataOfTask(AbstractCommandLineInterface):
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id)
         metadata = annofabcli.common.cli.get_json_from_args(args.metadata)
         super().validate_project(args.project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
-        main_obj = UpdateMetadataOfTaskMain(self.service)
-        main_obj.update_metadata_of_task(
-            args.project_id, task_id_list=task_id_list, metadata=metadata, batch_size=args.batch_size
-        )
+        main_obj = UpdateMetadataOfTaskMain(self.service, is_overwrite_metadata=args.overwrite, all_yes=args.yes)
+        main_obj.update_metadata_of_task(args.project_id, task_id_list=task_id_list, metadata=metadata)
 
 
 def main(args):
@@ -77,12 +152,15 @@ def parse_args(parser: argparse.ArgumentParser):
     )
 
     parser.add_argument(
-        "--batch_size",
-        required=False,
-        default=500,
-        type=int,
-        help="タスクのメタデータを何個ごとに更新するかを指定してください。一度に更新するタスクが多いとタイムアウトが発生する恐れがあります。",
+        "--overwrite",
+        action="store_true",
+        help="指定した場合、メタデータを上書きして更新します（すでに設定されているメタデータは削除されます）。指定しない場合、 ``--metadata`` に指定されたキーのみ更新されます。",
     )
+
+    parser.add_argument(
+        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+    )
+
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import sys
 import argparse
 import logging
 import multiprocessing
@@ -13,6 +13,7 @@ import annofabcli
 import annofabcli.common.cli
 from annofabcli import AnnofabApiFacade
 from annofabcli.common.cli import (
+    COMMAND_LINE_ERROR_STATUS_CODE,
     AbstractCommandLineInterface,
     AbstractCommandLineWithConfirmInterface,
     ArgumentParser,
@@ -30,6 +31,12 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
         self.is_overwrite_metadata = is_overwrite_metadata
         AbstractCommandLineWithConfirmInterface.__init__(self, all_yes)
 
+    def get_confirm_message(self, task_id: str, metadata: dict[str, Any]) -> str:
+        if self.is_overwrite_metadata:
+            return f"タスク '{task_id}' のメタデータを '{metadata}' に変更しますか？ "
+        else:
+            return f"タスク '{task_id}' のメタデータに '{metadata}' を追加しますか？ "
+
     def set_metadata_to_task(
         self,
         project_id: str,
@@ -44,7 +51,9 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{logging_prefix} タスク '{task_id}' は存在しないのでスキップします。")
             return False
 
-        if not self.confirm_processing(f"タスク '{task_id}' のメタデータを更新しますか？ "):
+        logger.debug(f"task_id: {task_id}, metadata='{task['metadata']}'")
+
+        if not self.confirm_processing(self.get_confirm_message(task_id, metadata)):
             return False
 
         task["last_updated_datetime"] = task["updated_datetime"]
@@ -66,7 +75,7 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
             task_index=task_index,
         )
 
-    def update_metadata_of_task2(
+    def update_metadata_of_task(
         self,
         project_id: str,
         task_ids: Collection[str],
@@ -74,9 +83,9 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
         parallelism: Optional[int] = None,
     ):
         if self.is_overwrite_metadata:
-            logger.info(f"{len(task_ids)} 件のタスクのmetadataを、{metadata} に変更します（上書き）。")
+            logger.info(f"{len(task_ids)} 件のタスクのメタデータを、{metadata} に変更します（上書き）。")
         else:
-            logger.info(f"{len(task_ids)} 件のタスクのmetadataに、{metadata} を追加します。")
+            logger.info(f"{len(task_ids)} 件のタスクのメタデータに、{metadata} を追加します。")
 
         if self.is_overwrite_metadata and self.all_yes:
             self.update_metadata_with_patch_tasks_metadata_api(project_id, task_ids=task_ids, metadata=metadata)
@@ -95,7 +104,7 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
             else:
                 # 逐次処理
                 for task_index, task_id in enumerate(task_ids):
-                    result = self.set_metadata_to_task_wrapper(
+                    result = self.set_metadata_to_task(
                         project_id,
                         task_id,
                         metadata=metadata,
@@ -115,21 +124,41 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
         BATCH_SIZE = 500
         logger.info(f"{len(task_ids)} 件のタスクのmetadataを{metadata} に、{BATCH_SIZE}個ずつ変更します。")
         first_index = 0
-        while first_index < len(task_ids):
-            logger.info(f"{first_index+1} 〜 {min(first_index+BATCH_SIZE, len(task_ids))} 件目のタスクのmetadataを更新します。")
-            request_body = {task_id: metadata for task_id in task_ids[first_index : first_index + BATCH_SIZE]}
+        task_id_list = list(task_ids)
+        while first_index < len(task_id_list):
+            logger.info(f"{first_index+1} 〜 {min(first_index+BATCH_SIZE, len(task_id_list))} 件目のタスクのmetadataを更新します。")
+            request_body = {task_id: metadata for task_id in task_id_list[first_index : first_index + BATCH_SIZE]}
             self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
             first_index += BATCH_SIZE
 
 
 class UpdateMetadataOfTask(AbstractCommandLineInterface):
+    @staticmethod
+    def validate(args: argparse.Namespace) -> bool:
+        COMMON_MESSAGE = "annofabcli task update_metadata: error:"
+
+        if args.parallelism is not None and not args.yes:
+            print(
+                f"{COMMON_MESSAGE} argument --parallelism: '--parallelism' を指定するときは、必ず '--yes' を指定してください。",
+                file=sys.stderr,
+            )
+            return False
+
+        return True
+
     def main(self):
         args = self.args
+
+        if not self.validate(args):
+            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id)
         metadata = annofabcli.common.cli.get_json_from_args(args.metadata)
         super().validate_project(args.project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
         main_obj = UpdateMetadataOfTaskMain(self.service, is_overwrite_metadata=args.overwrite, all_yes=args.yes)
-        main_obj.update_metadata_of_task(args.project_id, task_id_list=task_id_list, metadata=metadata)
+        main_obj.update_metadata_of_task(
+            args.project_id, task_ids=task_id_list, metadata=metadata, parallelism=args.parallelism
+        )
 
 
 def main(args):
@@ -160,7 +189,6 @@ def parse_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
     )
-
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -136,6 +136,8 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
         """patch_tasks_metadata webapiを呼び出して、タスクのメタデータを更新します。
         注意：メタデータは上書きされます。
         """
+
+        # 1000件以上の大量のタスクを一度に更新しようとするとwebapiが失敗するので、何回かに分けてメタデータを更新するようにする。
         BATCH_SIZE = 500
         logger.info(f"{len(task_ids)} 件のタスクのmetadataを{metadata} に、{BATCH_SIZE}個ずつ変更します。")
         first_index = 0

--- a/docs/command_reference/task/update_metadata.rst
+++ b/docs/command_reference/task/update_metadata.rst
@@ -76,7 +76,7 @@ Examples
 
 .. note::
 
-    ``--overwrite --yes`` オプションを指定すると `patchTasksMetadata <https://annofab.com/docs/api/#operation/patchTasksMetadata>`_ WebAPIを使ってタスクのメタデータを更新するので、通常より処理時間が大幅に短くなります。
+    ``--overwrite --yes`` の両方を指定すると、通常より処理時間が大幅に短くなります。これは、task_idを複数指定できる `patchTasksMetadata <https://annofab.com/docs/api/#operation/patchTasksMetadata>`_ WebAPIを使ってタスクのメタデータを更新するからです。
     1万件以上の大量のタスクに対して初めてメタデータを付与するときは、``--overwrite --yes`` オプションを指定することを推奨します。
 
 

--- a/docs/command_reference/task/update_metadata.rst
+++ b/docs/command_reference/task/update_metadata.rst
@@ -44,31 +44,58 @@ Examples
 
 
 
+
+デフォルトでは ``--metadata`` に指定したキーのみ更新されます。メタデータ自体を上書きする場合は ``--overwrite`` を指定してください。
+
+
+.. code-block::
+
+    $ annofabcli task update_metadata --project_id prj1 --task_id task1 \
+     --metadata '{"category":"202010"}'
+
+    $ annofabcli task list --project_id prj1 --task_id task1 \
+     --format json --query "[0].metadata"
+    {"category": "202010"}
+
+    # メタデータの一部のキーのみ更新する
+    $ annofabcli task update_metadata --project_id prj1 --task_id task1 \
+     --metadata '{"country":"Japan"}'
+    $ annofabcli task list --project_id prj1 --task_id task1 \
+     --format json --query "[0].metadata"
+    {"category": "202010", "country":"Japan"}
+
+    # メタデータ自体を上書きする
+    $ annofabcli task update_metadata --project_id prj1 --task_id task1 \
+     --metadata '{"weather":"sunny"}' --overwrite
+    $ annofabcli task list --project_id prj1 --task_id task1 \
+     --format json --query "[0].metadata"
+    {"weather":"sunny"}
+
+
+
+
 .. note::
 
-    一度に大量のタスクのメタデータを更新すると、タイムアウトが発生する場合があります。
-    タイムアウトが発生した場合は、``--batch_size`` を指定して、更新するタスク数を減らしてください。
+    ``--overwrite --yes`` オプションを指定すると `patchTasksMetadata <https://annofab.com/docs/api/#operation/patchTasksMetadata>`_ WebAPIを使ってタスクのメタデータを更新するので、通常より処理時間が大幅に短くなります。
+    1万件以上の大量のタスクに対して初めてメタデータを付与するときは、``--overwrite --yes`` オプションを指定することを推奨します。
 
 
-.. warning::
 
-    メタデータを更新すると、メタデータ自体が上書きされます。
-    メタデータの一部のキーのみ更新することはできません。
 
-    .. code-block::
+並列処理
+----------------------------------------------
 
-        $ annofabcli task list --project_id prj1 --task_id task1 --format json \
-        --query "[0].metadata"
-        {"priority": 2}
+以下のコマンドは、並列数4で実行します。
 
-        # メタデータに`required`キーも追加しようとする
-        $ annofabcli task update_metadata --project_id prj1 --task_id task1 \
-        --metadata '{"rquired":true}'
+.. code-block::
 
-        # 更新前の`priority`キーが消えてしまった
-        $ annofabcli task list --project_id prj1 --task_id task1 --format json \
-        --query "[0].metadata"
-        {"required": true}
+    $ annofabcli task update_metadata --project_id prj1 \
+     --task_id file://input_data_id.txt \
+     --metadata '{"category":"202010"}' --parallelism 4 --yes
+
+
+
+
 
 Usage Details
 =================================

--- a/docs/examples/edit_annotation.rst
+++ b/docs/examples/edit_annotation.rst
@@ -15,18 +15,18 @@ AnnoFabcliではAnnofabプロジェクト内のアノテーションのエクス
 =================================
 
 既存のAnnoFabプロジェクト内のアノテーションをエクスポートする
---------------------------
+------------------------------------------------------------------------------
 
-1. annotation dump コマンド (https://annofab-cli.readthedocs.io/ja/latest/command_reference/annotation/dump.html) を利用してアノテーションをエクスポートします。
+1. `annotation dump <https://annofab-cli.readthedocs.io/ja/latest/command_reference/annotation/dump.html>`_ コマンドを利用してアノテーションをエクスポートします。
 
 .. code-block::
 
-    annofabcli annotation dump --project_id prj1 --task_id file://task.txt --output_dir dump-dir/
+    $ annofabcli annotation dump --project_id prj1 --task_id file://task.txt --output_dir dump-dir/
 
 
 
 エクスポートしたアノテーションを加工する
---------------------------
+------------------------------------------------------------------------------
 
 1. エクスポートされたアノテーションをコマンド・スクリプト等を用いて加工します。
 
@@ -34,7 +34,7 @@ AnnoFabcliではAnnofabプロジェクト内のアノテーションのエクス
 
 .. code-block::
 
-    #!/bin/sh
+    #!/bin/bash
     from_dir=$1
     to_dir=$2
 
@@ -50,24 +50,24 @@ AnnoFabcliではAnnofabプロジェクト内のアノテーションのエクス
 
 
 アノテーションをインポートする
---------------------------
+----------------------------------------------------
 
 1. アノテーションのインポートはエクスポート元のプロジェクト・新しく作成したプロジェクト、どちらでも利用することができます。
 
 新しく作成したプロジェクトで利用する場合、エクスポート元のプロジェクトと同一のデータ・タスクが存在する必要があります。
-project copy コマンド (https://annofab-cli.readthedocs.io/ja/latest/command_reference/project/copy.html) を利用して、エクスポート元のプロジェクトをコピーすることで同一のデータ・タスクのプロジェクトを作成できます。
+`project copy <https://annofab-cli.readthedocs.io/ja/latest/command_reference/project/copy.html>`_ コマンドを利用して、エクスポート元のプロジェクトをコピーすることで同一のデータ・タスクのプロジェクトを作成できます。
 
 .. code-block::
 
-    annofabcli project copy --project_id prj1 --dest_title prj2-title  --dest_project_id prj2 --copy_tasks
+    $ annofabcli project copy --project_id prj1 --dest_title prj2-title  --dest_project_id prj2 --copy_tasks
 
 
 
-2. annotation restore コマンド(https://annofab-cli.readthedocs.io/ja/latest/command_reference/annotation/restore.html) を利用して、編集したアノテーションをインポートします。
+2. `annotation restore <https://annofab-cli.readthedocs.io/ja/latest/command_reference/annotation/restore.html>`_ コマンド を利用して、編集したアノテーションをインポートします。
 
 .. code-block::
 
-    annofabcli annotation restore --project_id prj2 --annotation dump-dir/
+    $ annofabcli annotation restore --project_id prj2 --annotation dump-dir/
 
 
 


### PR DESCRIPTION
# `task update_metadata` コマンドのオプションを改善しました。
* デフォルトではメタデータが常に上書きされましたが、`--overwrite`オプションで上書きするかどうかを指定できるようにしました。
* `--parallelism` を指定しました。
* `--batch_size` を削除しました。指定する機会がほとんどないためです。