### PR TITLE
塗りつぶしアノテーションを8bit grayscaleの画像に変換する

### DIFF
--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -240,32 +240,31 @@ def write_annotation_grayscale_image(
         # channel depthは8bitなので、255個のアノテーションまでしか描画できない
         raise ValueError(f"アノテーションは255個までしか描画できません。アノテーションの数={len(annotation_list)}")
 
-    for index, annotation in enumerate(annotation_list):
-        color = index + 1
+    color = 1
+    for annotation in annotation_list:
         data = annotation["data"]
-        if data is None:
-            # 画像全体アノテーション
-            continue
-
-        data_type = data["_type"]
+        data_type = annotation["data"]["_type"]
         if data_type == "BoundingBox":
             xy = [
                 (data["left_top"]["x"], data["left_top"]["y"]),
                 (data["right_bottom"]["x"], data["right_bottom"]["y"]),
             ]
             draw.rectangle(xy, fill=color)
+            color += 1
 
         elif data_type == "Points":
             # Polygon or Polyline
             # 本当はPolylineのときは描画したくないのだが、Simple Annotationだけでは判断できないので、とりあえず描画する
             xy = [(e["x"], e["y"]) for e in data["points"]]
             draw.polygon(xy, fill=color)
+            color += 1
 
         elif data_type in ["SegmentationV2", "Segmentation"]:
             # 塗りつぶしv2 or 塗りつぶし
             with parser.open_outer_file(data["data_uri"]) as f:
                 outer_image = PIL.Image.open(f)
                 draw.bitmap([0, 0], outer_image, fill=color)
+                color += 1
         else:
             continue
 

--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -195,7 +195,7 @@ def write_annotation_grayscale_image(
     image_size: InputDataSize,
     output_image_file: Path,
     label_name_list: Optional[List[str]] = None,
-):
+) -> None:
     """
     JSONファイルに記載されているアノテーション情報を、グレースケール(8bit 1channel)で画像化します。
     グレースケールの値は0〜255です。0が背景です。それ以外は`details`のlistの降順で 1〜255の値が割り当てられます。

--- a/tests/common/test_image.py
+++ b/tests/common/test_image.py
@@ -2,10 +2,16 @@ import os
 import zipfile
 from pathlib import Path
 
+import numpy
+import PIL
 import pytest
 from annofabapi.parser import SimpleAnnotationDirParser, SimpleAnnotationParser, SimpleAnnotationZipParser
 
-from annofabcli.common.image import write_annotation_image, write_annotation_images_from_path
+from annofabcli.common.image import (
+    write_annotation_grayscale_image,
+    write_annotation_image,
+    write_annotation_images_from_path,
+)
 
 # プロジェクトトップに移動する
 os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../../")
@@ -24,7 +30,7 @@ label_color_dict = {
 }
 
 
-def test_write_image():
+def test_write_annotation_image():
     zip_path = test_dir / "simple-annotation.zip"
     output_image_file = out_dir / "annotation.png"
 
@@ -40,7 +46,7 @@ def test_write_image():
         )
 
 
-def test_write_image_wihtout_outer_file():
+def test_write_annotation_image__wihtout_outer_file():
     output_image_file = out_dir / "annotation_without_painting.png"
 
     # 外部ファイルが見つからない状態で画像を生成する。
@@ -52,6 +58,25 @@ def test_write_image_wihtout_outer_file():
         output_image_file=output_image_file,
         background_color=(64, 64, 64),
     )
+
+
+class Test__write_annotation_grayscale_image:
+    def test_ok(self):
+        zip_path = test_dir / "simple-annotation.zip"
+        output_image_file = out_dir / "annotation_grayscale.png"
+
+        with zipfile.ZipFile(zip_path) as zip_file:
+            parser = SimpleAnnotationZipParser(zip_file, "sample_1/c6e1c2ec-6c7c-41c6-9639-4244c2ed2839.json")
+
+            write_annotation_grayscale_image(
+                parser=parser,
+                image_size=(64, 64),
+                output_image_file=output_image_file,
+            )
+
+        data = numpy.array(PIL.Image.open(output_image_file).conert("L"))
+        assert data.min() == 0
+        assert data.max() == 7
 
 
 class Test_write_annotation_images_from_path:

--- a/tests/common/test_image.py
+++ b/tests/common/test_image.py
@@ -74,9 +74,9 @@ class Test__write_annotation_grayscale_image:
                 output_image_file=output_image_file,
             )
 
-        data = numpy.array(PIL.Image.open(output_image_file).conert("L"))
+        data = numpy.array(PIL.Image.open(output_image_file).convert("L"))
         assert data.min() == 0
-        assert data.max() == 7
+        assert data.max() == 5
 
 
 class Test_write_annotation_images_from_path:


### PR DESCRIPTION
- [ ] 実際の塗りつぶし画像で、重なりが表現できているかを確認する