### PR TITLE
pandasの警告に対応する

### DIFF
--- a/annofabcli/statistics/table.py
+++ b/annofabcli/statistics/table.py
@@ -342,7 +342,7 @@ class Table:
 
         group_obj["worktime_ratio_by_task"] = group_obj.groupby(
             level=["task_id", "phase", "phase_stage"], group_keys=False
-        ).apply(lambda e: e / float(e.sum()))
+        ).apply(lambda e: e / e / e["worktime_hour"].sum())
         group_obj["annotation_count"] = group_obj.apply(get_annotation_count, axis="columns")
         group_obj["input_data_count"] = group_obj.apply(get_input_data_count, axis="columns")
         group_obj["pointed_out_inspection_comment_count"] = group_obj.apply(


### PR DESCRIPTION
以下の警告メッセージに対応した。
```
tests/statistics/test_table.py::TestTable::test_create_annotation_count_ratio_df
  /workspaces/annofab-cli/annofabcli/statistics/table.py:350: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
    return e / float(e.sum())

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```