### PR TITLE
`stat_visualization merge` : bokehの3.0バージョンアップの対応漏れに対処

### DIFF
--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -85,7 +85,9 @@ class LineGraph:
 
         self.exists_secondary_y_axis = False
         self.line_glyphs: dict[str, GlyphRenderer] = {}
+        """key:凡例, value: 描画している折れ線"""
         self.marker_glyphs: dict[str, GlyphRenderer] = {}
+        """key:凡例, value: 描画しているマーカー"""
 
     def add_secondary_y_axis(
         self,

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -598,6 +598,18 @@ class UserPerformance:
                 df[(f"{worktime_type.value}_worktime_hour/annotation_count", phase)] * 60
             )
 
+        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
+        # TODO この問題が解決されたら、削除する
+        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
+        df = df.astype(
+            {
+                ("user_id", ""): "object",
+                ("username", ""): "object",
+                ("biography", ""): "object",
+                ("last_working_date", ""): "object",
+            }
+        )
+
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
             for fig, phase in zip(figure_list, self.phase_list):
                 filtered_df = df[
@@ -702,6 +714,18 @@ class UserPerformance:
         ]
 
         phase = "annotation"
+
+        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
+        # TODO この問題が解決されたら、削除する
+        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
+        df = df.astype(
+            {
+                ("user_id", ""): "object",
+                ("username", ""): "object",
+                ("biography", ""): "object",
+                ("last_working_date", ""): "object",
+            }
+        )
 
         df["biography"] = df["biography"].fillna("")
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
@@ -891,6 +915,19 @@ class UserPerformance:
         ]
         phase = TaskPhase.ANNOTATION.value
         df["biography"] = df["biography"].fillna("")
+
+        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
+        # TODO この問題が解決されたら、削除する
+        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
+        df = df.astype(
+            {
+                ("user_id", ""): "object",
+                ("username", ""): "object",
+                ("biography", ""): "object",
+                ("last_working_date", ""): "object",
+            }
+        )
+
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
             for fig, column_pair in zip(figure_list, column_pair_list):
                 x_column, y_column = column_pair

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -1,3 +1,4 @@
+# pylint disable=too-many-lines
 """
 各ユーザの合計の生産性と品質
 """

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -1,4 +1,4 @@
-# pylint disable=too-many-lines
+# pylint: disable=too-many-lines
 """
 各ユーザの合計の生産性と品質
 """

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -396,6 +396,13 @@ class WorktimePerDate:
         df_cumulative = self._get_cumulative_dataframe(df_continuous_date)
         df_cumulative["dt_date"] = df_cumulative["date"].map(lambda e: datetime.datetime.fromisoformat(e).date())
 
+        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
+        # TODO この問題が解決されたら、削除する
+        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
+        df_cumulative = df_cumulative.astype(
+            {"date": "object", "user_id": "object", "username": "object", "biography": "object"}
+        )
+
         line_count = 0
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df_cumulative[df_cumulative["user_id"] == user_id]


### PR DESCRIPTION
* `stat_visualization merge` : bokehに関するエラーを修正
* update document
* `statistics visualize` : 全件ファイルのダウンロードを非同期から同期的にする。同期的でも速度はそこまで変わらないため。その分コードの見通しがよくなるため。