### PR TITLE
dataclasses-jsonの`Unknown type str at ChangedInputData.input_data_name`のような警告wo

### DIFF
--- a/annofabcli/input_data/change_input_data_name.py
+++ b/annofabcli/input_data/change_input_data_name.py
@@ -129,7 +129,7 @@ class ChangeInputDataNameMain(AbstractCommandLineWithConfirmInterface):
 
 
 def create_changed_input_data_list_from_dict(input_data_dict_list: list[dict[str, str]]) -> list[ChangedInputData]:
-    return ChangedInputData.schema().load(input_data_dict_list, many=True, unknown="exclude")
+    return [ChangedInputData.from_dict(e) for e in input_data_dict_list]
 
 
 def create_changed_input_data_list_from_csv(csv_file: Path) -> list[ChangedInputData]:
@@ -153,7 +153,7 @@ def create_changed_input_data_list_from_csv(csv_file: Path) -> list[ChangedInput
     )
 
     input_data_dict_list = df_input_data.to_dict("records")
-    return ChangedInputData.schema().load(input_data_dict_list, many=True, unknown="exclude")
+    return [ChangedInputData.from_dict(e) for e in input_data_dict_list]
 
 
 class ChangeInputDataName(AbstractCommandLineInterface):

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -323,7 +323,7 @@ class PutInputData(AbstractCommandLineInterface):
             if not allow_duplicated_input_data:
                 raise RuntimeError("`input_data_path`が重複しています。")
 
-        return CsvInputData.schema().load(input_data_dict_list, many=True, unknown="exclude")
+        return [CsvInputData.from_dict(e) for e in input_data_dict_list]
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.csv is not None:

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -303,7 +303,7 @@ class PutSupplementaryData(AbstractCommandLineInterface):
     def get_supplementary_data_list_from_dict(
         supplementary_data_dict_list: List[Dict[str, Any]]
     ) -> List[CsvSupplementaryData]:
-        return CsvSupplementaryData.schema().load(supplementary_data_dict_list, many=True, unknown="exclude")
+        return [CsvSupplementaryData.from_dict(e) for e in supplementary_data_dict_list]
 
     @staticmethod
     def get_supplementary_data_list_from_csv(csv_path: Path) -> List[CsvSupplementaryData]:


### PR DESCRIPTION
以下の警告が出ないようにしました。

```
tests/test_input_data.py::TestCommandLine::test_scenario
  /workspaces/annofab-cli/.venv/lib/python3.11/site-packages/dataclasses_json/mm.py:271: UserWarning: Unknown type str at ChangedInputData.input_data_name: str It's advised to pass the correct marshmallow type to `mm_field`.
    warnings.warn(

```


https://qiita.com/yuji38kwmt/items/3421f946b0cd892d6e10

