### PR TITLE
`stat_visualization merge` : マージ対象ディレクトリに`教師付開始日毎の生産量と生産性.csv`や`日毎の生産量と生産性.csv`が存在しなくても、ファイルを出力できるようにしました。

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/task.py
+++ b/annofabcli/statistics/visualization/dataframe/task.py
@@ -336,8 +336,6 @@ class Task:
 
         print_csv(self.df[columns], str(output_file))
 
-        self,
-
     def mask_user_info(
         self,
         to_replace_for_user_id: Optional[dict[str, str]] = None,

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -27,6 +27,7 @@ from annofabcli.statistics.linegraph import (
     get_weekly_sum,
     write_bokeh_graph,
 )
+from annofabcli.statistics.visualization.dataframe.task import Task
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +156,7 @@ class WholeProductivityPerCompletedDate:
         df_agg_sub_task = df_sub_task.pivot_table(
             values=value_columns,
             index="first_acceptance_completed_date",
-            aggfunc=numpy.sum,
+            aggfunc="sum",
         ).fillna(0)
         if len(df_agg_sub_task) > 0:
             df_agg_sub_task["task_count"] = df_sub_task.pivot_table(
@@ -175,7 +176,7 @@ class WholeProductivityPerCompletedDate:
                     "monitored_acceptance_worktime_hour",
                 ],
                 index="date",
-                aggfunc=numpy.sum,
+                aggfunc="sum",
             ).fillna(0)
 
             # 作業したユーザ数を算出
@@ -909,7 +910,8 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         add_velocity_column(df, numerator_column="acceptance_worktime_hour", denominator_column="annotation_count")
 
     @classmethod
-    def from_df(cls, df_task: pandas.DataFrame) -> WholeProductivityPerFirstAnnotationStartedDate:
+    def from_task(cls, task: Task) -> WholeProductivityPerFirstAnnotationStartedDate:
+        df_task = task.df
         df_sub_task = df_task[df_task["status"] == TaskStatus.COMPLETE.value][
             [
                 "task_id",
@@ -937,7 +939,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         df_agg_sub_task = df_sub_task.pivot_table(
             values=value_columns,
             index="first_annotation_started_date",
-            aggfunc=numpy.sum,
+            aggfunc="sum",
         ).fillna(0)
         if len(df_agg_sub_task) > 0:
             df_agg_sub_task["task_count"] = df_sub_task.pivot_table(

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -206,11 +206,14 @@ class WholeProductivityPerCompletedDate:
                     "monitored_acceptance_worktime_hour",
                     "unmonitored_worktime_hour",
                     "working_user_count",
-                ]
+                ],
+                dtype="float",
+                index=pandas.Index([], name="date", dtype="string"),
             )
 
         # 日付の一覧を生成
         df_date_base = cls._create_df_date(df_agg_sub_task.index, df_agg_labor.index)
+
         df_date = df_date_base.join(df_agg_sub_task).join(df_agg_labor).fillna(0)
         df_date["date"] = df_date.index
 

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -192,7 +192,7 @@ class WriteCsvGraph:
 
         self.project_dir.write_whole_productivity_per_date(productivity_per_completed_date_obj)
 
-        productivity_per_started_date_obj = WholeProductivityPerFirstAnnotationStartedDate.from_df(df_task)
+        productivity_per_started_date_obj = WholeProductivityPerFirstAnnotationStartedDate.from_task(df_task)
         self.project_dir.write_whole_productivity_per_first_annotation_started_date(productivity_per_started_date_obj)
 
         if not self.output_only_text:

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -185,14 +185,14 @@ class WriteCsvGraph:
 
         self.project_dir.write_worktime_per_date_user(worktime_per_date_obj)
 
-        df_task = self._get_task_df()
+        task = Task(self._get_task_df())
         productivity_per_completed_date_obj = WholeProductivityPerCompletedDate.from_df_wrapper(
-            df_task, worktime_per_date_obj.df
+            task, worktime_per_date_obj
         )
 
         self.project_dir.write_whole_productivity_per_date(productivity_per_completed_date_obj)
 
-        productivity_per_started_date_obj = WholeProductivityPerFirstAnnotationStartedDate.from_task(df_task)
+        productivity_per_started_date_obj = WholeProductivityPerFirstAnnotationStartedDate.from_task(task)
         self.project_dir.write_whole_productivity_per_first_annotation_started_date(productivity_per_started_date_obj)
 
         if not self.output_only_text:

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -186,7 +186,7 @@ class WriteCsvGraph:
         self.project_dir.write_worktime_per_date_user(worktime_per_date_obj)
 
         df_task = self._get_task_df()
