### PR TITLE
`statitics visualize` : `メンバごとの生産性と品質.csv`の出力に失敗する不具合を修正

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -287,8 +287,7 @@ class UserPerformance:
                 * level0がpointed_out_inspection_comment_countで、level1がinspection, acceptanceの列
                 * level0がrejected_countで、level1がinspection, acceptanceの列
             """
-            tmp_phases = set(phase_list) - set(TaskPhase.ANNOTATION.value)
-
+            tmp_phases = set(phase_list) - {TaskPhase.ANNOTATION.value}
             dropped_column = []
             dropped_column.extend([("pointed_out_inspection_comment_count", phase) for phase in tmp_phases])
             dropped_column.extend([("rejected_count", phase) for phase in tmp_phases])

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -205,8 +205,16 @@ class UserPerformance:
 
         Args:
             df_task_history: タスク履歴のDataFrame
-            df_worktime_ratio: 作業したタスク数を、作業時間で按分した値が格納されたDataFrame. 以下の列を参照する。
-                account_id, phase, worktime_hour
+            df_worktime_ratio: 作業したタスク数などの情報を、作業時間で按分した値が格納されたDataFrame. 以下の列を参照する。
+                * account_id
+                * phase
+                * worktime_hour
+                * task_count
+                * input_data_count
+                * annotation_count
+                * rejected_count.
+                * pointed_out_inspection_comment_count
+
             df_labor: 実績作業時間のDataFrame。以下の列を参照する
                 actual_worktime_hour, date, account_id
 
@@ -223,49 +231,52 @@ class UserPerformance:
 
             return phase_list
 
-        def create_df_agg_production() -> pandas.DataFrame:
+        def join_various_counts(df: pandas.DataFrame) -> pandas.DataFrame:
             """
-            生産量を集計したDataFrameを生成します。
+            生産量や指摘数などの個数情報を引数`df`に結合して、そのDataFrameを返します。
+
+            Args:
+                df: multiindexの列を持つDataFrame
 
             Returns: 生成されるDataFrame
                 columns(level0): task_count, input_data_count, annotation_count, pointed_out_inspection_comment_count, rejected_count
                 columns(level1): ${phase}
                 index: account_id
-            """# noqa: E501
-            if len(df_worktime_ratio) > 0:
-                df_agg_production = df_worktime_ratio.pivot_table(
-                    values=[
-                        "task_count",
-                        "input_data_count",
-                        "annotation_count",
-                        "pointed_out_inspection_comment_count",
-                        "rejected_count",
-                    ],
-                    columns="phase",
-                    index="account_id",
-                    aggfunc=numpy.sum,
-                ).fillna(0)
+            """  # noqa: E501
+            if len(df_worktime_ratio) == 0:
+                # 集計対象のタスクが0件の場合など
+                # 生産量、指摘の量の情報は、生産性/品質の列を算出するのに必要なので追加する
+                phase = TaskPhase.ANNOTATION.value
+                df2 = df.copy()
+                df2[("task_count", phase)] = 0
+                df2[("input_data_count", phase)] = 0
+                df2[("annotation_count", phase)] = 0
+                df2[("pointed_out_inspection_comment_count", phase)] = 0
+                df2[("rejected_count", phase)] = 0
+                return df2
 
-                # 特定のフェーズの生産量の列が存在しないときは、列を追加する
-                # 理由：たとえば受入フェーズが着手されていないときは、受入フェーズの時間の列は存在するが、生産量(~_count)の列は存在しない。生産量の列は生産性の算出に必要なので、列を追加する
-                for phase in phase_list:
-                    for production_amount in ["task_count", "input_data_count", "annotation_count"]:
-                        if (production_amount, phase) not in df_agg_production.columns:
-                            df_agg_production[(production_amount, phase)] = 0
+            df_agg_production = df_worktime_ratio.pivot_table(
+                values=[
+                    "task_count",
+                    "input_data_count",
+                    "annotation_count",
+                    "pointed_out_inspection_comment_count",
+                    "rejected_count",
+                ],
+                columns="phase",
+                index="account_id",
+                aggfunc=numpy.sum,
+            ).fillna(0)
 
