### PR TITLE
pandas 2.2以上ならばCopy-on-Writeの警告を出すようにしました。

### DIFF
--- a/annofabcli/__main__.py
+++ b/annofabcli/__main__.py
@@ -26,8 +26,20 @@ import annofabcli.supplementary.subcommand_supplementary
 import annofabcli.task.subcommand_task
 import annofabcli.task_history.subcommand_task_history
 import annofabcli.task_history_event.subcommand_task_history_event
+import pandas
 
 logger = logging.getLogger(__name__)
+
+
+def warn_pandas_copy_on_write() -> None:
+    """
+    pandas2.2以上ならば、Copy-on-Writeの警告を出す。
+    pandas 3.0で予期しない挙動になるのを防ぐため。
+    https://pandas.pydata.org/docs/user_guide/copy_on_write.html
+    """
+    major, minor, _ = pandas.__version__.split(".")
+    if int(major) >= 2 and int(minor) >= 2:
+        pandas.options.mode.copy_on_write = "warn"
 
 
 def mask_argv(argv: list[str]) -> list[str]:
@@ -111,4 +123,5 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    warn_pandas_copy_on_write()
     main()

--- a/annofabcli/__main__.py
+++ b/annofabcli/__main__.py
@@ -6,6 +6,8 @@ import logging
 import sys
 from typing import Optional
 
+import pandas
+
 import annofabcli.annotation.subcommand_annotation
 import annofabcli.annotation_specs.subcommand_annotation_specs
 import annofabcli.comment.subcommand_comment
@@ -26,7 +28,6 @@ import annofabcli.supplementary.subcommand_supplementary
 import annofabcli.task.subcommand_task
 import annofabcli.task_history.subcommand_task_history
 import annofabcli.task_history_event.subcommand_task_history_event
-import pandas
 
 logger = logging.getLogger(__name__)
 

--- a/annofabcli/statistics/summarize_task_count.py
+++ b/annofabcli/statistics/summarize_task_count.py
@@ -88,6 +88,12 @@ def create_task_count_summary(task_list: List[Task], number_of_inspections: int)
         number_of_inspections: プロジェクト設定から取得した検査フェーズの回数
 
     Returns:
+        以下の列を持つDataFrame
+        * step
+        * phase
+        * phase_stage
+        * simple_status
+        * task_count
 
     """
     for task in task_list:
@@ -112,8 +118,11 @@ def create_task_count_summary(task_list: List[Task], number_of_inspections: int)
         ],
     )
 
+    # `observed=True`を指定する理由：以下の警告に対応するため
+    # FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas.  # noqa: E501
+    # Specify observed=False to silence this warning and retain the current behavior
     summary_df = df.pivot_table(
-        values="task_id", index=["step", "phase", "phase_stage", "simple_status"], aggfunc="count"
+        values="task_id", index=["step", "phase", "phase_stage", "simple_status"], aggfunc="count", observed=False
     ).reset_index()
     summary_df.rename(columns={"task_id": "task_count"}, inplace=True)
 

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -130,7 +130,7 @@ class ProjectWorktimePerMonth:
         df = project_dir.read_worktime_per_date_user().df.copy()
         df["dt_date"] = pandas.to_datetime(df["date"], format="ISO8601")
 
-        series = df.groupby(pandas.Grouper(key="dt_date", freq="MonthEnd")).sum(numeric_only=True)[
+        series = df.groupby(pandas.Grouper(key="dt_date", freq=get_frequency_of_monthend())).sum(numeric_only=True)[
             worktime_column.value
         ]
         # indexを"2022-04"という形式にする

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -130,7 +130,7 @@ class ProjectWorktimePerMonth:
         df = project_dir.read_worktime_per_date_user().df.copy()
         df["dt_date"] = pandas.to_datetime(df["date"], format="ISO8601")
 
-        series = df.groupby(pandas.Grouper(key="dt_date", freq=get_frequency_of_monthend())).sum(numeric_only=True)[
+        series = df.groupby(pandas.Grouper(key="dt_date", freq="MonthEnd")).sum(numeric_only=True)[
             worktime_column.value
         ]
         # indexを"2022-04"という形式にする


### PR DESCRIPTION
# pandasのFutureWarningに対応
```

tests/test_statistics.py::TestCommandLine::test_summarize_task_count
  /workspaces/annofab-cli/annofabcli/statistics/summarize_task_count.py:123: FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas. Specify observed=False to silence this warning and retain the current behavior
    summary_df = df.pivot_table(
```

# pandas2.2以上ならばCopy-on-Writeの警告を出すようにした