### PR TITLE
bokeh3.1, pandas2.0へのバージョンアップ対応

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -208,10 +208,6 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
         # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
         df["first_annotation_started_date"] = df["first_annotation_started_datetime"].astype("string").str[:10]
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_annotation_started_date"] = df["first_annotation_started_date"].astype("object")
 
         # 元に戻す
         df = df.drop(["task_count"], axis=1)
@@ -450,11 +446,6 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
         df["first_inspection_started_date"] = df["first_inspection_started_datetime"].astype("string").str[:10]
 
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_inspection_started_date"] = df["first_inspection_started_date"].astype("object")
-
         # 元に戻す
         df = df.drop(["task_count"], axis=1)
 
@@ -643,10 +634,6 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
         # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
         df["first_acceptance_started_date"] = df["first_acceptance_started_datetime"].astype("string").str[:10]
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_acceptance_started_date"] = df["first_acceptance_started_date"].astype("object")
 
         # 元に戻す
         df = df.drop(["task_count"], axis=1)

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -175,7 +175,7 @@ class ProjectWorktimePerMonth:
         1個のプロジェクトディレクトリから、月ごとの作業時間を算出する
         """
         df = project_dir.read_worktime_per_date_user().df.copy()
-        df["dt_date"] = pandas.to_datetime(df["date"])
+        df["dt_date"] = pandas.to_datetime(df["date"], format="ISO8601")
         series = df.groupby(pandas.Grouper(key="dt_date", freq="M")).sum(numeric_only=True)[worktime_column.value]
         # indexを"2022-04"という形式にする
         new_index = [str(dt)[0:7] for dt in series.index]

--- a/annofabcli/statistics/visualization/dataframe/task.py
+++ b/annofabcli/statistics/visualization/dataframe/task.py
@@ -186,8 +186,8 @@ class Task:
         """
 
         def diff_days(s1: pandas.Series, s2: pandas.Series) -> pandas.Series:
-            dt1 = pandas.to_datetime(s1)
-            dt2 = pandas.to_datetime(s2)
+            dt1 = pandas.to_datetime(s1, format="ISO8601")
+            dt2 = pandas.to_datetime(s2, format="ISO8601")
 
             # タイムゾーンを指定している理由::
             # すべてがNaNのseriesをdatetimeに変換すると、型にタイムゾーンが指定されない。

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -610,18 +610,6 @@ class UserPerformance:
                 df[(f"{worktime_type.value}_worktime_hour/annotation_count", phase)] * 60
             )
 
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df = df.astype(
-            {
-                ("user_id", ""): "object",
-                ("username", ""): "object",
-                ("biography", ""): "object",
-                ("last_working_date", ""): "object",
-            }
-        )
-
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
             for fig, phase in zip(figure_list, self.phase_list):
                 filtered_df = df[
@@ -726,18 +714,6 @@ class UserPerformance:
         ]
 
         phase = "annotation"
-
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df = df.astype(
-            {
-                ("user_id", ""): "object",
-                ("username", ""): "object",
-                ("biography", ""): "object",
-                ("last_working_date", ""): "object",
-            }
-        )
 
         df["biography"] = df["biography"].fillna("")
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
@@ -927,18 +903,6 @@ class UserPerformance:
         ]
         phase = TaskPhase.ANNOTATION.value
         df["biography"] = df["biography"].fillna("")
-
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df = df.astype(
-            {
-                ("user_id", ""): "object",
-                ("username", ""): "object",
-                ("biography", ""): "object",
-                ("last_working_date", ""): "object",
-            }
-        )
 
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
             for fig, column_pair in zip(figure_list, column_pair_list):

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -397,13 +397,6 @@ class WorktimePerDate:
         df_cumulative = self._get_cumulative_dataframe(df_continuous_date)
         df_cumulative["dt_date"] = df_cumulative["date"].map(lambda e: datetime.datetime.fromisoformat(e).date())
 
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # またpandas.NAを持つDataFrameも描画できないので、numpy.nanに変換する
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df_cumulative = df_cumulative.astype(
-            {"date": "object", "user_id": "object", "username": "object", "biography": "object"}
-        )
         df_cumulative.replace(pandas.NA, numpy.nan, inplace=True)
 
         line_count = 0

--- a/poetry.lock
+++ b/poetry.lock
@@ -2401,4 +2401,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f79738c7347c075d4dc4ae8a520f9c36d7c5be1b4748d6cc2ca7138326c3fafd"
+content-hash = "5c714849a0f69d32d7d350f52d4d3c72320543de0fdd26094fb3d86ca7679182"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ isodate = "*"
 annofabapi = ">=0.67.1"
 python-datauri = "*"
 pandas = "*"
-bokeh = "^3.0"
+bokeh = "^3.1"
 Pillow = "*"
 
 [tool.poetry.group.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pyquery = "*"
 isodate = "*"
 annofabapi = ">=0.67.1"
 python-datauri = "*"
-pandas = "*"
+pandas = "^2.0"
 bokeh = "^3.1"
 Pillow = "*"
 


### PR DESCRIPTION
# bokeh3.1へのバージョンアップ対応
https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186

# pandas2.0へのバージョンアップ対応
`pandas.to_datetiem`関数に`format="ISO8601"`を指定する
https://qiita.com/yuji38kwmt/items/9aeed6e8f54d0ebf3720