### PR TITLE
`task update_metadata`: メタデータを更新するAPIを`putTask`から`patchTasksMetadata`に変更する。

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/actual_worktime.py
+++ b/annofabcli/statistics/visualization/dataframe/actual_worktime.py
@@ -33,7 +33,7 @@ class ActualWorktime:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            ValueError(f"引数`df`には、{ActualWorktime.columns}の列が必要です。")
+            raise ValueError(f"引数`df`には、{ActualWorktime.columns}の列が必要です。")
         self.df = df
 
     def is_empty(self) -> bool:


### PR DESCRIPTION
`putTask` APIはアノテーションユーザーロールでは実行できないが、`patchTasksMetadata` APIならばアノテーションユーザーロールでも実行できる。
したがって、`putTask` APIではなく`patchTasksMetadata` APIでメタデータを更新するように変更した。
