### PR TITLE
`statistcs list_annotation_count --type attribute`：列の順番を変更しました。

### DIFF
--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -518,9 +518,7 @@ class AttributeCountCsv:
         columns = get_columns()
         df = pandas.DataFrame([to_cell(e) for e in counter_list], columns=pandas.MultiIndex.from_tuples(columns))
 
-        # NaNを0に変換する
-        # 列が重複していると`ValueError: cannot handle a non-unique multi-index!`が発生するため、列を指定せずに`fillna`関数を実行する
-        # `basic_columns`は必ずnanではないので、問題ないはず
+        # `task_id`列など`basic_columns`も`fillna`対象だが、nanではないはずので問題ない
         df.fillna(0, inplace=True)
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
@@ -563,10 +561,7 @@ class AttributeCountCsv:
         columns = get_columns()
         df = pandas.DataFrame([to_cell(e) for e in counter_list], columns=pandas.MultiIndex.from_tuples(columns))
 
-        # NaNを0に変換する
-        # 列が重複していると`
-        # `が発生するため、列を指定せずに`fillna`関数を実行する
-        # `basic_columns`は必ずnanではないので、問題ないはず
+        # `task_id`列など`basic_columns`も`fillna`対象だが、nanではないはずので問題ない
         df.fillna(0, inplace=True)
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-lines
 from __future__ import annotations
-
+import copy
 import abc
 import argparse
 import collections
@@ -460,11 +460,29 @@ class AttributeCountCsv:
         if prior_attribute_columns is not None:
             remaining_columns = sorted(all_attr_key_set - set(prior_attribute_columns))
             remaining_columns_only_selective_attribute = self._only_selective_attribute(remaining_columns)
-            value_columns = prior_attribute_columns + remaining_columns_only_selective_attribute
+
+            # `remaining_columns_only_selective_attribute`には、属性値が空である列が格納されている
+            # `remaining_columns_only_selective_attribute`を、`value_columns`の関連している位置に挿入する。
+            value_columns = copy.deepcopy(prior_attribute_columns)
+            for remaining_column in remaining_columns_only_selective_attribute:
+                is_inserted = False
+                for i in range(len(value_columns)-1, -1, -1):
+                    col = value_columns[i]
+                    if col[0:2] == remaining_column[0:2]:
+                        value_columns.insert(i+1, remaining_column)
+                        is_inserted = True
+                        break
+                if not is_inserted:
+                    value_columns.append(remaining_column)
+                        
+            assert len(value_columns) == len(prior_attribute_columns) + len(remaining_columns_only_selective_attribute)
+ 
         else:
             remaining_columns = sorted(all_attr_key_set)
             value_columns = self._only_selective_attribute(remaining_columns)
 
