### PR TITLE
pypyroject.tomlの依存ライブラリのグループ化を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
 
       - name: Upgrade pip, and install poetry, pyinstaller
         run: |
-          python -m pip install --upgrade pip poetry
-          poetry add "pyinstaller==4.5.1" --lock
+          python -m pip install --upgrade pip 
+          python -m pip install "poetry<1.5"
       - name: poetry install
-        run: poetry install --no-dev
-
+        run: poetry install --only main,publish
       - name: create executable file
         run: |
           mv annofabcli\__main__.py annofabcli\annofabcli.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install pip --upgrade
   - pip install "poetry<1.5"
   # 必要なライブラリだけインストールする
-  - travis_retry poetry install --without formatter,documentation,dev
+  - travis_retry poetry install --only main,linter,test,typeshed
 
 script:
    - make lint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,4 +54,8 @@
         ".devcontainer/venv/": true
     },
     "editor.minimap.enabled": false,
+    "ruff.args": [
+        "--config=pyproject.toml"
+    ],
+    
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1558,28 +1558,33 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyinstaller"
-version = "4.5.1"
+version = "5.9.0"
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = "<3.12,>=3.7"
 files = [
-    {file = "pyinstaller-4.5.1-py3-none-macosx_10_13_universal2.whl", hash = "sha256:ecc2baadeeefd2b6fbf39d13c65d4aa603afdda1c6aaaebc4577ba72893fee9e"},
-    {file = "pyinstaller-4.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d848cd782ee0893d7ad9fe2bfe535206a79f0b6760cecc5f2add831258b9322"},
-    {file = "pyinstaller-4.5.1-py3-none-manylinux2014_i686.whl", hash = "sha256:8f747b190e6ad30e2d2fd5da9a64636f61aac8c038c0b7f685efa92c782ea14f"},
-    {file = "pyinstaller-4.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c587da8f521a7ce1b9efb4e3d0117cd63c92dc6cedff24590aeef89372f53012"},
-    {file = "pyinstaller-4.5.1-py3-none-win32.whl", hash = "sha256:fed9f5e4802769a416a8f2ca171c6be961d1861cc05a0b71d20dfe05423137e9"},
-    {file = "pyinstaller-4.5.1-py3-none-win_amd64.whl", hash = "sha256:aae456205c68355f9597411090576bb31b614e53976b4c102d072bbe5db8392a"},
-    {file = "pyinstaller-4.5.1.tar.gz", hash = "sha256:30733baaf8971902286a0ddf77e5499ac5f7bf8e7c39163e83d4f8c696ef265e"},
+    {file = "pyinstaller-5.9.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:93d7e8443a6b60745d42aa50f08730f6b419410832b4c616c4f1bb315f087661"},
+    {file = "pyinstaller-5.9.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:3b2c34c3c3ddf38f68d9f5afbed82abe0f89d53014c56892326fef10172ee652"},
+    {file = "pyinstaller-5.9.0-py3-none-manylinux2014_i686.whl", hash = "sha256:dcd348b174fd72c4df271790ac582969c9423cb099fe92db9ec131a8a9243d5a"},
+    {file = "pyinstaller-5.9.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4b21b0298db44f5f07fc04d8ff81ec31efa47b72798efaecc4e811c50a102111"},
+    {file = "pyinstaller-5.9.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:12ca6567be457826e14416637ea54485a185d0ce7a5a044df0d0daf588fff6d1"},
+    {file = "pyinstaller-5.9.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7dd156c2438f197c168b990bbce03c97d3fb758dd9bbc3ca93626c2f4473a47"},
+    {file = "pyinstaller-5.9.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:2ba42038b3bd83e1fba7c8eb9e7cde43bd5938e37ca542c89e8779355d213f52"},
+    {file = "pyinstaller-5.9.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:d1ff94347183ae3755cfb8f02e64744eb7fe384469bd61e453c6ff59a81665d6"},
+    {file = "pyinstaller-5.9.0-py3-none-win32.whl", hash = "sha256:8476538aec8a0a3be4f74b93388bd6989b91cc437ff86d6f0d3a68961176dce6"},
+    {file = "pyinstaller-5.9.0-py3-none-win_amd64.whl", hash = "sha256:e7a4c292810285c2466f3bdcb1e03ba2170177ebe3d7054ff1af3bb348bf61a4"},
+    {file = "pyinstaller-5.9.0-py3-none-win_arm64.whl", hash = "sha256:6cf6c032c72ef78fd9aa5e47d8952e784db45b2c3f7862bd44a99df68c216f64"},
+    {file = "pyinstaller-5.9.0.tar.gz", hash = "sha256:2bde16a8d664e8eba9aa7b84f729f7ab005c1793be4fe1986b3c9cad6c486622"},
 ]
 
 [package.dependencies]
 altgraph = "*"
 macholib = {version = ">=1.8", markers = "sys_platform == \"darwin\""}
-pefile = {version = ">=2017.8.1", markers = "sys_platform == \"win32\""}
-pyinstaller-hooks-contrib = ">=2020.6"
+pefile = {version = ">=2022.5.30", markers = "sys_platform == \"win32\""}
+pyinstaller-hooks-contrib = ">=2021.4"
 pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
-setuptools = "*"
+setuptools = ">=42.0.0"
 
 [package.extras]
 encryption = ["tinyaes (>=1.0.0)"]
@@ -2393,5 +2398,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "6276c1b0c2b67c13eb8a52292ab137a75b1062bcb8aa7beea01283383c2ec20b"
+python-versions = ">=3.8,<3.12"
+content-hash = "1ffc26f2de86fe0436b7740dc0972f449c6bf97e985cc3a00660b4b8d9ec0908"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = "^3.8"
+# `<3.12`を指定している理由: pyinstallerがこのように記述しているので、それに合わせた。
+python = ">=3.8,<3.12"
 requests = "*"
 pyyaml = "*"
 dictdiffer = "*"
@@ -57,14 +58,20 @@ types-requests = "*"
 types-python-dateutil = "*"
 types-PyYAML = "*"
 
+[tool.poetry.group.dev]
+# 開発するときのみ必要なライブラリ。インストールしなくても開発はできるので、オプショナルにする
+optional = true
+
 [tool.poetry.group.dev.dependencies]
-# 開発するときのみ必要なライブラリ
 ipython = "*"
 
+[tool.poetry.group.publish]
+# リリース時に必要なツール。インストールしなくても開発できるので、オプショナルにする
+optional = true
+
 [tool.poetry.group.publish.dependencies]
-# 公開時に必要なツール
 # GitHubでリリース時に、 GitHub Actionでannofabcliのexeを公開している
-pyinstaller = "^4.5.1"
+pyinstaller = "^5.9"
 
 [tool.poetry.scripts]
 annofabcli = "annofabcli.__main__:main"


### PR DESCRIPTION
### pyproject.toml
* dev, publishグループをオプショナルにした。開発時は利用しないので。

### travis.yaml, release.yml
* poetry installのやり方を変えた