-        productivity_per_completed_date_obj = WholeProductivityPerCompletedDate.from_df(
+        productivity_per_completed_date_obj = WholeProductivityPerCompletedDate.from_df_wrapper(
             df_task, worktime_per_date_obj.df
         )
 

--- a/tests/statistics/visualization/dataframe/test_whole_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_whole_productivity_per_date.py
@@ -32,7 +32,6 @@ class TestWholeProductivityPerCompletedDate:
         worktime_per_date = WorktimePerDate.from_csv(data_dir / "ユーザ_日付list-作業時間.csv")
         WholeProductivityPerCompletedDate.from_df_wrapper(task, worktime_per_date)
 
-
     def test_from_df__df_worktime引数が空でもインスタンスを生成できることを確認する(self):
         # 完了タスクが１つもない状態で試す
         task = Task.from_csv(data_dir / "task.csv")

--- a/tests/statistics/visualization/dataframe/test_whole_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_whole_productivity_per_date.py
@@ -2,12 +2,13 @@ from pathlib import Path
 
 import pandas
 
+from annofabcli.statistics.visualization.dataframe.task import Task
 from annofabcli.statistics.visualization.dataframe.whole_productivity_per_date import (
     WholeProductivityPerCompletedDate,
     WholeProductivityPerFirstAnnotationStartedDate,
 )
 
-output_dir = Path("./tests/out/statistics/visualization/dataframe")
+output_dir = Path("./tests/out/statistics/visualization/dataframe/whole_productivity_per_date")
 data_dir = Path("./tests/data/statistics")
 output_dir.mkdir(exist_ok=True, parents=True)
 
@@ -58,23 +59,26 @@ class TestWholeProductivityPerCompletedDate:
 
 
 class TestWholeProductivityPerFirstAnnotationStartedDate:
-    main_obj: WholeProductivityPerFirstAnnotationStartedDate
+    output_dir: Path
 
     @classmethod
-    def setup_class(cls):
-        df_task = pandas.read_csv(str(data_dir / "task.csv"))
-        cls.main_obj = WholeProductivityPerFirstAnnotationStartedDate.from_df(df_task)
+    def setup_class(cls) -> None:
+        cls.output_dir = output_dir / "WholeProductivityPerFirstAnnotationStartedDate"
+        cls.output_dir.mkdir(exist_ok=True, parents=True)
 
-    def test_plot(self):
-        self.main_obj.plot(output_dir / "教師付開始日ごとの生産量と生産性.html")
+    def test__from_task__and__to_csv(self):
+        task = Task.from_csv(data_dir / "task.csv")
+        obj = WholeProductivityPerFirstAnnotationStartedDate.from_task(task)
+        obj.to_csv(self.output_dir / "test__from_task__and__to_csv.csv")
 
-    def test_to_csv(self):
-        self.main_obj.to_csv(output_dir / "教師付開始日ごとの生産量と生産性.csv")
+    def test__from_task__and__plot(self):
+        task = Task.from_csv(data_dir / "task.csv")
+        obj = WholeProductivityPerFirstAnnotationStartedDate.from_task(task)
+        obj.plot(self.output_dir / "test__from_task__and__plot.html")
 
-    def test_merge(self):
-        df1 = pandas.read_csv(str(data_dir / "教師付開始日毎の生産量と生産性.csv"))
-        df2 = pandas.read_csv(str(data_dir / "教師付開始日毎の生産量と生産性2.csv"))
-        merged_obj = WholeProductivityPerFirstAnnotationStartedDate.merge(
-            WholeProductivityPerFirstAnnotationStartedDate(df1), WholeProductivityPerFirstAnnotationStartedDate(df2)
-        )
-        merged_obj.to_csv(output_dir / "merge-教師付開始日毎の生産量と生産性.csv")
+    def test__merge(self):
+        obj1 = WholeProductivityPerFirstAnnotationStartedDate.from_csv(data_dir / "教師付開始日毎の生産量と生産性.csv")
+        obj2 = WholeProductivityPerFirstAnnotationStartedDate.from_csv(data_dir / "教師付開始日毎の生産量と生産性2.csv")
+        merged_obj = WholeProductivityPerFirstAnnotationStartedDate.merge(obj1, obj2)
+        merged_obj.to_csv(self.output_dir / "test__merge.csv")
+        merged_obj.plot(self.output_dir / "test__merge.html")


### PR DESCRIPTION
# 対応前
マージ対象ディレクトリにある`教師付開始日毎の生産量と生産性.csv`や`日毎の生産量と生産性.csv`を読み込み、合算した値をファイル出力しました。

# 対応後
`タスクlist.csv`と`ユーザ_日付list-作業時間.csv`を読み込み合算して、`教師付開始日毎の生産量と生産性.csv`や`日毎の生産量と生産性.csv`を出力するようにしました。