### PR TITLE
ruffでpyupgradeを有効にする

### DIFF
--- a/annofabcli/project/copy_project.py
+++ b/annofabcli/project/copy_project.py
@@ -13,7 +13,8 @@ from annofabcli.common.cli import AbstractCommandLineInterface, ArgumentParser, 
 from annofabcli.common.dataclasses import WaitOptions
 from annofabcli.common.facade import AnnofabApiFacade
 
-DEFAULT_WAIT_OPTIONS = WaitOptions(interval=60, max_tries=360)
+# 入力データをコピーしなければ1分以内にコピーが完了したので、intervalを60秒以下にした
+DEFAULT_WAIT_OPTIONS = WaitOptions(interval=30, max_tries=360)
 
 logger = logging.getLogger(__name__)
 

--- a/annofabcli/statistics/summarize_task_count_by_task_id_group.py
+++ b/annofabcli/statistics/summarize_task_count_by_task_id_group.py
@@ -48,7 +48,7 @@ class TaskStatusForSummary(Enum):
     """休憩中/作業中/2回目移行の各フェーズの未着手状態"""
 
     @staticmethod
-    def _get_not_started_status(task: Task) -> "TaskStatusForSummary":
+    def _get_not_started_status(task: Task) -> TaskStatusForSummary:
         # `number_of_inspections=1`を指定する理由：多段検査を無視して、検査フェーズが１回目かどうかを知りたいため
         step = get_step_for_current_phase(task, number_of_inspections=1)
         if step == 1:
@@ -65,7 +65,17 @@ class TaskStatusForSummary(Enum):
             return TaskStatusForSummary.OTHER
 
     @staticmethod
-    def from_task(task: Task) -> "TaskStatusForSummary":
+    def from_task(task: Task) -> TaskStatusForSummary:
+        """
+        タスク情報(dict)からインスタンスを生成します。
+        Args:
+            task: APIから取得したタスク情報. 以下のkeyが必要です。
+                * status
+                * phase
+                * phase_stage
+                * histories_by_phase
+
+        """
         status = TaskStatus(task["status"])
         if status == TaskStatus.COMPLETE:
             return TaskStatusForSummary.COMPLETE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ ignore = [
 
     "PL", # pylintに関する警告がたくさんあって対応できなかったので、除外する
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
-    "UP", # `pyupgrade`を指定したいのだがPython3.8で利用できないコードが提案されるので、除外した
 
     # 以下のルールはannofabcliのコードに合っていないので無効化した
     "RSE", # flake8-raise
@@ -132,6 +131,11 @@ select = [
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.ruff.pyupgrade]
+# Python3.8をサポートしているため、`typing.List`などの型ヒントは警告しないようにする
+# https://beta.ruff.rs/docs/settings/#keep-runtime-typing
+keep-runtime-typing = true
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/statistics/test_summarize_task_count_by_task_id_group.py
+++ b/tests/statistics/test_summarize_task_count_by_task_id_group.py
@@ -1,7 +1,11 @@
 import json
 from pathlib import Path
 
-from annofabcli.statistics.summarize_task_count_by_task_id_group import create_task_count_summary_df, get_task_id_prefix
+from annofabcli.statistics.summarize_task_count_by_task_id_group import (
+    TaskStatusForSummary,
+    create_task_count_summary_df,
+    get_task_id_prefix,
+)
 
 data_dir = Path("./tests/data/statistics")
 
@@ -17,3 +21,21 @@ def test_create_task_count_summary_df():
     df = create_task_count_summary_df(task_list, task_id_delimiter="_", task_id_groups=None)
     assert len(df) == 1
     assert df.iloc[0]["task_id_group"] == "sample"
+
+
+class TestTaskStatusForSummary:
+    def test_from_task(self):
+        task = {
+            "phase": "annotation",
+            "phase_stage": 1,
+            "status": "not_started",
+            "histories_by_phase": [
+                {
+                    "account_id": "alice",
+                    "phase": "annotation",
+                    "phase_stage": 1,
+                    "worked": False,
+                }
+            ],
+        }
+        assert TaskStatusForSummary.from_task(task) == TaskStatusForSummary.ANNOTATION_NOT_STARTED


### PR DESCRIPTION
* ruffでpyupgradeを有効にする
* `project copy`で待ち時間を1分以下にする。コピーが1分で終わるときがあるため