### PR TITLE
`--annofab_user_id`, `--annofab_password`を指定したときは、その値をマスクしてログに出力する

### DIFF
--- a/annofabcli/__main__.py
+++ b/annofabcli/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import logging
 import sys
 from typing import Optional
@@ -29,6 +30,20 @@ import annofabcli.task_history_event.subcommand_task_history_event
 logger = logging.getLogger(__name__)
 
 
+def mask_argv(argv: list[str]) -> list[str]:
+    """
+    `argv`にセンシティブな情報が含まれている場合は、`***`に置き換える。
+    """
+    tmp_argv = copy.deepcopy(argv)
+    for masked_option in ["--annofab_user_id", "--annofab_password"]:
+        try:
+            index = tmp_argv.index(masked_option)
+            tmp_argv[index + 1] = "***"
+        except ValueError:
+            continue
+    return tmp_argv
+
+
 def main(arguments: Optional[list[str]] = None) -> None:
     """
     annofabcliコマンドのメイン処理
@@ -51,7 +66,7 @@ def main(arguments: Optional[list[str]] = None) -> None:
             argv = sys.argv
             if arguments is not None:
                 argv = ["annofabcli", *list(arguments)]
-            logger.info(f"argv={argv}")
+            logger.info(f"argv={mask_argv(argv)}")
             args.subcommand_func(args)
         except Exception as e:
             logger.exception(e)

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -304,9 +304,11 @@ class UserPerformance:
         # タスク履歴の作業時間を集計する
         # `["worktime_hour"]>0]`を指定している理由：受入フェーズのタスクは存在するが、一度も受入作業が実施されていないときに、df_agg_task_historyに"acceptance"の列を含まないようにするため
         # 受入作業が実施されていないのに、"acceptance"列が存在すると、bokehなどでwarningが発生する。それを回避するため
-        df_agg_task_history = df_task_history[df_task_history["worktime_hour"]>0].pivot_table(
-            values="worktime_hour", columns="phase", index="account_id", aggfunc=numpy.sum
-        ).fillna(0)
+        df_agg_task_history = (
+            df_task_history[df_task_history["worktime_hour"] > 0]
+            .pivot_table(values="worktime_hour", columns="phase", index="account_id", aggfunc=numpy.sum)
+            .fillna(0)
+        )
 
         if df_labor is not None and len(df_labor) > 0:
             df_agg_labor = df_labor.pivot_table(values="actual_worktime_hour", index="account_id", aggfunc=numpy.sum)


### PR DESCRIPTION

```
vscode@example:/workspaces/annofab-cli$ poetry run annofabcli my_account get --annofab_user_id foo --annofab_password bar
INFO     : 2024-01-25 06:52:20,480 : annofabcli.__main__            : argv=['/workspaces/annofab-cli/.venv/bin/annofabcli', 'my_account', 'get', '--annofab_user_id', '***', '--annofab_password', '***']
```