+        # 重複している場合は、重複要素を取り除く。ただし元の順番は維持する
+        value_columns = list(dict.fromkeys(value_columns).keys())
         return value_columns
 
     def print_csv_by_task(
@@ -546,7 +564,8 @@ class AttributeCountCsv:
         df = pandas.DataFrame([to_cell(e) for e in counter_list], columns=pandas.MultiIndex.from_tuples(columns))
 
         # NaNを0に変換する
-        # 列が重複していると`ValueError: cannot handle a non-unique multi-index!`が発生するため、列を指定せずに`fillna`関数を実行する
+        # 列が重複していると`
+        # `が発生するため、列を指定せずに`fillna`関数を実行する
         # `basic_columns`は必ずnanではないので、問題ないはず
         df.fillna(0, inplace=True)
 
@@ -883,7 +902,7 @@ class ListAnnotationCountMain:
             attribute_columns: Optional[list[AttributeValueKey]] = None
             if annotation_specs is not None:
                 attribute_columns = annotation_specs.selective_attribute_value_keys()
-
+            
             AttributeCountCsv().print_csv_by_task(
                 counter_list_by_task, output_file, prior_attribute_columns=attribute_columns
             )

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -461,7 +461,7 @@ class AttributeCountCsv:
             remaining_columns = sorted(all_attr_key_set - set(prior_attribute_columns))
             remaining_columns_only_selective_attribute = self._only_selective_attribute(remaining_columns)
 
-            # `remaining_columns_only_selective_attribute`には、属性値が空である列が格納されている
+            # `remaining_columns_only_selective_attribute`には、属性値が空である列などが格納されている
             # `remaining_columns_only_selective_attribute`を、`value_columns`の関連している位置に挿入する。
             value_columns = copy.deepcopy(prior_attribute_columns)
             for remaining_column in remaining_columns_only_selective_attribute:

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -1,9 +1,10 @@
 # pylint: disable=too-many-lines
 from __future__ import annotations
-import copy
+
 import abc
 import argparse
 import collections
+import copy
 import json
 import logging
 import sys
@@ -466,17 +467,17 @@ class AttributeCountCsv:
             value_columns = copy.deepcopy(prior_attribute_columns)
             for remaining_column in remaining_columns_only_selective_attribute:
                 is_inserted = False
-                for i in range(len(value_columns)-1, -1, -1):
+                for i in range(len(value_columns) - 1, -1, -1):
                     col = value_columns[i]
                     if col[0:2] == remaining_column[0:2]:
-                        value_columns.insert(i+1, remaining_column)
+                        value_columns.insert(i + 1, remaining_column)
                         is_inserted = True
                         break
                 if not is_inserted:
                     value_columns.append(remaining_column)
-                        
+
             assert len(value_columns) == len(prior_attribute_columns) + len(remaining_columns_only_selective_attribute)
- 
+
         else:
             remaining_columns = sorted(all_attr_key_set)
             value_columns = self._only_selective_attribute(remaining_columns)
@@ -694,7 +695,7 @@ class AnnotationSpecs:
         result = [to_label_name(label) for label in self._labels_v1]
         duplicated_labels = [key for key, value in collections.Counter(result).items() if value > 1]
         if len(duplicated_labels) > 0:
-            logger.warning(f"アノテーション仕様のラベル英語名が重複しています。:: {duplicated_labels}")
+            logger.warning(f"アノテーション仕様のラベル英語名が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_labels}")
         return result
 
     def selective_attribute_value_keys(self) -> list[AttributeValueKey]:
@@ -735,7 +736,7 @@ class AnnotationSpecs:
             key for key, value in collections.Counter(target_attribute_value_keys).items() if value > 1
         ]
         if len(duplicated_attributes) > 0:
-            logger.warning(f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。:: {duplicated_attributes}")
+            logger.warning(f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_attributes}")
 
         return target_attribute_value_keys
 
@@ -897,7 +898,7 @@ class ListAnnotationCountMain:
             attribute_columns: Optional[list[AttributeValueKey]] = None
             if annotation_specs is not None:
                 attribute_columns = annotation_specs.selective_attribute_value_keys()
-            
+
             AttributeCountCsv().print_csv_by_task(
                 counter_list_by_task, output_file, prior_attribute_columns=attribute_columns
             )

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -736,7 +736,9 @@ class AnnotationSpecs:
             key for key, value in collections.Counter(target_attribute_value_keys).items() if value > 1
         ]
         if len(duplicated_attributes) > 0:
-            logger.warning(f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_attributes}")
+            logger.warning(
+                f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_attributes}"
+            )
 
         return target_attribute_value_keys
 


### PR DESCRIPTION
# 元の挙動

```
$ annofabcli statistcs list_annotation_count --type attribute -p ${PROJECT_ID} -o out.csv
```

`out.csv`の列の順番は以下のように、label1, label2でまとまっていませんでした。

```
label1, attr1, true
label1, attr1, false
label2, attr2, true
label2, attr2, false
label1, attr1, ""
label2, attr2, ""
```

3番目の属性値用の列は、アノテーション仕様の定義に関わらず空欄になる可能性があるためです。


# 変更内容
`out.csv`の列が以下のような順番になるよう、変更しました。

```
label1, attr1, true
label1, attr1, false
label1, attr1, ""
label2, attr2, true
label2, attr2, false
label2, attr2, ""
```
