### PR TITLE
pandasのFutureWarningを対応

### DIFF
--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -562,8 +562,9 @@ class AttributeCountCsv:
         columns = get_columns()
         df = pandas.DataFrame([to_cell(e) for e in counter_list], columns=pandas.MultiIndex.from_tuples(columns))
 
-        # `task_id`列など`basic_columns`も`fillna`対象だが、nanではないはずので問題ない
-        df.fillna(0, inplace=True)
+        # アノテーション数の列のNaNを0に変換する
+        value_columns = self._value_columns(counter_list, prior_attribute_columns)
+        df = df.fillna({column:0 for column in value_columns})
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -666,9 +666,10 @@ class LabelCountCsv:
         columns = get_columns()
         df = pandas.DataFrame([to_dict(e) for e in counter_list], columns=columns)
 
-        # NaNを0に変換する
-        # `basic_columns`は必ずnanではないので、すべての列に対してfillnaを実行しても問題ないはず
-        df.fillna(0, inplace=True)
+        # アノテーション数列のNaNを0に変換する
+        value_columns = self._value_columns(counter_list, prior_label_columns)
+        df = df.fillna({column:0 for column in value_columns})
+
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
 

--- a/annofabcli/statistics/summarize_task_count_by_task_id_group.py
+++ b/annofabcli/statistics/summarize_task_count_by_task_id_group.py
@@ -134,7 +134,7 @@ def create_task_count_summary_df(
     if task_id_delimiter is not None:
         df_task["task_id_group"] = df_task["task_id"].map(lambda e: get_task_id_prefix(e, delimiter=task_id_delimiter))
 
-    df_task["task_id_group"].fillna(TASK_ID_GROUP_UNKNOWN, inplace=True)
+    df_task.fillna({"task_id_group":TASK_ID_GROUP_UNKNOWN}, inplace=True)
 
     df_summary = df_task.pivot_table(
         values="task_id", index=["task_id_group"], columns=["status_for_summary"], aggfunc="count", fill_value=0


### PR DESCRIPTION
pandasの以下の警告を修正しました。
```
tests/statistics/test_list_annotation_count.py::TestLabelCountCsv::test_print_csv_by_input_data
  /workspaces/annofab-cli/annofabcli/statistics/list_annotation_count.py:671: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
    df.fillna(0, inplace=True)

tests/statistics/test_list_annotation_count.py::TestAttributeCountCsv::test_print_csv_by_input_data
  /workspaces/annofab-cli/annofabcli/statistics/list_annotation_count.py:566: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
    df.fillna(0, inplace=True)

tests/statistics/test_summarize_task_count_by_task_id_group.py::test_create_task_count_summary_df
  /workspaces/annofab-cli/annofabcli/statistics/summarize_task_count_by_task_id_group.py:137: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
  The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.
  
  For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.
  
  
    df_task["task_id_group"].fillna(TASK_ID_GROUP_UNKNOWN, inplace=True)
```