-            else:
-                df_agg_production = pandas.DataFrame(
-                    columns=pandas.MultiIndex.from_tuples(
-                        [
-                            ("task_count", "annotation"),
-                            ("input_data_count", "annotation"),
-                            ("annotation_count", "annotation"),
-                            ("pointed_out_inspection_comment_count", "annotation"),
-                            ("rejected_count", "annotation"),
-                        ]
-                    )
-                )
-            return df_agg_production
+            # 特定のフェーズの生産量の列が存在しないときは、列を追加する
+            # 理由：たとえば受入フェーズが着手されていないときは、受入フェーズの時間の列は存在するが、生産量(~_count)の列は存在しない。生産量の列は生産性の算出に必要なので、列を追加する
+            for phase in phase_list:
+                for production_amount in ["task_count", "input_data_count", "annotation_count"]:
+                    if (production_amount, phase) not in df_agg_production.columns:
+                        df_agg_production[(production_amount, phase)] = 0
+
+            df2 = df.join(df_agg_production)
+            return df2
 
         def drop_unnecessary_columns(df: pandas.DataFrame) -> pandas.DataFrame:
             """
@@ -280,9 +291,7 @@ class UserPerformance:
 
             dropped_column = []
             dropped_column.extend([("pointed_out_inspection_comment_count", phase) for phase in tmp_phases])
-            dropped_column.extend([
-                ("rejected_count", phase) for phase in tmp_phases
-            ])
+            dropped_column.extend([("rejected_count", phase) for phase in tmp_phases])
             # 'errors="ignore"を指定する理由：削除する列が存在しないときでも、処理を継続するため
             return df.drop(dropped_column, axis=1, errors="ignore")
 
@@ -325,15 +334,13 @@ class UserPerformance:
         if len(phase_list) == 0:
             df[("monitored_worktime_hour", TaskPhase.ANNOTATION.value)] = 0
 
-        # 生産量情報を集計して、dfに結合する
-        df = df.join(create_df_agg_production())
-        # 数値列のNaNを0にする(df_agg_productionが0件のときの対応)
-        df.fillna(0, inplace=True)
+        # 生産量などの情報をdfに結合する
+        df = join_various_counts(df)
 
         # 比例関係の列を計算して追加する
         cls._add_ratio_column_for_productivity_per_user(df, phase_list=phase_list)
 
-        # 不要な列を削除する
+        # 出力に不要な列を削除する
         df = drop_unnecessary_columns(df)
 
         # ユーザ情報を取得

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -293,6 +293,14 @@ class UserPerformance:
             # 'errors="ignore"を指定する理由：削除する列が存在しないときでも、処理を継続するため
             return df.drop(dropped_column, axis=1, errors="ignore")
 
+        def get_phase_list(columns: list[str]) -> list[str]:
+            phase_list = []
+
+            for phase in TaskPhase:
+                if phase.value in columns:
+                    phase_list.append(phase.value)
+            return phase_list
+
         df_agg_task_history = df_task_history.pivot_table(
             values="worktime_hour", columns="phase", index="account_id", aggfunc=numpy.sum
         ).fillna(0)
@@ -319,7 +327,7 @@ class UserPerformance:
             df["actual_worktime_hour"] = 0
             df["last_working_date"] = None
 
-        phase_list = UserPerformance.get_phase_list(list(df.columns))
+        phase_list = get_phase_list(list(df.columns))
         df = df[["actual_worktime_hour", "last_working_date", *phase_list]].copy()
         df.columns = pandas.MultiIndex.from_tuples(
             [("actual_worktime_hour", "sum"), ("last_working_date", "")]


### PR DESCRIPTION
# 不具合内容
受入完了状態のタスクが一つもない状態で以下のコマンドを実行すると、エラーが発生した。


```
$ annofabcli statistics visualize -p prj1 -tq '{"phase":"acceptance"}'
WARNING  : 2024-01-22 09:38:43,279 : annofabcli.statistics.visualize_statistics : project_id='foo'であるプロジェクトでのファイル出力に失敗しました。
Traceback (most recent call last):
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/annofabcli/statistics/visualize_statistics.py", line 91, in wrapped
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/annofabcli/statistics/visualize_statistics.py", line 135, in write_user_performance
    user_performance = UserPerformance.from_df(
                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/annofabcli/statistics/visualization/dataframe/user_performance.py", line 297, in from_df
    cls._add_ratio_column_for_productivity_per_user(df, phase_list=phase_list)
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/annofabcli/statistics/visualization/dataframe/user_performance.py", line 128, in _add_ratio_column_for_productivity_per_user
    df[("monitored_worktime_hour", phase)] / df[("input_data_count", phase)]
                                             ~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/pandas/core/frame.py", line 3760, in __getitem__
    return self._getitem_multilevel(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/pandas/core/frame.py", line 3815, in _getitem_multilevel
    loc = self.columns.get_loc(key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/3.12.1/lib/python3.12/site-packages/pandas/core/indexes/multi.py", line 2825, in get_loc
    return self._engine.get_loc(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pandas/_libs/index.pyx", line 832, in pandas._libs.index.BaseMultiIndexCodesEngine.get_loc
  File "pandas/_libs/index.pyx", line 147, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 176, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 2152, in pandas._libs.hashtable.UInt64HashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 2176, in pandas._libs.hashtable.UInt64HashTable.get_item
KeyError: 35
```


