### PR TITLE
コマンドリファレンスを修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as devcontainer
+FROM ubuntu:20.04 as devcontainer
 
 RUN set -x \
     && sed -i.bak -r 's!(deb|deb-src) \S+!\1 mirror://mirrors.ubuntu.com/mirrors.txt!' /etc/apt/sources.list
@@ -101,25 +101,24 @@ RUN set -x \
     && chmod +x /usr/local/devcontainer-tool/bin/docker-compose
 ENV PATH=/usr/local/devcontainer-tool/bin:${PATH}
 
-# python3.8
+# python3.9
 RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        python3.8 \
-        python3-distutils \
+        python3.9 \
+        python3.9-dev \
+        python3-pip \
     && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
-    && ln -s $(which python3.8) /usr/local/bin/python
-
-# pip
-RUN set -x \
-    && curl -sSL https://bootstrap.pypa.io/get-pip.py | sudo -u vscode -i python - 
+    && ln -s $(which python3.9) /usr/local/bin/python
 ENV PIP_DEFAULT_TIMEOUT=100
+
 
 # poetry
 RUN set -x \
-    && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | sudo -u vscode -i python - \
-    && sudo -u vscode -i /home/vscode/.local/bin/poetry config virtualenvs.in-project true
-ENV PATH=$PATH:/home/vscode/.local/bin
+    && python -m pip install -U pip setuptools \
+    && pip install poetry \
+    && sudo -u vscode -i poetry config virtualenvs.in-project true
+
 
 # fix poetry issue (see: https://github.com/python-poetry/poetry/issues/221)
 RUN set -x \

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -106,15 +106,6 @@ def create_parent_parser() -> argparse.ArgumentParser:
 
     group.add_argument("--yes", action="store_true", help="処理中に現れる問い合わせに対して、常に ``yes`` と回答します。")
 
