### PR TITLE
標準入力からMFA codeを入力させる

### DIFF
--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -68,8 +68,18 @@ def build_annofabapi_resource_and_login(args: argparse.Namespace) -> annofabapi.
         if e.response.status_code == requests.codes.unauthorized:
             raise AuthenticationError(service.api.login_user_id) from e
         raise e
-    except AnnofabApiMfaEnabledUserExecutionError as e:
-        raise MfaEnabledUserExecutionError(service.api.login_user_id) from e
+
+    except AnnofabApiMfaEnabledUserExecutionError:
+        # 標準入力からMFAコードを入力させる
+        inputted_mfa_code = ""
+        while inputted_mfa_code == "":
+            inputted_mfa_code = input("Enter MFA Code: ")
+
+        try:
+            service.api.login(mfa_code=inputted_mfa_code)
+            return service
+        except AnnofabApiMfaEnabledUserExecutionError as e:
+            raise MfaEnabledUserExecutionError(service.api.login_user_id) from e
 
 
 def add_parser(

--- a/annofabcli/common/exceptions.py
+++ b/annofabcli/common/exceptions.py
@@ -20,8 +20,8 @@ class AuthenticationError(AnnofabCliException):
     Annofabの認証エラー
     """
 
-    def __init__(self, loing_user_id: str) -> None:
-        msg = f"Annofabにログインできませんでした。User ID: {loing_user_id}"
+    def __init__(self, login_user_id: str) -> None:
+        msg = f"Annofabにログインできませんでした。User ID: {login_user_id}"
         super().__init__(msg)
 
 
@@ -69,5 +69,5 @@ class MfaEnabledUserExecutionError(AnnofabCliException):
     """
 
     def __init__(self, login_user_id: str) -> None:
-        msg = f"ユーザー(User ID: {login_user_id})はMFAが有効化されているため、ログインできません。コマンドライン引数 `--mfa_code` にMFAコードを指定してください。"
+        msg = f"MFAによるログインで失敗しました。User ID: {login_user_id}"
         super().__init__(msg)


### PR DESCRIPTION
MFAが有効化されているユーザーで、コマンドライン引数に`--mfa_code`を指定しない場合、標準入力からMFA codeを入力させる。
そうすれば、コマンドを終了することなく処理を続行できるため。



