### PR TITLE
[task delete] タスクが参照している入力データも削除するオプションを追加

### DIFF
--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -391,15 +391,20 @@ def parse_args(parser: argparse.ArgumentParser):
         "--csv",
         type=str,
         help=(
-            "補助情報が記載されたCVファイルのパスを指定してください。"
-            "CSVのフォーマットは、「1列目:input_data_id(required), 2列目:supplementary_data_number(required), "
-            "3列目:supplementary_data_name(required), 4列目:supplementary_data_path(required), 5列目:supplementary_data_id, "
-            "6列目:supplementary_data_type, ヘッダ行なし, カンマ区切り」です。"
-            "supplementary_data_pathの先頭が ``file://`` の場合、ローカルのファイルを補助情報として登録します。 "
-            "supplementary_data_idが空の場合はUUIDv4になります。"
-            "各項目の詳細は ``putSupplementaryData`` API を参照してください。"
+            "補助情報が記載されたCVファイルのパスを指定してください。CSVのフォーマットは、以下の通りです。\n"
+            "\n"
+            " * ヘッダ行なし, カンマ区切り\n"
+            " * 1列目: input_data_id (required)\n"
+            " * 2列目: supplementary_data_number (required)\n"
+            " * 3列目: supplementary_data_name (required)\n"
+            " * 4列目: supplementary_data_path (required)\n"
+            " * 5列目: supplementary_data_id\n"
+            " * 6列目: supplementary_data_type\n"
+            "\n"
+            "各項目の詳細は https://annofab-cli.readthedocs.io/ja/latest/command_reference/supplementary/put.html を参照してください。"
         ),
     )
+
 
     JSON_SAMPLE = [
         {
@@ -413,8 +418,8 @@ def parse_args(parser: argparse.ArgumentParser):
         "--json",
         type=str,
         help=(
-            "登録対象の補助情報データをJSON形式で指定してください。"
-            f"(ex) '{json.dumps(JSON_SAMPLE)}' "
+            "登録対象の補助情報データをJSON形式で指定してください。\n"
+            f"(ex) ``{json.dumps(JSON_SAMPLE)}`` \n"
             "JSONの各キーは'--csv'に渡すCSVの各列に対応しています。"
             " ``file://`` を先頭に付けるとjsonファイルを指定できます。"
         ),

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -405,7 +405,6 @@ def parse_args(parser: argparse.ArgumentParser):
         ),
     )
 
-
     JSON_SAMPLE = [
         {
             "input_data_id": "input1",

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -419,8 +419,10 @@ def parse_args(parser: argparse.ArgumentParser):
         type=str,
         help=(
             "登録対象の補助情報データをJSON形式で指定してください。\n"
+            "\n"
             f"(ex) ``{json.dumps(JSON_SAMPLE)}`` \n"
-            "JSONの各キーは'--csv'に渡すCSVの各列に対応しています。"
+            "\n"
+            "JSONの各キーは ``--csv`` に渡すCSVの各列に対応しています。"
             " ``file://`` を先頭に付けるとjsonファイルを指定できます。"
         ),
     )

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import annofabapi
-import requests
 from annofabapi.dataclass.task import Task
 from annofabapi.models import ProjectMemberRole, TaskStatus
 

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -231,7 +231,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
                 if result:
                     count_delete_task += 1
 
-            except requests.exceptions.HTTPError as e:
+            except Exception:  # pylint: disable=broad-except
                 logger.warning(f"task_id='{task_id}'の削除に失敗しました。", exc_info=True)
                 continue
 

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -274,7 +274,7 @@ def parse_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--delete_input_data",
         action="store_true",
-        help="指定した場合、タスクから参照されている入力データと、その入力データに紐づく補助情報を削除します。ただし、他のタスクから参照されている場合は、削除しません。",
+        help="指定した場合、タスクから参照されている入力データと、その入力データに紐づく補助情報を削除します。ただし、他のタスクから参照されている入力データは削除しません。",
     )
     parser.add_argument("--dryrun", action="store_true", help="削除が行われた時の結果を表示しますが、実際はタスクを削除しません。")
     argument_parser.add_task_query()

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -104,7 +104,8 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
         if len(other_task_list) > 0:
             other_task_id_list = [e["task_id"] for e in other_task_list]
             logger.info(
-                f"task_id='{task_id}' :: input_data_id='{input_data_id}'の入力データは、他のタスクから参照されているため、削除しません。 :: 参照しているタスク = {other_task_id_list}"
+                f"task_id='{task_id}' :: input_data_id='{input_data_id}'の入力データは、"
+                f"他のタスクから参照されているため、削除しません。 :: 参照しているタスク = {other_task_id_list}"
             )
             return False
 