-    # EXAMPLE_CREDENTAILS = '{"user_id": "test_user", "password": "test_password"}'
-    # group.add_argument(
-    #     "--credentials",
-    #     type=str,
-    #     help=f"AnnoFabにログインするユーザの認証情報をJSON形式で指定します。"
-    #     f"(ex) `{EXAMPLE_CREDENTAILS}` ."
-    #     f"`file://`を先頭に付けると、JSON形式のファイルを指定できます。",
-    # )
-
     group.add_argument(
         "--endpoint_url", type=str, help=f"AnnoFab WebAPIのエンドポイントを指定します。指定しない場合は ``{DEFAULT_ENDPOINT_URL}`` です。"
     )

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -116,7 +116,7 @@ def create_parent_parser() -> argparse.ArgumentParser:
     # )
 
     group.add_argument(
-        "--endpoint_url", type=str, help=f"AnnoFab WebAPIのエンドポイントを指定します。指定しない場合は`{DEFAULT_ENDPOINT_URL}`です。"
+        "--endpoint_url", type=str, help=f"AnnoFab WebAPIのエンドポイントを指定します。指定しない場合は ``{DEFAULT_ENDPOINT_URL}`` です。"
     )
 
     group.add_argument(

--- a/docs/command_reference/annotation/change_attributes.rst
+++ b/docs/command_reference/annotation/change_attributes.rst
@@ -55,6 +55,7 @@ Usage Details
     :ref: annofabcli.annotation.change_annotation_attributes.add_parser
     :prog: annofabcli annotation change_attributes
     :nosubcommands:
+    :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/annotation/delete.rst
+++ b/docs/command_reference/annotation/delete.rst
@@ -55,6 +55,7 @@ Usage Details
     :ref: annofabcli.annotation.delete_annotation.add_parser
     :prog: annofabcli annotation delete
     :nosubcommands:
+    :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/annotation/dump.rst
+++ b/docs/command_reference/annotation/dump.rst
@@ -46,6 +46,7 @@ Usage Details
     :ref: annofabcli.annotation.dump_annotation.add_parser
     :prog: annofabcli annotation dump
     :nosubcommands:
+    :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/annotation/import.rst
+++ b/docs/command_reference/annotation/import.rst
@@ -161,6 +161,7 @@ Usage Details
     :ref: annofabcli.annotation.import_annotation.add_parser
     :prog: annofabcli annotation import
     :nosubcommands:
+    :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/annotation/list.rst
+++ b/docs/command_reference/annotation/list.rst
@@ -124,3 +124,4 @@ Usage Details
     :ref: annofabcli.annotation.list_annotation.add_parser
     :prog: annofabcli annotation list
     :nosubcommands:
+    :nodefaultconst:

--- a/docs/command_reference/annotation/list_count.rst
+++ b/docs/command_reference/annotation/list_count.rst
@@ -77,6 +77,7 @@ Usage Details
     :ref: annofabcli.annotation.list_annotation_count.add_parser
     :prog: annofabcli annotation list_count
     :nosubcommands:
+    :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/annotation/restore.rst
+++ b/docs/command_reference/annotation/restore.rst
@@ -56,6 +56,7 @@ Usage Details
     :ref: annofabcli.annotation.restore_anotation.add_parser
     :prog: annofabcli annotation restore
     :nosubcommands:
+    :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/annotation_specs/list_history.rst
+++ b/docs/command_reference/annotation_specs/list_history.rst
@@ -59,3 +59,4 @@ Usage Details
    :ref: annofabcli.annotation_specs.list_annotation_specs_history.add_parser
    :prog: annofabcli annotation_specs list_history
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/annotation_specs/list_label.rst
+++ b/docs/command_reference/annotation_specs/list_label.rst
@@ -135,6 +135,7 @@ Usage Details
    :ref: annofabcli.annotation_specs.list_annotation_specs_label.add_parser
    :prog: annofabcli annotation_specs list_label
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/annotation_specs/list_label_color.rst
+++ b/docs/command_reference/annotation_specs/list_label_color.rst
@@ -56,4 +56,5 @@ Usage Details
    :ref: annofabcli.annotation_specs.print_label_color.add_parser
    :prog: annofabcli annotation_specs list_label_color
    :nosubcommands:
+   :nodefaultconst:
 

--- a/docs/command_reference/filesystem/draw_annotation.rst
+++ b/docs/command_reference/filesystem/draw_annotation.rst
@@ -220,6 +220,7 @@ Usage Details
    :ref: annofabcli.filesystem.draw_annotation.add_parser
    :prog: annofabcli filesystem draw_annotation
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/filesystem/filter_annotation.rst
+++ b/docs/command_reference/filesystem/filter_annotation.rst
@@ -45,6 +45,7 @@ Usage Details
    :ref: annofabcli.filesystem.filter_annotation.add_parser
    :prog: annofabcli filesystem filter_annotation
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/filesystem/mask_user_info.rst
+++ b/docs/command_reference/filesystem/mask_user_info.rst
@@ -86,3 +86,4 @@ Usage Details
    :ref: annofabcli.filesystem.mask_user_info.add_parser
    :prog: annofabcli filesystem mask_user_info
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/filesystem/merge_annotation.rst
+++ b/docs/command_reference/filesystem/merge_annotation.rst
@@ -116,6 +116,7 @@ Usage Details
    :ref: annofabcli.filesystem.merge_annotation.add_parser
    :prog: annofabcli filesystem merge_annotation
    :nosubcommands:
+   :nodefaultconst:
     
 
 See also

--- a/docs/command_reference/filesystem/write_annotation_image.rst
+++ b/docs/command_reference/filesystem/write_annotation_image.rst
@@ -203,6 +203,7 @@ Usage Details
    :ref: annofabcli.filesystem.write_annotation_image.add_parser
    :prog: annofabcli filesystem write_annotation_image
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/input_data/delete.rst
+++ b/docs/command_reference/input_data/delete.rst
@@ -61,4 +61,5 @@ Usage Details
    :ref: annofabcli.input_data.delete_input_data.add_parser
    :prog: annofabcli input_data delete
    :nosubcommands:
+   :nodefaultconst:
 

--- a/docs/command_reference/input_data/list.rst
+++ b/docs/command_reference/input_data/list.rst
@@ -143,6 +143,7 @@ Usage Details
    :ref: annofabcli.input_data.list_input_data.add_parser
    :prog: annofabcli input_data list
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/input_data/list_merged_task.rst
+++ b/docs/command_reference/input_data/list_merged_task.rst
@@ -120,3 +120,4 @@ Usage Details
    :ref: annofabcli.input_data.list_input_data_merged_task.add_parser
    :prog: annofabcli input_data list_merged_task
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/input_data/list_with_json.rst
+++ b/docs/command_reference/input_data/list_with_json.rst
@@ -70,6 +70,7 @@ Usage Details
    :ref: annofabcli.input_data.list_input_data_with_json.add_parser
    :prog: annofabcli input_data list_with_json
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/input_data/put.rst
+++ b/docs/command_reference/input_data/put.rst
@@ -145,5 +145,6 @@ Usage Details
    :ref: annofabcli.input_data.put_input_data.add_parser
    :prog: annofabcli input_data put
    :nosubcommands:
+   :nodefaultconst:
 
 

--- a/docs/command_reference/input_data/update_metadata.rst
+++ b/docs/command_reference/input_data/update_metadata.rst
@@ -83,3 +83,4 @@ Usage Details
    :ref: annofabcli.input_data.update_metadata_of_input_data.add_parser
    :prog: annofabcli input_data update_metadata
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/inspection_comment/delete.rst
+++ b/docs/command_reference/inspection_comment/delete.rst
@@ -53,3 +53,4 @@ Usage Details
    :ref: annofabcli.inspection_comment.delete_inspection_comments.add_parser
    :prog: annofabcli inspection_comment delete
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/inspection_comment/list.rst
+++ b/docs/command_reference/inspection_comment/list.rst
@@ -106,6 +106,7 @@ Usage Details
    :ref: annofabcli.inspection_comment.list_inspections.add_parser
    :prog: annofabcli inspection_comment list
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/inspection_comment/list_with_json.rst
+++ b/docs/command_reference/inspection_comment/list_with_json.rst
@@ -58,6 +58,7 @@ Usage Details
    :ref: annofabcli.inspection_comment.list_inspections_with_json.add_parser
    :prog: annofabcli inspection_comment list_with_json
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/inspection_comment/put.rst
+++ b/docs/command_reference/inspection_comment/put.rst
@@ -83,3 +83,4 @@ Usage Details
    :ref: annofabcli.inspection_comment.put_inspection_comments.add_parser
    :prog: annofabcli inspection_comment put
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/instruction/copy.rst
+++ b/docs/command_reference/instruction/copy.rst
@@ -28,3 +28,4 @@ Usage Details
    :ref: annofabcli.instruction.copy_instruction.add_parser
    :prog: annofabcli instruction copy
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/instruction/download.rst
+++ b/docs/command_reference/instruction/download.rst
@@ -88,6 +88,7 @@ Usage Details
    :ref: annofabcli.instruction.download_instruction.add_parser
    :prog: annofabcli instruction download
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/instruction/list_history.rst
+++ b/docs/command_reference/instruction/list_history.rst
@@ -63,3 +63,4 @@ Usage Details
    :ref: annofabcli.instruction.list_instruction_history.add_parser
    :prog: annofabcli instruction list_history
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/instruction/upload.rst
+++ b/docs/command_reference/instruction/upload.rst
@@ -66,3 +66,4 @@ Usage Details
    :ref: annofabcli.instruction.upload_instruction.add_parser
    :prog: annofabcli instruction upload
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/job/delete.rst
+++ b/docs/command_reference/job/delete.rst
@@ -32,3 +32,4 @@ Usage Details
    :ref: annofabcli.job.delete_job.add_parser
    :prog: annofabcli job delete
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/job/list.rst
+++ b/docs/command_reference/job/list.rst
@@ -72,3 +72,4 @@ Usage Details
    :ref: annofabcli.job.list_job.add_parser
    :prog: annofabcli job list
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/job/list_last.rst
+++ b/docs/command_reference/job/list_last.rst
@@ -91,3 +91,4 @@ Usage Details
    :ref: annofabcli.job.list_last_job.add_parser
    :prog: annofabcli job list_last
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/job/list_task_creation_history.rst
+++ b/docs/command_reference/job/list_task_creation_history.rst
@@ -88,3 +88,4 @@ Usage Details
    :ref: annofabcli.job.list_generated_task_history.add_parser
    :prog: annofabcli job list_task_creation_history
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/job/wait.rst
+++ b/docs/command_reference/job/wait.rst
@@ -31,3 +31,4 @@ Usage Details
    :ref: annofabcli.job.wait_job.add_parser
    :prog: annofabcli job wait
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/labor/list_worktime_by_user.rst
+++ b/docs/command_reference/labor/list_worktime_by_user.rst
@@ -80,3 +80,4 @@ Usage Details
    :ref: annofabcli.labor.list_worktime_by_user.add_parser
    :prog: annofabcli labor list_worktime_by_user
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/organization_member/list.rst
+++ b/docs/command_reference/organization_member/list.rst
@@ -74,3 +74,4 @@ Usage Details
    :ref: annofabcli.organization_member.list_organization_member.add_parser
    :prog: annofabcli organization_member list
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project/change_status.rst
+++ b/docs/command_reference/project/change_status.rst
@@ -39,3 +39,4 @@ Usage Details
    :ref: annofabcli.project.change_project_status.add_parser
    :prog: annofabcli project change_status
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project/copy.rst
+++ b/docs/command_reference/project/copy.rst
@@ -57,3 +57,4 @@ Usage Details
    :ref: annofabcli.project.copy_project.add_parser
    :prog: annofabcli project copy
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project/diff.rst
+++ b/docs/command_reference/project/diff.rst
@@ -69,3 +69,4 @@ Usage Details
    :ref: annofabcli.project.diff_projects.add_parser
    :prog: annofabcli project diff
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project/download.rst
+++ b/docs/command_reference/project/download.rst
@@ -71,6 +71,7 @@ Usage Details
    :ref: annofabcli.project.download.add_parser
    :prog: annofabcli project download
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/project/list.rst
+++ b/docs/command_reference/project/list.rst
@@ -176,3 +176,4 @@ Usage Details
    :ref: annofabcli.project.list_project.add_parser
    :prog: annofabcli project list
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project/update_annotation_zip.rst
+++ b/docs/command_reference/project/update_annotation_zip.rst
@@ -55,3 +55,4 @@ Usage Details
    :ref: annofabcli.project.update_annotation_zip.add_parser
    :prog: annofabcli project update_annotation_zip
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project_member/change.rst
+++ b/docs/command_reference/project_member/change.rst
@@ -56,3 +56,4 @@ Usage Details
    :ref: annofabcli.project_member.change_project_members.add_parser
    :prog: annofabcli project_member change
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project_member/copy.rst
+++ b/docs/command_reference/project_member/copy.rst
@@ -36,3 +36,4 @@ Usage Details
    :ref: annofabcli.project_member.copy_project_members.add_parser
    :prog: annofabcli project_member copy
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project_member/delete.rst
+++ b/docs/command_reference/project_member/delete.rst
@@ -35,4 +35,5 @@ Usage Details
    :ref: annofabcli.project_member.drop_project_members.add_parser
    :prog: annofabcli project_member delete
    :nosubcommands:
+   :nodefaultconst:
 

--- a/docs/command_reference/project_member/invite.rst
+++ b/docs/command_reference/project_member/invite.rst
@@ -44,3 +44,4 @@ Usage Details
    :ref: annofabcli.project_member.invite_project_members.add_parser
    :prog: annofabcli project_member change
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/project_member/list.rst
+++ b/docs/command_reference/project_member/list.rst
@@ -93,4 +93,5 @@ Usage Details
    :ref: annofabcli.project_member.list_users.add_parser
    :prog: annofabcli project_member list
    :nosubcommands:
+   :nodefaultconst:
 

--- a/docs/command_reference/project_member/put.rst
+++ b/docs/command_reference/project_member/put.rst
@@ -59,3 +59,4 @@ Usage Details
    :ref: annofabcli.project_member.put_project_members.add_parser
    :prog: annofabcli project_member put
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/stat_visualization/mask_user_info.rst
+++ b/docs/command_reference/stat_visualization/mask_user_info.rst
@@ -90,6 +90,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.mask_visualization_dir.add_parser
    :prog: annofabcli stat_visualization mask_user_info
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/merge.rst
+++ b/docs/command_reference/stat_visualization/merge.rst
@@ -61,6 +61,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.merge_visualization_dir.add_parser
    :prog: annofabcli stat_visualization merge
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/merge_performance_csv_per_date.rst
+++ b/docs/command_reference/stat_visualization/merge_performance_csv_per_date.rst
@@ -34,6 +34,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.merge_performance_per_date.add_parser
    :prog: annofabcli stat_visualization merge_performance_csv_per_date
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/merge_performance_csv_per_user.rst
+++ b/docs/command_reference/stat_visualization/merge_performance_csv_per_user.rst
@@ -33,6 +33,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.merge_performance_per_user.add_parser
    :prog: annofabcli stat_visualization merge_performance_csv_per_user
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/summarise_whole_performance_csv.rst
+++ b/docs/command_reference/stat_visualization/summarise_whole_performance_csv.rst
@@ -47,6 +47,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.summarise_whole_performance_csv.add_parser
    :prog: annofabcli stat_visualization summarise_whole_performance_csv
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/write_linegraph_per_user.rst
+++ b/docs/command_reference/stat_visualization/write_linegraph_per_user.rst
@@ -52,6 +52,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.write_linegraph_per_user.add_parser
    :prog: annofabcli stat_visualization write_linegraph_per_user
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/write_performance_rating_csv.rst
+++ b/docs/command_reference/stat_visualization/write_performance_rating_csv.rst
@@ -91,6 +91,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.write_performance_rating_csv.add_parser
    :prog: annofabcli stat_visualization write_performance_rating_csv
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/stat_visualization/write_performance_scatter_per_user.rst
+++ b/docs/command_reference/stat_visualization/write_performance_scatter_per_user.rst
@@ -46,6 +46,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.write_performance_scatter_per_user.add_parser
    :prog: annofabcli stat_visualization write_performance_scatter_per_user
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/stat_visualization/write_task_histogram.rst
+++ b/docs/command_reference/stat_visualization/write_task_histogram.rst
@@ -44,6 +44,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.write_task_histogram.add_parser
    :prog: annofabcli stat_visualization write_task_histogram
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/stat_visualization/write_whole_linegraph.rst
+++ b/docs/command_reference/stat_visualization/write_whole_linegraph.rst
@@ -45,6 +45,7 @@ Usage Details
    :ref: annofabcli.stat_visualization.write_whole_linegraph.add_parser
    :prog: annofabcli stat_visualization write_whole_linegraph
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/statistics/list_annotation_count.rst
+++ b/docs/command_reference/statistics/list_annotation_count.rst
@@ -140,3 +140,4 @@ Usage Details
    :ref: annofabcli.statistics.list_annotation_count.add_parser
    :prog: annofabcli statistics list_annotation_count
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/list_by_date_user.rst
+++ b/docs/command_reference/statistics/list_by_date_user.rst
@@ -75,3 +75,4 @@ Usage Details
    :ref: annofabcli.statistics.list_by_date_user.add_parser
    :prog: annofabcli statistics list_by_date_user
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/list_cumulative_labor_time.rst
+++ b/docs/command_reference/statistics/list_cumulative_labor_time.rst
@@ -52,3 +52,4 @@ Usage Details
    :ref: annofabcli.statistics.list_cumulative_labor_time.add_parser
    :prog: annofabcli statistics list_cumulative_labor_time
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/list_labor_time_per_user.rst
+++ b/docs/command_reference/statistics/list_labor_time_per_user.rst
@@ -63,3 +63,4 @@ Usage Details
    :ref: annofabcli.statistics.list_labor_time_per_user.add_parser
    :prog: annofabcli statistics list_labor_time_per_user
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/list_task_progress.rst
+++ b/docs/command_reference/statistics/list_task_progress.rst
@@ -50,3 +50,4 @@ Usage Details
    :ref: annofabcli.statistics.list_task_progress.add_parser
    :prog: annofabcli statistics list_task_progress
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/summarize_task_count.rst
+++ b/docs/command_reference/statistics/summarize_task_count.rst
@@ -63,3 +63,4 @@ Usage Details
    :ref: annofabcli.statistics.summarize_task_count.add_parser
    :prog: annofabcli statistics summarize_task_count
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/summarize_task_count_by_task_id.rst
+++ b/docs/command_reference/statistics/summarize_task_count_by_task_id.rst
@@ -60,3 +60,4 @@ Usage Details
    :ref: annofabcli.statistics.summarize_task_count_by_task_id.add_parser
    :prog: annofabcli statistics summarize_task_count_by_task_id
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/summarize_task_count_by_user.rst
+++ b/docs/command_reference/statistics/summarize_task_count_by_user.rst
@@ -54,3 +54,4 @@ Usage Details
    :ref: annofabcli.statistics.summarize_task_count_by_user.add_parser
    :prog: annofabcli statistics summarize_task_count_by_user
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/statistics/visualize.rst
+++ b/docs/command_reference/statistics/visualize.rst
@@ -400,3 +400,4 @@ Usage Details
    :ref: annofabcli.statistics.visualize_statistics.add_parser
    :prog: annofabcli statistics visualize
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/supplementary/delete.rst
+++ b/docs/command_reference/supplementary/delete.rst
@@ -99,3 +99,4 @@ Usage Details
    :ref: annofabcli.supplementary.delete_supplementary_data.add_parser
    :prog: annofabcli supplementary delete
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/supplementary/list.rst
+++ b/docs/command_reference/supplementary/list.rst
@@ -76,3 +76,4 @@ Usage Details
    :ref: annofabcli.supplementary.list_supplementary_data.add_parser
    :prog: annofabcli supplementary list
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/supplementary/put.rst
+++ b/docs/command_reference/supplementary/put.rst
@@ -120,3 +120,4 @@ Usage Details
    :ref: annofabcli.supplementary.put_supplementary_data.add_parser
    :prog: annofabcli supplementary put
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/cancel_acceptance.rst
+++ b/docs/command_reference/task/cancel_acceptance.rst
@@ -80,3 +80,4 @@ Usage Details
    :ref: annofabcli.task.cancel_acceptance.add_parser
    :prog: annofabcli task cancel_acceptance
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/change_operator.rst
+++ b/docs/command_reference/task/change_operator.rst
@@ -74,3 +74,4 @@ Usage Details
    :ref: annofabcli.task.change_operator.add_parser
    :prog: annofabcli task
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/complete.rst
+++ b/docs/command_reference/task/complete.rst
@@ -109,3 +109,4 @@ Usage Details
    :ref: annofabcli.task.complete_tasks.add_parser
    :prog: annofabcli task complete
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/copy.rst
+++ b/docs/command_reference/task/copy.rst
@@ -37,3 +37,4 @@ Usage Details
    :ref: annofabcli.task.copy_tasks.add_parser
    :prog: annofabcli task copy
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/delete.rst
+++ b/docs/command_reference/task/delete.rst
@@ -60,3 +60,4 @@ Usage Details
    :ref: annofabcli.task.delete_tasks.add_parser
    :prog: annofabcli task delete
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/list.rst
+++ b/docs/command_reference/task/list.rst
@@ -176,6 +176,7 @@ Usage Details
    :ref: annofabcli.task.list_tasks.add_parser
    :prog: annofabcli task list
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/task/list_added_task_history.rst
+++ b/docs/command_reference/task/list_added_task_history.rst
@@ -91,6 +91,7 @@ Usage Details
    :ref: annofabcli.task.list_tasks_added_task_history.add_parser
    :prog: annofabcli task list_added_task_history
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/task/list_with_json.rst
+++ b/docs/command_reference/task/list_with_json.rst
@@ -68,6 +68,7 @@ Usage Details
    :ref: annofabcli.task.list_tasks_with_json.add_parser
    :prog: annofabcli task list_with_json
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/task/put.rst
+++ b/docs/command_reference/task/put.rst
@@ -111,3 +111,4 @@ Usage Details
    :ref: annofabcli.task.put_tasks.add_parser
    :prog: annofabcli task put
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/reject.rst
+++ b/docs/command_reference/task/reject.rst
@@ -153,3 +153,4 @@ Usage Details
    :ref: annofabcli.task.reject_tasks.add_parser
    :prog: annofabcli task reject
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task/update_metadata.rst
+++ b/docs/command_reference/task/update_metadata.rst
@@ -104,3 +104,4 @@ Usage Details
    :ref: annofabcli.task.update_metadata_of_task.add_parser
    :prog: annofabcli task update_metadata
    :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/task_history/list.rst
+++ b/docs/command_reference/task_history/list.rst
@@ -91,6 +91,7 @@ Usage Details
    :ref: annofabcli.task_history.list_task_history.add_parser
    :prog: annofabcli task_history list
    :nosubcommands:
+   :nodefaultconst:
 
 See also
 =================================

--- a/docs/command_reference/task_history/list_with_json.rst
+++ b/docs/command_reference/task_history/list_with_json.rst
@@ -41,6 +41,7 @@ Usage Details
    :ref: annofabcli.task_history.list_task_history_with_json.add_parser
    :prog: annofabcli task_history list_with_json
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/task_history_event/list_with_json.rst
+++ b/docs/command_reference/task_history_event/list_with_json.rst
@@ -105,6 +105,7 @@ Usage Details
    :ref: annofabcli.task_history_event.list_task_history_event_with_json.add_parser
    :prog: annofabcli task_history_event list_with_json
    :nosubcommands:
+   :nodefaultconst:
 
 
 See also

--- a/docs/command_reference/task_history_event/list_worktime.rst
+++ b/docs/command_reference/task_history_event/list_worktime.rst
@@ -99,4 +99,5 @@ Usage Details
    :ref: annofabcli.task_history_event.list_worktime.add_parser
    :prog: annofabcli task_history_event list_worktime
    :nosubcommands:
+   :nodefaultconst:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -127,7 +127,7 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "21.11b1"
+version = "21.12b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -138,7 +138,6 @@ click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
-regex = ">=2021.4.4"
 tomli = ">=0.2.6,<2.0.0"
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = [
@@ -193,7 +192,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.8"
+version = "2.0.9"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -414,7 +413,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipython"
-version = "7.30.0"
+version = "7.30.1"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
@@ -717,7 +716,7 @@ tests = ["pytest", "pytest-cov", "flake8"]
 
 [[package]]
 name = "parso"
-version = "0.8.2"
+version = "0.8.3"
 description = "A Python Parser"
 category = "dev"
 optional = false
@@ -915,7 +914,7 @@ python-versions = "*"
 
 [[package]]
 name = "pylint"
-version = "2.12.1"
+version = "2.12.2"
 description = "python code static checker"
 category = "dev"
 optional = false
@@ -1080,14 +1079,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "regex"
-version = "2021.11.10"
-description = "Alternative regular expression module, to replace re."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "requests"
 version = "2.26.0"
 description = "Python HTTP for Humans."
@@ -1162,17 +1153,16 @@ test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
 name = "sphinx-argparse"
-version = "0.2.5"
+version = "0.3.1"
 description = "A sphinx extension that automatically documents argparse commands and options"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 sphinx = ">=1.2.0"
 
 [package.extras]
-dev = ["pytest", "sphinx-rtd-theme"]
 markdown = ["CommonMark (>=0.5.6)"]
 
 [[package]]
@@ -1342,7 +1332,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.0"
+version = "4.0.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
@@ -1412,7 +1402,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "1b27be157163f03638d08b2599f81dda7c951f45b8726d78361e45f8a47d8419"
+content-hash = "0ad068683c89d4dd9173d66e835f95154c31989ce07d79e081df1ee1d38d407c"
 
 [metadata.files]
 alabaster = [
@@ -1463,8 +1453,8 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.10.0.tar.gz", hash = "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"},
 ]
 black = [
-    {file = "black-21.11b1-py3-none-any.whl", hash = "sha256:802c6c30b637b28645b7fde282ed2569c0cd777dbe493a41b6a03c1d903f99ac"},
-    {file = "black-21.11b1.tar.gz", hash = "sha256:a042adbb18b3262faad5aff4e834ff186bb893f95ba3a8013f09de1e5569def2"},
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
@@ -1479,8 +1469,8 @@ certifi = [
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.8.tar.gz", hash = "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0"},
-    {file = "charset_normalizer-2.0.8-py3-none-any.whl", hash = "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"},
+    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
+    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -1595,8 +1585,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipython = [
-    {file = "ipython-7.30.0-py3-none-any.whl", hash = "sha256:c8f3e07aefb9cf9e067f39686f035ce09b27a1ee602116a3030b91b6fc138ee4"},
-    {file = "ipython-7.30.0.tar.gz", hash = "sha256:d41f8e80b99690122400f9b2069b12f670246a1b4cc5d332bd6c4e2500e6d6fb"},
+    {file = "ipython-7.30.1-py3-none-any.whl", hash = "sha256:fc60ef843e0863dd4e24ab2bb5698f071031332801ecf8d1aeb4fb622056545c"},
+    {file = "ipython-7.30.1.tar.gz", hash = "sha256:cb6aef731bf708a7727ab6cde8df87f0281b1427d41e65d62d4b68934fa54e97"},
 ]
 isodate = [
     {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
@@ -1883,8 +1873,8 @@ param = [
     {file = "param-1.12.0.tar.gz", hash = "sha256:35d0281c8e3beb6dd469f46ff0b917752a54bed94d1b0c567346c76d0ff59c4a"},
 ]
 parso = [
-    {file = "parso-0.8.2-py2.py3-none-any.whl", hash = "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"},
-    {file = "parso-0.8.2.tar.gz", hash = "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398"},
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -1998,8 +1988,8 @@ pyinstaller-hooks-contrib = [
     {file = "pyinstaller_hooks_contrib-2021.4-py2.py3-none-any.whl", hash = "sha256:60a57e4057fa2183bbaa81f10401a27eb7dd701ef8a11b287bb6345b571f94e7"},
 ]
 pylint = [
-    {file = "pylint-2.12.1-py3-none-any.whl", hash = "sha256:b4b5a7b6d04e914a11c198c816042af1fb2d3cda29bb0c98a9c637010da2a5c5"},
-    {file = "pylint-2.12.1.tar.gz", hash = "sha256:4f4a52b132c05b49094b28e109febcec6bfb7bc6961c7485a5ad0a0f961df289"},
+    {file = "pylint-2.12.2-py3-none-any.whl", hash = "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"},
+    {file = "pylint-2.12.2.tar.gz", hash = "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
@@ -2080,57 +2070,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-regex = [
-    {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},
-    {file = "regex-2021.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
-    {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
-    {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
-    {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
-    {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
-    {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
-    {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
-    {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
-    {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
-    {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
-    {file = "regex-2021.11.10-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
-    {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
-    {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
-    {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
-    {file = "regex-2021.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
-    {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
-    {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
-    {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
-]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
@@ -2152,7 +2091,8 @@ sphinx = [
     {file = "Sphinx-4.3.1.tar.gz", hash = "sha256:32a5b3e9a1b176cc25ed048557d4d3d01af635e6b76c5bc7a43b0a34447fbd45"},
 ]
 sphinx-argparse = [
-    {file = "sphinx-argparse-0.2.5.tar.gz", hash = "sha256:60ab98f80ffd38731d62e267171388a421abbc96c74901b7785a8e058b438c17"},
+    {file = "sphinx-argparse-0.3.1.tar.gz", hash = "sha256:82151cbd43ccec94a1530155f4ad34f251aaca6a0ffd5516d7fadf952d32dc1e"},
+    {file = "sphinx_argparse-0.3.1-py2.py3-none-any.whl", hash = "sha256:295ccae425874630b6a3b47254854027345d786bab2c3ffd5e9a0407bc6856b2"},
 ]
 sphinx-last-updated-by-git = [
     {file = "sphinx-last-updated-by-git-0.3.0.tar.gz", hash = "sha256:425dbac8eb0cb78f6b14ab9b42345800547a8863d6c7b00c970e9509e2174336"},
@@ -2286,8 +2226,8 @@ types-requests = [
     {file = "types_requests-2.26.1-py3-none-any.whl", hash = "sha256:853571b3accc188976c0f4feffcaebf6cdfc170082b5e43f3358aa78de61f531"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.0.0-py3-none-any.whl", hash = "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"},
-    {file = "typing_extensions-4.0.0.tar.gz", hash = "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed"},
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 typing-inspect = [
     {file = "typing_inspect-0.7.1-py2-none-any.whl", hash = "sha256:b1f56c0783ef0f25fb064a01be6e5407e54cf4a4bf4f3ba3fe51e0bd6dcea9e5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ pylint = "*"
 sphinx = "*"
 pydata-sphinx-theme = "*"
 sphinx-last-updated-by-git = "*"
-sphinx-argparse = "^0.2.5"
+sphinx-argparse = "*"
 
 
 # type stub package


### PR DESCRIPTION
コマンドリファレンスの`rst`ファイルに ` :nodefaultconst:` を付与して、`--wait`などのオプションのデフォルト値を出力しないようにした。