### PR TITLE
Python3.8でpandas操作に失敗する不具合を修正

### DIFF
--- a/annofabcli/common/pandas.py
+++ b/annofabcli/common/pandas.py
@@ -1,0 +1,14 @@
+import pandas
+
+
+def get_frequency_of_monthend() -> str:
+    """
+    "MonthEnd"を表すfrequencyコードを取得する。
+    pandas2.2から"M"は非推奨になったので、pandas2.2以上ならば"ME"を返す。そうでなければ"M"を返す。
+
+    https://github.com/pandas-dev/pandas/issues/9586
+    """
+    major, minor, _ = pandas.__version__.split(".")
+    if int(major) >= 2 and int(minor) >= 2:
+        return "ME"
+    return "M"

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -564,7 +564,7 @@ class AttributeCountCsv:
 
         # アノテーション数の列のNaNを0に変換する
         value_columns = self._value_columns(counter_list, prior_attribute_columns)
-        df = df.fillna({column:0 for column in value_columns})
+        df = df.fillna({column: 0 for column in value_columns})
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
@@ -669,7 +669,7 @@ class LabelCountCsv:
 
         # アノテーション数列のNaNを0に変換する
         value_columns = self._value_columns(counter_list, prior_label_columns)
-        df = df.fillna({column:0 for column in value_columns})
+        df = df.fillna({column: 0 for column in value_columns})
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 

--- a/annofabcli/statistics/summarize_task_count_by_task_id_group.py
+++ b/annofabcli/statistics/summarize_task_count_by_task_id_group.py
@@ -134,7 +134,7 @@ def create_task_count_summary_df(
     if task_id_delimiter is not None:
         df_task["task_id_group"] = df_task["task_id"].map(lambda e: get_task_id_prefix(e, delimiter=task_id_delimiter))
 
-    df_task.fillna({"task_id_group":TASK_ID_GROUP_UNKNOWN}, inplace=True)
+    df_task.fillna({"task_id_group": TASK_ID_GROUP_UNKNOWN}, inplace=True)
 
     df_summary = df_task.pivot_table(
         values="task_id", index=["task_id_group"], columns=["status_for_summary"], aggfunc="count", fill_value=0

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy
 import pandas
 
+from annofabcli.common.pandas import get_frequency_of_monthend
 from annofabcli.common.utils import print_csv
 from annofabcli.statistics.visualization.dataframe.user_performance import UserPerformance
 from annofabcli.statistics.visualization.dataframe.whole_performance import WholePerformance
@@ -128,7 +129,10 @@ class ProjectWorktimePerMonth:
         """
         df = project_dir.read_worktime_per_date_user().df.copy()
         df["dt_date"] = pandas.to_datetime(df["date"], format="ISO8601")
-        series = df.groupby(pandas.Grouper(key="dt_date", freq="ME")).sum(numeric_only=True)[worktime_column.value]
+
+        series = df.groupby(pandas.Grouper(key="dt_date", freq=get_frequency_of_monthend())).sum(numeric_only=True)[
+            worktime_column.value
+        ]
         # indexを"2022-04"という形式にする
         new_index = [str(dt)[0:7] for dt in series.index]
         result = pandas.Series(series.values, index=new_index)

--- a/tests/test_stat_visualization.py
+++ b/tests/test_stat_visualization.py
@@ -52,7 +52,7 @@ class TestCommandLine:
                 "stat_visualization",
                 "write_performance_rating_csv",
                 "--dir",
-                str(data_dir/"write_performance_rating_csv"),
+                str(data_dir / "write_performance_rating_csv"),
                 "--output_dir",
                 str(out_dir / "write_performance_rating_csv-out"),
             ]


### PR DESCRIPTION
https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#deprecate-aliases-m-q-y-etc-in-favour-of-me-qe-ye-etc-for-offsets

pandasのバージョンを見て、frequencyコードを変えるようにした。
* pandas 2.2.0以上ならば"ME"
* そうでないならば"M"