@@ -254,7 +255,12 @@ class DeleteTask(AbstractCommandLineInterface):
         super().validate_project(args.project_id, [ProjectMemberRole.OWNER])
 
         main_obj = DeleteTaskMain(
-            self.service, project_id=args.project_id, all_yes=args.yes, dryrun=args.dryrun, force=args.force, should_delete_input_data=args.delete_input_data
+            self.service,
+            project_id=args.project_id,
+            all_yes=args.yes,
+            dryrun=args.dryrun,
+            force=args.force,
+            should_delete_input_data=args.delete_input_data,
         )
         main_obj.delete_task_list(task_id_list=task_id_list, task_query=task_query)
 

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -66,7 +66,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
                     f"supplementary_data_name='{supplementary_data['supplementary_data_name']}'"
                 )
                 deleted_count += 1
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 logger.warning(
                     f"task_id='{task_id}', input_data_id='{input_data_id}' :: 補助情報の削除に失敗しました。 :: "
                     f"supplementary_data_id='{supplementary_data_id}', "
@@ -188,7 +188,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
                     result = self.delete_input_data_and_supplementary_data(task_id, input_data_id)
                     if result:
                         deleted_input_data_count += 1
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     logger.warning(
                         f"task_id='{task_id}' :: 入力データの削除に失敗しました。 :: input_data_id='{input_data_id}'", exc_info=True
                     )

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -104,7 +104,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
         if len(other_task_list) > 0:
             other_task_id_list = [e["task_id"] for e in other_task_list]
             logger.info(
-                f"input_data_id='{input_data_id}'の入力データは、他のタスクから参照されているため、削除しません。 :: 参照しているタスク = {other_task_id_list}"
+                f"task_id='{task_id}' :: input_data_id='{input_data_id}'の入力データは、他のタスクから参照されているため、削除しません。 :: 参照しているタスク = {other_task_id_list}"
             )
             return False
 
@@ -147,7 +147,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
         """
         task = self.service.wrapper.get_task_or_none(self.project_id, task_id)
         if task is None:
-            logger.info(f"task_id={task_id} のタスクは存在しません。")
+            logger.warning(f"task_id={task_id} のタスクは存在しません。")
             return False
 
         logger.debug(
@@ -193,7 +193,8 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
                         f"task_id='{task_id}' :: 入力データの削除に失敗しました。 :: input_data_id='{input_data_id}'", exc_info=True
                     )
                 continue
-            logger.debug(f"task_id='{task_id}' :: {deleted_input_data_count} 件の入力データを削除しました。")
+            if deleted_input_data_count > 0:
+                logger.debug(f"task_id='{task_id}' :: {deleted_input_data_count} 件の入力データを削除しました。")
 
         return True
 
@@ -225,7 +226,6 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
                 result = self.delete_task(task_id, task_query=task_query)
                 if result:
                     count_delete_task += 1
-                    logger.info(f"{task_index+1} / {len(task_id_list)} 件目: タスク'{task_id}'を削除しました。")
 
             except requests.exceptions.HTTPError as e:
                 logger.warning(e)
@@ -254,7 +254,7 @@ class DeleteTask(AbstractCommandLineInterface):
         super().validate_project(args.project_id, [ProjectMemberRole.OWNER])
 
         main_obj = DeleteTaskMain(
-            self.service, project_id=args.project_id, all_yes=args.yes, dryrun=args.dryrun, force=args.force
+            self.service, project_id=args.project_id, all_yes=args.yes, dryrun=args.dryrun, force=args.force, should_delete_input_data=args.delete_input_data
         )
         main_obj.delete_task_list(task_id_list=task_id_list, task_query=task_query)
 

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -256,9 +256,7 @@ class DeleteTask(AbstractCommandLineInterface):
         main_obj = DeleteTaskMain(
             self.service, project_id=args.project_id, all_yes=args.yes, dryrun=args.dryrun, force=args.force
         )
-        main_obj.delete_task_list(
-            task_id_list=task_id_list, task_query=task_query
-        )
+        main_obj.delete_task_list(task_id_list=task_id_list, task_query=task_query)
 
 
 def main(args):
@@ -273,7 +271,11 @@ def parse_args(parser: argparse.ArgumentParser):
     argument_parser.add_project_id()
     argument_parser.add_task_id()
     parser.add_argument("--force", action="store_true", help="アノテーションが付与されているタスクも強制的に削除します。")
-    parser.add_argument("--delete_input_data", action="store_true", help="指定した場合、タスクから参照されている入力データと、その入力データに紐づく補助情報を削除します。ただし、他のタスクから参照されている場合は、削除しません。")
+    parser.add_argument(
+        "--delete_input_data",
+        action="store_true",
+        help="指定した場合、タスクから参照されている入力データと、その入力データに紐づく補助情報を削除します。ただし、他のタスクから参照されている場合は、削除しません。",
+    )
     parser.add_argument("--dryrun", action="store_true", help="削除が行われた時の結果を表示しますが、実際はタスクを削除しません。")
     argument_parser.add_task_query()
 

--- a/docs/command_reference/supplementary/put.rst
+++ b/docs/command_reference/supplementary/put.rst
@@ -121,3 +121,6 @@ Usage Details
    :prog: annofabcli supplementary put
    :nosubcommands:
    :nodefaultconst:
+
+
+

--- a/docs/command_reference/task/delete.rst
+++ b/docs/command_reference/task/delete.rst
@@ -39,6 +39,15 @@ Examples
     $ annofabcli task delete --project_id prj1 --task_id file://task_id.txt --force
 
 
+``--delete_input_data`` を指定すれば、タスクが参照している入力データとそれに紐づく補助情報も削除されます。ただし、他のタスクから参照されている入力データは、削除されません。
+
+
+.. code-block::
+
+    $ annofabcli task delete --project_id prj1 --task_id file://task_id.txt --delete_input_data
+
+
+
 
 タスクのフェーズやステータスなどで絞り込み
 ----------------------------------------------

--- a/tests/test_inspection_comment.py
+++ b/tests/test_inspection_comment.py
@@ -72,6 +72,17 @@ class TestCommandLine:
 
         main(["inspection_comment", "put", "--project_id", project_id, "--json", json.dumps(dict_comments), "--yes"])
 
-
     def test_put_inspection_comment_simply(self):
-        main(["inspection_comment", "put_simply", "--project_id", project_id, "--task_id",  task_id, "--comment", "annofab-cli 自動テスト", "--yes"])
+        main(
+            [
+                "inspection_comment",
+                "put_simply",
+                "--project_id",
+                project_id,
+                "--task_id",
+                task_id,
+                "--comment",
+                "annofab-cli 自動テスト",
+                "--yes",
+            ]
+        )


### PR DESCRIPTION
close #720 

`--delete_input_data`オプションを追加した。
