### PR TITLE
Ruff v0.2.2に対応する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 .PHONY: docs lint test format publish_test publish
 
 format:
-	poetry run black ${SOURCE_FILES} ${TEST_FILES}
+	poetry run ruff format ${SOURCE_FILES} ${TEST_FILES}
 	poetry run ruff check ${SOURCE_FILES} ${TEST_FILES} --fix-only --exit-zero
 
 lint:
@@ -22,7 +22,7 @@ lint:
 test:
     # 更新の競合が発生する可能性があるので、並列実行しない
 	# skip対象のmakersを実行しないように"-m"で指定する
-	poetry run pytest --cov=${SOURCE_FILES} --cov-report=html ${TEST_FILES} -m "not submitting_job and not depending_on_annotation_specs" 
+	poetry run pytest --cov=${SOURCE_FILES} --cov-report=html ${TEST_FILES} -m "not submitting_job and not depending_on_annotation_specs"
 
 publish:
 	poetry publish --build

--- a/annofabcli/__main__.py
+++ b/annofabcli/__main__.py
@@ -91,9 +91,7 @@ def main(arguments: Optional[list[str]] = None) -> None:
 
 
 def create_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Command Line Interface for Annofab", formatter_class=annofabcli.common.cli.PrettyHelpFormatter
-    )
+    parser = argparse.ArgumentParser(description="Command Line Interface for Annofab", formatter_class=annofabcli.common.cli.PrettyHelpFormatter)
     parser.add_argument("--version", action="version", version=f"annofabcli {annofabcli.__version__}")
     parser.set_defaults(command_help=parser.print_help)
 

--- a/annofabcli/annotation/annotation_query.py
+++ b/annofabcli/annotation/annotation_query.py
@@ -111,7 +111,7 @@ def convert_attributes_from_cli_to_api(
     for attribute_name, attribute_value in attributes.items():
         additional_data = more_itertools.first_true(
             tmp_additionals,
-            pred=lambda e: get_message_for_i18n(e["name"]) == attribute_name,  # noqa: function-uses-loop-variable  # pylint: disable=cell-var-from-loop
+            pred=lambda e: get_message_for_i18n(e["name"]) == attribute_name,  # noqa: function-uses-loop-variable  # pylint: disable=cell-var-from-loop  # noqa: B023
         )
         tmp = [e for e in tmp_additionals if get_message_for_i18n(e["name"]) == attribute_name]
         if len(tmp) == 0:

--- a/annofabcli/annotation/annotation_query.py
+++ b/annofabcli/annotation/annotation_query.py
@@ -56,9 +56,7 @@ def _get_attribute_to_api(additional_data: dict[str, Any], attribute_value: Attr
         AdditionalDataDefinitionType.SELECT.value,
     ]:
         # 排他選択の場合、属性値に選択肢IDが入っているため、対象の選択肢を探す
-        choice_info = more_itertools.first_true(
-            additional_data["choices"], pred=lambda e: get_message_for_i18n(e["name"]) == attribute_value
-        )
+        choice_info = more_itertools.first_true(additional_data["choices"], pred=lambda e: get_message_for_i18n(e["name"]) == attribute_value)
         tmp = [e for e in additional_data["choices"] if get_message_for_i18n(e["name"]) == attribute_value]
 
         if len(tmp) == 0:
@@ -107,18 +105,13 @@ def convert_attributes_from_cli_to_api(
             raise ValueError(f"アノテーション仕様に、label_id='{label_id}' であるラベルは存在しません。")
 
         tmp_additional_data_definition_ids = set(label_info["additional_data_definitions"])
-        tmp_additionals = [
-            e
-            for e in annotation_specs["additionals"]
-            if e["additional_data_definition_id"] in tmp_additional_data_definition_ids
-        ]
+        tmp_additionals = [e for e in annotation_specs["additionals"] if e["additional_data_definition_id"] in tmp_additional_data_definition_ids]
 
     attributes_for_webapi: list[AdditionalDataV1] = []
     for attribute_name, attribute_value in attributes.items():
         additional_data = more_itertools.first_true(
             tmp_additionals,
-            pred=lambda e: get_message_for_i18n(e["name"])
-            == attribute_name,  # noqa: function-uses-loop-variable  # pylint: disable=cell-var-from-loop
+            pred=lambda e: get_message_for_i18n(e["name"]) == attribute_name,  # noqa: function-uses-loop-variable  # pylint: disable=cell-var-from-loop
         )
         tmp = [e for e in tmp_additionals if get_message_for_i18n(e["name"]) == attribute_name]
         if len(tmp) == 0:

--- a/annofabcli/annotation/annotation_query.py
+++ b/annofabcli/annotation/annotation_query.py
@@ -111,7 +111,7 @@ def convert_attributes_from_cli_to_api(
     for attribute_name, attribute_value in attributes.items():
         additional_data = more_itertools.first_true(
             tmp_additionals,
-            pred=lambda e: get_message_for_i18n(e["name"]) == attribute_name,  # noqa: function-uses-loop-variable  # pylint: disable=cell-var-from-loop  # noqa: B023
+            pred=lambda e: get_message_for_i18n(e["name"]) == attribute_name,  # noqa: B023  # pylint: disable=cell-var-from-loop
         )
         tmp = [e for e in tmp_additionals if get_message_for_i18n(e["name"]) == attribute_name]
         if len(tmp) == 0:

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -92,9 +92,7 @@ class ChangeAnnotationAttributesMain(AbstractCommandLineWithConfirmInterface):
         request_body = [_to_request_body_elm(annotation) for annotation in annotation_list]
         return self.service.api.batch_update_annotations(self.project_id, request_body=request_body)[0]
 
-    def get_annotation_list_for_task(
-        self, task_id: str, annotation_query: AnnotationQueryForAPI
-    ) -> list[dict[str, Any]]:
+    def get_annotation_list_for_task(self, task_id: str, annotation_query: AnnotationQueryForAPI) -> list[dict[str, Any]]:
         """
         タスク内のアノテーション一覧を取得する。
 
@@ -108,9 +106,7 @@ class ChangeAnnotationAttributesMain(AbstractCommandLineWithConfirmInterface):
         """
         dict_query = annotation_query.to_dict()
         dict_query.update({"task_id": task_id, "exact_match_task_id": True})
-        annotation_list = self.service.wrapper.get_all_annotation_list(
-            self.project_id, query_params={"query": dict_query}
-        )
+        annotation_list = self.service.wrapper.get_all_annotation_list(self.project_id, query_params={"query": dict_query})
         return annotation_list
 
     def change_attributes_for_task(
@@ -135,7 +131,7 @@ class ChangeAnnotationAttributesMain(AbstractCommandLineWithConfirmInterface):
         Returns:
             アノテーションの属性を変更するAPI ``change_annotation_attributes`` を実行したか否か
         """
-        logger_prefix = f"{str(task_index+1)} 件目: " if task_index is not None else ""
+        logger_prefix = f"{task_index+1!s} 件目: " if task_index is not None else ""
         dict_task = self.service.wrapper.get_task_or_none(self.project_id, task_id)
         if dict_task is None:
             logger.warning(f"task_id = '{task_id}' は存在しません。")
@@ -252,9 +248,7 @@ class ChangeAttributesOfAnnotation(AbstractCommandLineInterface):
         return True
 
     @classmethod
-    def get_annotation_query_for_api(
-        cls, str_annotation_query: str, annotation_specs: dict[str, Any]
-    ) -> AnnotationQueryForAPI:
+    def get_annotation_query_for_api(cls, str_annotation_query: str, annotation_specs: dict[str, Any]) -> AnnotationQueryForAPI:
         """
         CLIから受け取った`--annotation_query`の値から、APIに渡すクエリー情報を返す。
         """
@@ -263,9 +257,7 @@ class ChangeAttributesOfAnnotation(AbstractCommandLineInterface):
         return annotation_query_for_cli.to_query_for_api(annotation_specs)
 
     @classmethod
-    def get_attributes_for_api(
-        cls, str_attributes: str, annotation_specs: dict[str, Any], label_id: str
-    ) -> list[AdditionalDataV1]:
+    def get_attributes_for_api(cls, str_attributes: str, annotation_specs: dict[str, Any], label_id: str) -> list[AdditionalDataV1]:
         """
         CLIから受け取った`--attributes`の値から、APIに渡す属性情報を返す。
         """
@@ -290,15 +282,16 @@ class ChangeAttributesOfAnnotation(AbstractCommandLineInterface):
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         try:
-            attributes = self.get_attributes_for_api(
-                args.attributes, annotation_specs, label_id=annotation_query.label_id
-            )
+            attributes = self.get_attributes_for_api(args.attributes, annotation_specs, label_id=annotation_query.label_id)
         except ValueError as e:
             print(f"{self.COMMON_MESSAGE} argument '--attributes' の値が不正です。 :: {e}", file=sys.stderr)
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         if args.backup is None:
-            print("間違えてアノテーションを変更してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。", file=sys.stderr)
+            print(
+                "間違えてアノテーションを変更してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。",
+                file=sys.stderr,
+            )
             if not self.confirm_processing("復元用のバックアップディレクトリが指定されていません。処理を続行しますか？"):
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
             backup_dir = None
@@ -307,9 +300,7 @@ class ChangeAttributesOfAnnotation(AbstractCommandLineInterface):
 
         super().validate_project(project_id, [ProjectMemberRole.OWNER])
 
-        main_obj = ChangeAnnotationAttributesMain(
-            self.service, project_id=project_id, is_force=args.force, all_yes=args.yes
-        )
+        main_obj = ChangeAnnotationAttributesMain(self.service, project_id=project_id, is_force=args.force, all_yes=args.yes)
         main_obj.change_annotation_attributes_for_task_list(
             task_id_list,
             annotation_query=annotation_query,
@@ -347,7 +338,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--attributes",
         type=str,
         required=True,
-        help="変更後の属性をJSON形式で指定します。" "``file://`` を先頭に付けると、JSON形式のファイルを指定できます。" f"(ex): ``{EXAMPLE_ATTRIBUTES}``",
+        help="変更後の属性をJSON形式で指定します。"
+        "``file://`` を先頭に付けると、JSON形式のファイルを指定できます。"
+        f"(ex): ``{EXAMPLE_ATTRIBUTES}``",
     )
 
     parser.add_argument("--force", action="store_true", help="完了状態のタスクのアノテーション属性も変更します。")

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -349,7 +349,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--backup",
         type=str,
         required=False,
-        help="アノテーションのバックアップを保存するディレクトリを指定してください。アノテーションの復元は ``annotation restore`` コマンドで実現できます。",
+        help="アノテーションのバックアップを保存するディレクトリを指定してください。アノテーションの復元は ``annotation restore`` コマンドで実現できます。",  # noqa: E501
     )
     parser.add_argument(
         "--parallelism",

--- a/annofabcli/annotation/change_annotation_properties.py
+++ b/annofabcli/annotation/change_annotation_properties.py
@@ -68,9 +68,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
 
         now_datetime = str_now()
 
-        def to_properties_from_cli(
-            annotation_list: List[SingleAnnotation], properties: AnnotationDetailForCli
-        ) -> List[Dict[str, Any]]:
+        def to_properties_from_cli(annotation_list: List[SingleAnnotation], properties: AnnotationDetailForCli) -> List[Dict[str, Any]]:
             annotations_for_api = []
             annotation_details_by_input_data: Dict[str, List[Dict[str, Any]]] = {}
 
@@ -113,9 +111,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
         for annotation in annotations:
             _to_request_body_elm(annotation)
 
-    def get_annotation_list_for_task(
-        self, task_id: str, annotation_query: Optional[AnnotationQueryForAPI]
-    ) -> list[dict[str, Any]]:
+    def get_annotation_list_for_task(self, task_id: str, annotation_query: Optional[AnnotationQueryForAPI]) -> list[dict[str, Any]]:
         """
         タスク内のアノテーション一覧を取得する。
 
@@ -131,9 +127,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
         if annotation_query is not None:
             dict_query.update(annotation_query.to_dict())
 
-        annotation_list = self.service.wrapper.get_all_annotation_list(
-            self.project_id, query_params={"query": dict_query}
-        )
+        annotation_list = self.service.wrapper.get_all_annotation_list(self.project_id, query_params={"query": dict_query})
         return annotation_list
 
     def change_properties_for_task(  # pylint: disable=too-many-return-statements
@@ -154,7 +148,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
             backup_dir: アノテーションをバックアップとして保存するディレクトリ。指定しない場合は、バックアップを取得しない。
 
         """
-        logger_prefix = f"{str(task_index+1)} 件目: " if task_index is not None else ""
+        logger_prefix = f"{task_index+1!s} 件目: " if task_index is not None else ""
         dict_task = self.service.wrapper.get_task_or_none(self.project_id, task_id)
         if dict_task is None:
             logger.warning(f"task_id = '{task_id}' は存在しません。")
@@ -166,7 +160,9 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
         )
 
         if dict_task["status"] in [TaskStatus.WORKING.value, TaskStatus.COMPLETE.value]:
-            logger.info(f"タスク'{task_id}'は作業中または受入完了状態のため、アノテーションプロパティの変更をスキップします。 status={dict_task['status']}")
+            logger.info(
+                f"タスク'{task_id}'は作業中または受入完了状態のため、アノテーションプロパティの変更をスキップします。 status={dict_task['status']}"
+            )
             return False
 
         old_account_id: Optional[str] = dict_task["account_id"]
@@ -328,7 +324,10 @@ class ChangePropertiesOfAnnotation(AbstractCommandLineInterface):
         properties_for_cli = AnnotationDetailForCli.from_dict(properties_of_dict)
 
         if args.backup is None:
-            print("間違えてアノテーションを変更してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。", file=sys.stderr)
+            print(
+                "間違えてアノテーションを変更してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。",
+                file=sys.stderr,
+            )
             if not self.confirm_processing("復元用のバックアップディレクトリが指定されていません。処理を続行しますか？"):
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
             backup_dir = None
@@ -337,9 +336,7 @@ class ChangePropertiesOfAnnotation(AbstractCommandLineInterface):
 
         super().validate_project(project_id, [ProjectMemberRole.OWNER])
 
-        main_obj = ChangePropertiesOfAnnotationMain(
-            self.service, project_id=project_id, is_force=args.force, all_yes=args.yes
-        )
+        main_obj = ChangePropertiesOfAnnotationMain(self.service, project_id=project_id, is_force=args.force, all_yes=args.yes)
         main_obj.change_annotation_properties_task_list(
             task_id_list,
             properties=properties_for_cli,
@@ -382,7 +379,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--force", action="store_true", help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を自分自身に変更してからアノテーションプロパティを変更します。"
+        "--force",
+        action="store_true",
+        help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を自分自身に変更してからアノテーションプロパティを変更します。",
     )
 
     parser.add_argument(

--- a/annofabcli/annotation/change_annotation_properties.py
+++ b/annofabcli/annotation/change_annotation_properties.py
@@ -388,7 +388,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--backup",
         type=str,
         required=False,
-        help="アノテーションのバックアップを保存するディレクトリを指定してください。アノテーションの復元は ``annotation restore`` コマンドで実現できます。",
+        help="アノテーションのバックアップを保存するディレクトリを指定してください。アノテーションの復元は ``annotation restore`` コマンドで実現できます。",  # noqa: E501
     )
 
     parser.add_argument(
@@ -405,7 +405,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "アノテーションのプロパティを変更します。"
     description = (
         "アノテーションのプロパティを一括で変更します。ただし、作業中状態のタスクのアノテーションのプロパティは変更できません。"
-        "間違えてアノテーションのプロパティを変更したときに復元できるようにするため、 ``--backup`` でバックアップ用のディレクトリを指定することを推奨します。"
+        "間違えてアノテーションのプロパティを変更したときに復元できるようにするため、 ``--backup`` でバックアップ用のディレクトリを指定することを推奨します。"  # noqa: E501
     )
     epilog = "オーナロールを持つユーザで実行してください。"
 

--- a/annofabcli/annotation/copy_annotation.py
+++ b/annofabcli/annotation/copy_annotation.py
@@ -123,9 +123,7 @@ def get_copy_target_list(str_copy_target_list: list[str]) -> list[CopyTarget]:
 
 
 class CopyAnnotationMain(AbstractCommandLineWithConfirmInterface):
-    def __init__(
-        self, service: annofabapi.Resource, *, project_id: str, all_yes: bool, overwrite: bool, merge: bool, force: bool
-    ) -> None:
+    def __init__(self, service: annofabapi.Resource, *, project_id: str, all_yes: bool, overwrite: bool, merge: bool, force: bool) -> None:
         self.service = service
         self.project_id = project_id
         self.overwrite = overwrite
@@ -183,9 +181,7 @@ class CopyAnnotationMain(AbstractCommandLineWithConfirmInterface):
         return copy_count > 0
 
     @staticmethod
-    def _merge_annotation(
-        src_details: list[dict[str, Any]], dest_details: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def _merge_annotation(src_details: list[dict[str, Any]], dest_details: list[dict[str, Any]]) -> list[dict[str, Any]]:
         details = copy.deepcopy(dest_details)
 
         # annotation_idが重複してたときに上書きできるように、annotation_idからindexを取得できるようにする
@@ -214,7 +210,7 @@ class CopyAnnotationMain(AbstractCommandLineWithConfirmInterface):
         )
         if src_annotation is None:
             logger.warning(
-                f"task_id='{copy_target.src_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.src_task_id}'のタスクにinput_data_id='{copy_target.src_input_data_id}'の入力データが存在しません。"  # noqa: E501
+                f"task_id='{copy_target.src_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.src_task_id}'のタスクにinput_data_id='{copy_target.src_input_data_id}'の入力データが存在しません。"
             )
             return False
 
@@ -225,7 +221,7 @@ class CopyAnnotationMain(AbstractCommandLineWithConfirmInterface):
         )
         if dest_annotation is None:
             logger.warning(
-                f"task_id='{copy_target.dest_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.dest_task_id}'のタスクにinput_data_id='{copy_target.dest_input_data_id}'の入力データが存在しません。"  # noqa: E501
+                f"task_id='{copy_target.dest_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.dest_task_id}'のタスクにinput_data_id='{copy_target.dest_input_data_id}'の入力データが存在しません。"
             )
             return False
 
@@ -252,9 +248,7 @@ class CopyAnnotationMain(AbstractCommandLineWithConfirmInterface):
             account_id=self.service.api.account_id,
         )
         request_body["updated_datetime"] = dest_annotation["updated_datetime"]
-        self.service.api.put_annotation(
-            self.project_id, copy_target.dest_task_id, copy_target.dest_input_data_id, request_body=request_body
-        )
+        self.service.api.put_annotation(self.project_id, copy_target.dest_task_id, copy_target.dest_input_data_id, request_body=request_body)
         logger.debug(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'にコピーしました。")
         return True
 
@@ -396,7 +390,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     overwrite_merge_group.add_argument(
         "--overwrite",
         action="store_true",
-        help="コピー先にアノテーションが存在する場合、 ``--overwrite`` を指定していれば、すでに存在するアノテーションを削除してコピーします。" "指定しなければ、アノテーションのコピーをスキップします。",
+        help="コピー先にアノテーションが存在する場合、 ``--overwrite`` を指定していれば、すでに存在するアノテーションを削除してコピーします。"
+        "指定しなければ、アノテーションのコピーをスキップします。",
     )
     overwrite_merge_group.add_argument(
         "--merge",
@@ -406,7 +401,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "指定しなければ、アノテーションのコピーをスキップします。",
     )
     parser.add_argument(
-        "--force", action="store_true", help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を一時的に自分自身に変更してからアノテーションをコピーします。"
+        "--force",
+        action="store_true",
+        help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を一時的に自分自身に変更してからアノテーションをコピーします。",
     )
 
     parser.add_argument(

--- a/annofabcli/annotation/delete_annotation.py
+++ b/annofabcli/annotation/delete_annotation.py
@@ -232,7 +232,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--backup",
         type=str,
         required=False,
-        help="アノテーションのバックアップを保存するディレクトリを指定してください。アノテーションの復元は ``annotation restore`` コマンドで実現できます。",
+        help="アノテーションのバックアップを保存するディレクトリを指定してください。アノテーションの復元は ``annotation restore`` コマンドで実現できます。",  # noqa: E501
     )
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation/delete_annotation.py
+++ b/annofabcli/annotation/delete_annotation.py
@@ -72,9 +72,7 @@ class DeleteAnnotationMain(AbstractCommandLineWithConfirmInterface):
         request_body = [_to_request_body_elm(annotation) for annotation in annotation_list]
         self.service.api.batch_update_annotations(self.project_id, request_body=request_body)
 
-    def get_annotation_list_for_task(
-        self, task_id: str, annotation_query: Optional[AnnotationQueryForAPI]
-    ) -> list[dict[str, Any]]:
+    def get_annotation_list_for_task(self, task_id: str, annotation_query: Optional[AnnotationQueryForAPI]) -> list[dict[str, Any]]:
         """
         タスク内のアノテーション一覧を取得する。
 
@@ -90,9 +88,7 @@ class DeleteAnnotationMain(AbstractCommandLineWithConfirmInterface):
         if annotation_query is not None:
             dict_query.update(annotation_query.to_dict())
 
-        annotation_list = self.service.wrapper.get_all_annotation_list(
-            self.project_id, query_params={"query": dict_query}
-        )
+        annotation_list = self.service.wrapper.get_all_annotation_list(self.project_id, query_params={"query": dict_query})
         return annotation_list
 
     def delete_annotation_for_task(
@@ -116,10 +112,7 @@ class DeleteAnnotationMain(AbstractCommandLineWithConfirmInterface):
             return
 
         task: Task = Task.from_dict(dict_task)
-        logger.info(
-            f"task_id={task.task_id}, phase={task.phase.value}, status={task.status.value}, "
-            f"updated_datetime={task.updated_datetime}"
-        )
+        logger.info(f"task_id={task.task_id}, phase={task.phase.value}, status={task.status.value}, " f"updated_datetime={task.updated_datetime}")
 
         if task.status == TaskStatus.WORKING:
             logger.warning(f"task_id={task_id}: タスクが作業中状態のため、スキップします。")
@@ -194,7 +187,10 @@ class DeleteAnnotation(AbstractCommandLineInterface):
             annotation_query = None
 
         if args.backup is None:
-            print("間違えてアノテーションを削除してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。", file=sys.stderr)
+            print(
+                "間違えてアノテーションを削除してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。",
+                file=sys.stderr,
+            )
             if not self.confirm_processing("復元用のバックアップディレクトリが指定されていません。処理を続行しますか？"):
                 return
             backup_dir = None

--- a/annofabcli/annotation/download_annotation_zip.py
+++ b/annofabcli/annotation/download_annotation_zip.py
@@ -15,9 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingAnnotationZip(AbstractCommandLineInterface):
-    def download_annotation_zip(
-        self, project_id: str, output_zip: Path, is_latest: bool, should_download_full_annotation: bool = False
-    ):
+    def download_annotation_zip(self, project_id: str, output_zip: Path, is_latest: bool, should_download_full_annotation: bool = False):
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         project_title = self.facade.get_project_title(project_id)

--- a/annofabcli/annotation/dump_annotation.py
+++ b/annofabcli/annotation/dump_annotation.py
@@ -54,7 +54,7 @@ class DumpAnnotationMain:
         Returns:
             アノテーション情報をファイルに保存したかどうか。
         """
-        logger_prefix = f"{str(task_index+1)} 件目: " if task_index is not None else ""
+        logger_prefix = f"{task_index+1!s} 件目: " if task_index is not None else ""
         task = self.service.wrapper.get_task_or_none(self.project_id, task_id)
         if task is None:
             logger.warning(f"task_id = '{task_id}' のタスクは存在しません。スキップします。")

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -362,7 +362,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
         simple_annotation: ImportedSimpleAnnotation = ImportedSimpleAnnotation.from_dict(parser.load_json())
         if len(simple_annotation.details) == 0:
             logger.debug(
-                f"task_id={task_id}, input_data_id={input_data_id} : インポート元にアノテーションデータがないため、アノテーションの登録をスキップします。"
+                f"task_id={task_id}, input_data_id={input_data_id} : インポート元にアノテーションデータがないため、アノテーションの登録をスキップします。"  # noqa: E501
             )
             return False
 
@@ -650,7 +650,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "import"
     subcommand_help = "アノテーションをインポートします。"
-    description = "アノテーションをインポートします。アノテーションのフォーマットは、Simpleアノテーションと同じフォルダ構成のzipファイルまたはディレクトリです。ただし、作業中/完了状態のタスクはインポートできません。"
+    description = "アノテーションをインポートします。アノテーションのフォーマットは、Simpleアノテーションと同じフォルダ構成のzipファイルまたはディレクトリです。ただし、作業中/完了状態のタスクはインポートできません。"  # noqa: E501
     epilog = "オーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -106,9 +106,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
         logger.warning(f"アノテーション仕様に label_name='{label_name}' のラベルが存在しません。")
         return None
 
-    def _get_additional_data_from_attribute_name(
-        self, attribute_name: str, label_info: LabelV1
-    ) -> Optional[AdditionalDataDefinitionV1]:
+    def _get_additional_data_from_attribute_name(self, attribute_name: str, label_info: LabelV1) -> Optional[AdditionalDataDefinitionV1]:
         for additional_data in label_info["additional_data_definitions"]:
             additional_data_name_en = self.visualize.get_additional_data_name(
                 additional_data["additional_data_definition_id"], MessageLocale.EN, label_id=label_info["label_id"]
@@ -262,11 +260,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
 
         if data_holding_type == AnnotationDataHoldingType.OUTER:
             # TODO: 3dpc editorに依存したコード。annofab側でSimple Annotationのフォーマットが改善されたら、このコードを削除する
-            data_uri = (
-                detail.data["data_uri"]
-                if not self._is_3dpc_segment_label(label_info)
-                else self._get_3dpc_segment_data_uri(detail.data)
-            )
+            data_uri = detail.data["data_uri"] if not self._is_3dpc_segment_label(label_info) else self._get_3dpc_segment_data_uri(detail.data)
             with parser.open_outer_file(data_uri) as f:
                 s3_path = self.service.wrapper.upload_data_to_s3(self.project_id, f, content_type="image/png")
                 dest_obj.path = s3_path
@@ -389,9 +383,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
 
         logger.info(f"task_id={task_id}, input_data_id={input_data_id} : アノテーションを登録します。")
         if self.is_merge:
-            request_body = self.parser_to_request_body_with_merge(
-                parser, simple_annotation.details, old_annotation=old_annotation
-            )
+            request_body = self.parser_to_request_body_with_merge(parser, simple_annotation.details, old_annotation=old_annotation)
         else:
             request_body = self.parser_to_request_body(parser, simple_annotation.details, old_annotation=old_annotation)
 
@@ -429,7 +421,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
         if not self.confirm_processing(f"task_id={task_id} のアノテーションをインポートしますか？"):
             return False
 
-        logger_prefix = f"{str(task_index+1)} 件目: " if task_index is not None else ""
+        logger_prefix = f"{task_index+1!s} 件目: " if task_index is not None else ""
         logger.info(f"{logger_prefix}task_id={task_id} に対して処理します。")
 
         task = self.service.wrapper.get_task_or_none(self.project_id, task_id)
@@ -551,7 +543,7 @@ class ImportAnnotation(AbstractCommandLineInterface):
         annotation_path = Path(args.annotation)
         if not annotation_path.exists():
             print(
-                f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリが存在しません。'{str(annotation_path)}'",
+                f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリが存在しません。'{annotation_path!s}'",
                 file=sys.stderr,
             )
             return False
@@ -579,9 +571,7 @@ class ImportAnnotation(AbstractCommandLineInterface):
 
         super().validate_project(project_id, [ProjectMemberRole.OWNER])
 
-        target_task_ids = (
-            set(annofabcli.common.cli.get_list_from_args(args.task_id)) if args.task_id is not None else None
-        )
+        target_task_ids = set(annofabcli.common.cli.get_list_from_args(args.task_id)) if args.task_id is not None else None
 
         # Simpleアノテーションの読み込み
         if annotation_path.is_dir():
@@ -619,7 +609,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--annotation",
         type=Path,
         required=True,
-        help="Simpleアノテーションと同じフォルダ構成のzipファイル or ディレクトリのパスを指定してください。" "タスクの状態が作業中/完了の場合はインポートしません。",
+        help="Simpleアノテーションと同じフォルダ構成のzipファイル or ディレクトリのパスを指定してください。"
+        "タスクの状態が作業中/完了の場合はインポートしません。",
     )
 
     argument_parser.add_task_id(required=False)
@@ -629,7 +620,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     overwrite_merge_group.add_argument(
         "--overwrite",
         action="store_true",
-        help="アノテーションが存在する場合、 ``--overwrite`` を指定していれば、すでに存在するアノテーションを削除してインポートします。" "指定しなければ、アノテーションのインポートをスキップします。",
+        help="アノテーションが存在する場合、 ``--overwrite`` を指定していれば、すでに存在するアノテーションを削除してインポートします。"
+        "指定しなければ、アノテーションのインポートをスキップします。",
     )
 
     overwrite_merge_group.add_argument(
@@ -641,7 +633,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--force", action="store_true", help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を自分自身に変更してからアノテーションをインポートします。"
+        "--force",
+        action="store_true",
+        help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を自分自身に変更してからアノテーションをインポートします。",
     )
 
     parser.add_argument(
@@ -656,9 +650,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "import"
     subcommand_help = "アノテーションをインポートします。"
-    description = (
-        "アノテーションをインポートします。アノテーションのフォーマットは、Simpleアノテーションと同じフォルダ構成のzipファイルまたはディレクトリです。ただし、作業中/完了状態のタスクはインポートできません。"
-    )
+    description = "アノテーションをインポートします。アノテーションのフォーマットは、Simpleアノテーションと同じフォルダ構成のzipファイルまたはディレクトリです。ただし、作業中/完了状態のタスクはインポートできません。"
     epilog = "オーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/annotation/list_annotation.py
+++ b/annofabcli/annotation/list_annotation.py
@@ -120,7 +120,7 @@ def to_annotation_list_for_csv(annotation_list: List[SingleAnnotation]) -> List[
 class ListAnnotation(AbstractCommandLineInterface):
     COMMON_MESSAGE = "annofabcli annotation list: error:"
 
-    PRIOR_COLUMNS = [
+    PRIOR_COLUMNS = [  # noqa: RUF012
         "project_id",
         "task_id",
         "input_data_id",
@@ -136,7 +136,7 @@ class ListAnnotation(AbstractCommandLineInterface):
         "data",
     ]
 
-    DROPPED_COLUMNS = [
+    DROPPED_COLUMNS = [  # noqa: RUF012
         "detail",
         "additional_data_list",
         "etag",

--- a/annofabcli/annotation/list_annotation.py
+++ b/annofabcli/annotation/list_annotation.py
@@ -81,9 +81,7 @@ class ListAnnotationMain:
         elif input_data_id_list is not None:
             for input_data_id in input_data_id_list:
                 try:
-                    annotation_list = self.get_annotation_list(
-                        project_id, annotation_query, input_data_id=input_data_id
-                    )
+                    annotation_list = self.get_annotation_list(project_id, annotation_query, input_data_id=input_data_id)
                 except Exception:
                     logger.warning(f"入力データ'{input_data_id}'のアノテーションの一覧の取得に失敗しました。", exc_info=True)
                     continue
@@ -229,7 +227,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-i",
         "--input_data_id",
         nargs="+",
-        help=("対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"),
+        help=(
+            "対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
+        ),
     )
 
     argument_parser.add_format(

--- a/annofabcli/annotation/list_annotation_count.py
+++ b/annofabcli/annotation/list_annotation_count.py
@@ -122,7 +122,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-i",
         "--input_data_id",
         nargs="+",
-        help=("対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"),
+        help=(
+            "対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
+        ),
     )
 
     parser.add_argument(

--- a/annofabcli/annotation/restore_annotation.py
+++ b/annofabcli/annotation/restore_annotation.py
@@ -46,9 +46,7 @@ class RestoreAnnotationMain(AbstractCommandLineWithConfirmInterface):
         self.project_id = project_id
         self.is_force = is_force
 
-    def _to_annotation_detail_for_request(
-        self, parser: SimpleAnnotationParser, detail: AnnotationDetailV1
-    ) -> AnnotationDetailV1:
+    def _to_annotation_detail_for_request(self, parser: SimpleAnnotationParser, detail: AnnotationDetailV1) -> AnnotationDetailV1:
         """
         Request Bodyに渡すDataClassに変換する。塗りつぶし画像があれば、それをS3にアップロードする。
 
@@ -137,7 +135,7 @@ class RestoreAnnotationMain(AbstractCommandLineWithConfirmInterface):
             1個以上の入力データのアノテーションを変更したか
 
         """
-        logger_prefix = f"{str(task_index+1)} 件目: " if task_index is not None else ""
+        logger_prefix = f"{task_index+1!s} 件目: " if task_index is not None else ""
         task_id = task_parser.task_id
         if not self.confirm_processing(f"task_id={task_id} のアノテーションをリストアしますか？"):
             return False
@@ -314,7 +312,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_id(required=False)
 
     parser.add_argument(
-        "--force", action="store_true", help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を自分自身に変更してからアノテーションをリストアします。"
+        "--force",
+        action="store_true",
+        help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を自分自身に変更してからアノテーションをリストアします。",
     )
 
     parser.add_argument(
@@ -329,7 +329,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "restore"
     subcommand_help = "'annotation dump'コマンドで保存したファイルから、アノテーション情報をリストアします。"
-    description = "'annotation dump'コマンドで保存したファイルから、アノテーション情報をリストアします。ただし、作業中/完了状態のタスクはリストアできません。"
+    description = (
+        "'annotation dump'コマンドで保存したファイルから、アノテーション情報をリストアします。ただし、作業中/完了状態のタスクはリストアできません。"
+    )
     epilog = "チェッカーまたはオーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/annotation/subcommand_annotation.py
+++ b/annofabcli/annotation/subcommand_annotation.py
@@ -35,8 +35,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "アノテーション関係のサブコマンド"
     description = "アノテーション関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/annotation_specs/get_annotation_specs_with_attribute_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_attribute_id_replaced.py
@@ -24,9 +24,7 @@ logger = logging.getLogger(__name__)
 
 class ReplacingAttributeId(AbstractCommandLineWithConfirmInterface):
     @staticmethod
-    def replace_attribute_id_of_restrictions(
-        old_attribute_id: str, new_attribute_id: str, restriction_list: list[dict[str, Any]]
-    ) -> None:
+    def replace_attribute_id_of_restrictions(old_attribute_id: str, new_attribute_id: str, restriction_list: list[dict[str, Any]]) -> None:
         """
         制約情報の中で使用されている属性IDを新しい属性IDに変更する
 
@@ -50,9 +48,7 @@ class ReplacingAttributeId(AbstractCommandLineWithConfirmInterface):
             _replace_attribute_id_in_condition(restriction["condition"])
 
     @staticmethod
-    def replace_attribute_id_of_labels(
-        old_attribute_id: str, new_attribute_id: str, label_list: list[dict[str, Any]]
-    ) -> None:
+    def replace_attribute_id_of_labels(old_attribute_id: str, new_attribute_id: str, label_list: list[dict[str, Any]]) -> None:
         """
         ラベル情報の中で使用されている属性IDを新しい属性IDに変更する
 
@@ -72,10 +68,7 @@ class ReplacingAttributeId(AbstractCommandLineWithConfirmInterface):
     @staticmethod
     def exists_attribute_with_attribute_id(attribute_list: list[dict[str, Any]], attribute_id: str) -> bool:
         """指定したlabel_idを持つラベル情報が存在するか否か"""
-        return (
-            more_itertools.first_true(attribute_list, pred=lambda e: e["additional_data_definition_id"] == attribute_id)
-            is not None
-        )
+        return more_itertools.first_true(attribute_list, pred=lambda e: e["additional_data_definition_id"] == attribute_id) is not None
 
     @staticmethod
     def validate_attribute_id(str_id: str) -> bool:
@@ -84,9 +77,7 @@ class ReplacingAttributeId(AbstractCommandLineWithConfirmInterface):
         """
         return re.fullmatch("[A-Za-z0-9_.\\-]+", str_id) is not None
 
-    def main(
-        self, annotation_specs: dict[str, Any], *, target_attribute_names: Optional[Collection[str]] = None
-    ) -> None:
+    def main(self, annotation_specs: dict[str, Any], *, target_attribute_names: Optional[Collection[str]] = None) -> None:
         """
         アノテーション仕様内の属性IDを英語名に変更します。
 
@@ -125,9 +116,7 @@ class ReplacingAttributeId(AbstractCommandLineWithConfirmInterface):
                 continue
 
             attribute["additional_data_definition_id"] = attribute_name_en
-            self.replace_attribute_id_of_labels(
-                old_attribute_id=attribute_id, new_attribute_id=attribute_name_en, label_list=label_list
-            )
+            self.replace_attribute_id_of_labels(old_attribute_id=attribute_id, new_attribute_id=attribute_name_en, label_list=label_list)
             self.replace_attribute_id_of_restrictions(
                 old_attribute_id=attribute_id, new_attribute_id=attribute_name_en, restriction_list=restriction_list
             )
@@ -144,9 +133,7 @@ class GetAnnotationSpecsWithAttributeIdReplaced(AbstractCommandLineInterface):
 
         annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"v": 3})
 
-        target_attribute_names = (
-            set(get_list_from_args(args.attribute_name)) if args.attribute_name is not None else None
-        )
+        target_attribute_names = set(get_list_from_args(args.attribute_name)) if args.attribute_name is not None else None
 
         # アノテーション仕様のlabel_idを変更する
         ReplacingAttributeId(all_yes=args.yes).main(annotation_specs, target_attribute_names=target_attribute_names)

--- a/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
@@ -35,9 +35,7 @@ class ReplacingChoiceId(AbstractCommandLineWithConfirmInterface):
         """
         return re.fullmatch("[A-Za-z0-9_.\\-]+", str_id) is not None
 
-    def main(
-        self, annotation_specs: dict[str, Any], *, target_attribute_names: Optional[Collection[str]] = None
-    ) -> None:
+    def main(self, annotation_specs: dict[str, Any], *, target_attribute_names: Optional[Collection[str]] = None) -> None:
         """
         アノテーション仕様内の選択肢IDを英語名に変更します。
 
@@ -64,7 +62,8 @@ class ReplacingChoiceId(AbstractCommandLineWithConfirmInterface):
             choice_list = attribute["choices"]
 
             if not self.confirm_processing(
-                f"属性英語名='{attribute_name_en}'の{len(choice_list)}個の選択肢IDを、" "選択肢英語名に変更したアノテーション仕様のJSONを出力しますか？"
+                f"属性英語名='{attribute_name_en}'の{len(choice_list)}個の選択肢IDを、"
+                "選択肢英語名に変更したアノテーション仕様のJSONを出力しますか？"
             ):
                 continue
 
@@ -108,9 +107,7 @@ class GetAnnotationSpecsWithAttributeIdReplaced(AbstractCommandLineInterface):
 
         annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"v": 3})
 
-        target_attribute_names = (
-            set(get_list_from_args(args.attribute_name)) if args.attribute_name is not None else None
-        )
+        target_attribute_names = set(get_list_from_args(args.attribute_name)) if args.attribute_name is not None else None
 
         # アノテーション仕様のlabel_idを変更する
         ReplacingChoiceId(all_yes=args.yes).main(annotation_specs, target_attribute_names=target_attribute_names)

--- a/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
@@ -43,7 +43,7 @@ class ReplacingChoiceId(AbstractCommandLineWithConfirmInterface):
             annotation_specs: (IN/OUT) アノテーション仕様情報。中身が変更されます。
             target_attribute_names: 変更対象のラジオボタン/ドロップダウン属性の英語名。Noneならすべてのラジオボタン/ドロップダウン属性の選択肢IDを変更します。
 
-        """
+        """  # noqa: E501
         attribute_list = annotation_specs["additionals"]
 
         replaced_count = 0

--- a/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
@@ -24,9 +24,7 @@ logger = logging.getLogger(__name__)
 
 class ReplacingLabelId(AbstractCommandLineWithConfirmInterface):
     @staticmethod
-    def replace_label_id_of_restrictions(
-        old_label_id: str, new_label_id: str, restriction_list: list[dict[str, Any]]
-    ) -> None:
+    def replace_label_id_of_restrictions(old_label_id: str, new_label_id: str, restriction_list: list[dict[str, Any]]) -> None:
         """
         制約情報の中で使用されているlabel_idを新しいlabel_idに変更する
 
@@ -88,15 +86,12 @@ class ReplacingLabelId(AbstractCommandLineWithConfirmInterface):
 
             if not self.validate_label_id(label_name_en):
                 logger.warning(
-                    f"label_name_en='{label_name_en}'はlabel_idにできない文字を含むため、"
-                    f"label_id='{label_id}'を'{label_name_en}'に変更しません。"
+                    f"label_name_en='{label_name_en}'はlabel_idにできない文字を含むため、" f"label_id='{label_id}'を'{label_name_en}'に変更しません。"
                 )
                 continue
 
             if self.exists_label_with_label_id(label_list, label_id=label_name_en):
-                logger.warning(
-                    f"label_id='{label_name_en}'であるラベルが既に存在するため、label_id='{label_id}'を'{label_name_en}'に変更しません。"
-                )
+                logger.warning(f"label_id='{label_name_en}'であるラベルが既に存在するため、label_id='{label_id}'を'{label_name_en}'に変更しません。")
                 continue
 
             if not self.confirm_processing(f"label_id='{label_id}'を'{label_name_en}'に変更したアノテーション仕様のJSONを出力しますか？"):
@@ -104,9 +99,7 @@ class ReplacingLabelId(AbstractCommandLineWithConfirmInterface):
 
             # ラベル内のlabel_idを変更する
             label["label_id"] = label_name_en
-            self.replace_label_id_of_restrictions(
-                old_label_id=label_id, new_label_id=label_name_en, restriction_list=restriction_list
-            )
+            self.replace_label_id_of_restrictions(old_label_id=label_id, new_label_id=label_name_en, restriction_list=restriction_list)
             replaced_count += 1
 
         logger.info(f"{replaced_count} 個のラベルのlabel_idを変更しました。")

--- a/annofabcli/annotation_specs/list_annotation_specs_history.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_history.py
@@ -48,9 +48,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     argument_parser.add_project_id()
 
-    argument_parser.add_format(
-        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV
-    )
+    argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)
     argument_parser.add_output()
     argument_parser.add_csv_format()
     argument_parser.add_query()

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -44,8 +44,8 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
         """
         日本語名、英語名のタプルを取得する。
         """
-        ja_name = [e["message"] for e in messages if e["lang"] == "ja-JP"][0]
-        en_name = [e["message"] for e in messages if e["lang"] == "en-US"][0]
+        ja_name = [e["message"] for e in messages if e["lang"] == "ja-JP"][0]  # noqa: RUF015
+        en_name = [e["message"] for e in messages if e["lang"] == "en-US"][0]  # noqa: RUF015
         return (ja_name, en_name)
 
     @staticmethod

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -74,7 +74,7 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
                 )
                 if additional_data_definition["type"] in ["choice", "select"]:
                     for choice in additional_data_definition["choices"]:
-                        output_lines.append(
+                        output_lines.append(  # noqa: PERF401
                             "\t".join(
                                 [
                                     "",

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -29,23 +29,15 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
 
     COMMON_MESSAGE = "annofabcli annotation_specs list_label: error:"
 
-    def print_annotation_specs_label(
-        self, project_id: str, arg_format: str, output: Optional[str] = None, history_id: Optional[str] = None
-    ):
+    def print_annotation_specs_label(self, project_id: str, arg_format: str, output: Optional[str] = None, history_id: Optional[str] = None):
         # [REMOVE_V2_PARAM]
-        annotation_specs, _ = self.service.api.get_annotation_specs(
-            project_id, query_params={"history_id": history_id, "v": "2"}
-        )
-        labels_v1 = convert_annotation_specs_labels_v2_to_v1(
-            labels_v2=annotation_specs["labels"], additionals_v2=annotation_specs["additionals"]
-        )
+        annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"history_id": history_id, "v": "2"})
+        labels_v1 = convert_annotation_specs_labels_v2_to_v1(labels_v2=annotation_specs["labels"], additionals_v2=annotation_specs["additionals"])
         if arg_format == "text":
             self._print_text_format_labels(labels_v1, output=output)
 
         elif arg_format in [FormatArgument.JSON.value, FormatArgument.PRETTY_JSON.value]:
-            annofabcli.common.utils.print_according_to_format(
-                target=labels_v1, arg_format=FormatArgument(arg_format), output=output
-            )
+            annofabcli.common.utils.print_according_to_format(target=labels_v1, arg_format=FormatArgument(arg_format), output=output)
 
     @staticmethod
     def _get_name_tuple(messages: List[Dict[str, Any]]) -> tuple[str, str]:
@@ -103,8 +95,7 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
             return None
         history = histories[-(before + 1)]
         logger.info(
-            f"{history['updated_datetime']}のアノテーション仕様を出力します。"
-            f"history_id={history['history_id']}, comment={history['comment']}"
+            f"{history['updated_datetime']}のアノテーション仕様を出力します。" f"history_id={history['history_id']}, comment={history['comment']}"
         )
         return history["history_id"]
 
@@ -123,9 +114,7 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
             # args.beforeがNoneならば、必ずargs.history_idはNoneでない
             history_id = args.history_id
 
-        self.print_annotation_specs_label(
-            args.project_id, arg_format=args.format, output=args.output, history_id=history_id
-        )
+        self.print_annotation_specs_label(args.project_id, arg_format=args.format, output=args.output, history_id=history_id)
 
 
 def parse_args(parser: argparse.ArgumentParser) -> None:

--- a/annofabcli/annotation_specs/list_attribute_restriction.py
+++ b/annofabcli/annotation_specs/list_attribute_restriction.py
@@ -110,9 +110,7 @@ class ListAttributeRestrictionMain:
         if str_type == "Imply":
             # 属性間の制約
             premise = condition["premise"]
-            if_condition_text = self.get_restriction_text(
-                premise["additional_data_definition_id"], premise["condition"]
-            )
+            if_condition_text = self.get_restriction_text(premise["additional_data_definition_id"], premise["condition"])
             then_text = self.get_restriction_text(attribute_id, condition["condition"])
             return f"{then_text} IF {if_condition_text}"
 
@@ -190,12 +188,8 @@ class ListAttributeRestrictionMain:
         result: set[str] = set()
 
         if target_attribute_names is not None:
-            tmp_attribute_list = [
-                self.get_attribute_from_name(attribute_name) for attribute_name in target_attribute_names
-            ]
-            tmp_ids = {
-                attribute["additional_data_definition_id"] for attribute in tmp_attribute_list if attribute is not None
-            }
+            tmp_attribute_list = [self.get_attribute_from_name(attribute_name) for attribute_name in target_attribute_names]
+            tmp_ids = {attribute["additional_data_definition_id"] for attribute in tmp_attribute_list if attribute is not None}
             result = result | tmp_ids
 
         if target_label_names is not None:
@@ -214,9 +208,7 @@ class ListAttributeRestrictionMain:
         target_label_names: Optional[Collection[str]] = None,
     ) -> list[str]:
         if target_attribute_names is not None or target_label_names is not None:
-            target_attribute_ids = self.get_target_attribute_ids(
-                target_attribute_names=target_attribute_names, target_label_names=target_label_names
-            )
+            target_attribute_ids = self.get_target_attribute_ids(target_attribute_names=target_attribute_names, target_label_names=target_label_names)
             return [
                 self.get_restriction_text(e["additional_data_definition_id"], e["condition"])
                 for e in restrictions

--- a/annofabcli/annotation_specs/list_attribute_restriction.py
+++ b/annofabcli/annotation_specs/list_attribute_restriction.py
@@ -49,7 +49,7 @@ class ListAttributeRestrictionMain:
         self,
         labels: list[dict[str, Any]],
         additionals: list[dict[str, Any]],
-        format: FormatArgument = FormatArgument.DETAILED_TEXT,  # noqa: builtin-argument-shadowing # pylint: disable=redefined-builtin
+        format: FormatArgument = FormatArgument.DETAILED_TEXT,  # noqa: A002 # pylint: disable=redefined-builtin
     ) -> None:
         self.attribute_dict = {e["additional_data_definition_id"]: e for e in additionals}
         self.label_dict = {e["label_id"]: e for e in labels}

--- a/annofabcli/annotation_specs/list_label_color.py
+++ b/annofabcli/annotation_specs/list_label_color.py
@@ -52,9 +52,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     argument_parser.add_project_id()
 
-    argument_parser.add_format(
-        choices=[FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.PRETTY_JSON
-    )
+    argument_parser.add_format(choices=[FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.PRETTY_JSON)
 
     argument_parser.add_output()
 

--- a/annofabcli/annotation_specs/put_label_color.py
+++ b/annofabcli/annotation_specs/put_label_color.py
@@ -72,9 +72,7 @@ class PuttingLabelColorMain(AbstractCommandLineWithConfirmInterface):
     def confirm_to_change_label_color(self, changed_labels: list[Label]) -> bool:
         confirm_message = f"以下のラベル({len(changed_labels)})件を変更しますか？"
 
-        str_changed_labels = "\n".join(
-            [f" * label_name_en='{e.label_name_en}', label_id='{e.label_id}'" for e in changed_labels]
-        )
+        str_changed_labels = "\n".join([f" * label_name_en='{e.label_name_en}', label_id='{e.label_id}'" for e in changed_labels])
         confirm_message = confirm_message + "\n" + str_changed_labels
         return self.confirm_processing(confirm_message)
 

--- a/annofabcli/annotation_specs/subcommand_annotation_specs.py
+++ b/annofabcli/annotation_specs/subcommand_annotation_specs.py
@@ -32,8 +32,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "アノテーション仕様関係のサブコマンド"
     description = "アノテーション仕様関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/comment/delete_comment.py
+++ b/annofabcli/comment/delete_comment.py
@@ -45,9 +45,7 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
 
         AbstractCommandLineWithConfirmInterface.__init__(self, all_yes)
 
-    def _create_request_body(
-        self, task: Dict[str, Any], input_data_id: str, comment_ids: List[str]
-    ) -> List[Dict[str, Any]]:
+    def _create_request_body(self, task: Dict[str, Any], input_data_id: str, comment_ids: List[str]) -> List[Dict[str, Any]]:
         """batch_update_comments に渡すリクエストボディを作成する。"""
 
         def _convert(comment_id: str) -> Dict[str, Any]:
@@ -56,16 +54,13 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
                 "_type": "Delete",
             }
 
-        old_comment_list, _ = self.service.api.get_comments(
-            self.project_id, task["task_id"], input_data_id, query_params={"v": "2"}
-        )
+        old_comment_list, _ = self.service.api.get_comments(self.project_id, task["task_id"], input_data_id, query_params={"v": "2"})
         old_comment_ids = {e["comment_id"] for e in old_comment_list}
         request_body = []
         for comment_id in comment_ids:
             if comment_id not in old_comment_ids:
                 logger.warning(
-                    f"task_id={task['task_id']}, input_data_id={input_data_id}: "
-                    f"comment_id='{comment_id}'のコメントは存在しません。",
+                    f"task_id={task['task_id']}, input_data_id={input_data_id}: " f"comment_id='{comment_id}'のコメントは存在しません。",
                 )
                 continue
             request_body.append(_convert(comment_id))
@@ -132,11 +127,7 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{logging_prefix} : task_id='{task_id}' のタスクは存在しないので、スキップします。")
             return 0
 
-        logger.debug(
-            f"{logging_prefix} : task_id = {task['task_id']}, "
-            f"status = {task['status']}, "
-            f"phase = {task['phase']}, "
-        )
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
 
         if not self._can_delete_comment(
             task=task,
@@ -151,23 +142,16 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
         added_comments_count = 0
         for input_data_id, comment_ids in comment_ids_for_task.items():
             if input_data_id not in task["input_data_id_list"]:
-                logger.warning(
-                    f"{logging_prefix} : task_id='{task_id}'のタスクに input_data_id='{input_data_id}'の入力データは存在しません。"
-                )
+                logger.warning(f"{logging_prefix} : task_id='{task_id}'のタスクに input_data_id='{input_data_id}'の入力データは存在しません。")
                 continue
             try:
                 # コメントを削除
-                request_body = self._create_request_body(
-                    task=changed_task, input_data_id=input_data_id, comment_ids=comment_ids
-                )
+                request_body = self._create_request_body(task=changed_task, input_data_id=input_data_id, comment_ids=comment_ids)
                 if len(request_body) > 0:
-                    self.service.api.batch_update_comments(
-                        self.project_id, task_id, input_data_id, request_body=request_body
-                    )
+                    self.service.api.batch_update_comments(self.project_id, task_id, input_data_id, request_body=request_body)
                     added_comments_count += 1
                     logger.debug(
-                        f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: "
-                        f"{len(request_body)}件のコメントを削除しました。"
+                        f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: " f"{len(request_body)}件のコメントを削除しました。"
                     )
                 else:
                     logger.warning(
@@ -188,9 +172,7 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
         tpl: Tuple[int, Tuple[str, DeletedCommentsForTask]],
     ) -> int:
         task_index, (task_id, comment_ids_for_task) = tpl
-        return self.delete_comments_for_task(
-            task_id=task_id, comment_ids_for_task=comment_ids_for_task, task_index=task_index
-        )
+        return self.delete_comments_for_task(task_id=task_id, comment_ids_for_task=comment_ids_for_task, task_index=task_index)
 
     def delete_comments_for_task_list(
         self,
@@ -202,9 +184,7 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
 
         if parallelism is not None:
             with multiprocessing.Pool(parallelism) as pool:
-                result_bool_list = pool.map(
-                    self.delete_comments_for_task_wrapper, enumerate(comment_ids_for_task_list.items())
-                )
+                result_bool_list = pool.map(self.delete_comments_for_task_wrapper, enumerate(comment_ids_for_task_list.items()))
                 added_comments_count = sum(e for e in result_bool_list)
 
         else:
@@ -273,7 +253,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず '--yes' を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず '--yes' を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/delete_comment.py
+++ b/annofabcli/comment/delete_comment.py
@@ -98,7 +98,7 @@ class DeleteCommentMain(AbstractCommandLineWithConfirmInterface):
         task_id = task["task_id"]
         if task["status"] not in [TaskStatus.NOT_STARTED.value, TaskStatus.WORKING.value, TaskStatus.BREAK.value]:
             logger.warning(
-                f"task_id='{task_id}' : タスクの状態が未着手,作業中,休憩中 以外の状態なので、コメントを削除できません。（task_status='{task['status']}'）"
+                f"task_id='{task_id}' : タスクの状態が未着手,作業中,休憩中 以外の状態なので、コメントを削除できません。（task_status='{task['status']}'）"  # noqa: E501
             )
             return False
         return True

--- a/annofabcli/comment/download_comment_json.py
+++ b/annofabcli/comment/download_comment_json.py
@@ -55,8 +55,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "コメント全件ファイルをダウンロードします。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/comment/list_all_comment.py
+++ b/annofabcli/comment/list_all_comment.py
@@ -110,9 +110,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--comment_type",
         choices=[CommentType.INSPECTION.value, CommentType.ONHOLD.value],
         help=(
-            "コメントの種類で絞り込みます。\n\n"
-            f" * {CommentType.INSPECTION.value}: 検査コメント\n"
-            f" * {CommentType.ONHOLD.value}: 保留コメント\n"
+            "コメントの種類で絞り込みます。\n\n" f" * {CommentType.INSPECTION.value}: 検査コメント\n" f" * {CommentType.ONHOLD.value}: 保留コメント\n"
         ),
     )
 

--- a/annofabcli/comment/list_all_comment.py
+++ b/annofabcli/comment/list_all_comment.py
@@ -149,7 +149,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "すべてのコメントの一覧を出力します。"
     description = (
         "すべてのコメントの一覧を出力します。\n"
-        "コメント一覧は、コマンドを実行した日の02:00(JST)頃の状態です。最新のコメント情報を取得したい場合は、 ``annofabcli comment list`` コマンドを実行してください。"
+        "コメント一覧は、コマンドを実行した日の02:00(JST)頃の状態です。最新のコメント情報を取得したい場合は、 ``annofabcli comment list`` コマンドを実行してください。"  # noqa: E501
     )
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)

--- a/annofabcli/comment/list_comment.py
+++ b/annofabcli/comment/list_comment.py
@@ -62,9 +62,7 @@ class ListingComments(AbstractCommandLineInterface):
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id)
         comment_type = CommentType(args.comment_type) if args.comment_type is not None else None
 
-        comment_list = self.get_comment_list(
-            args.project_id, task_id_list, comment_type=comment_type, exclude_reply=args.exclude_reply
-        )
+        comment_list = self.get_comment_list(args.project_id, task_id_list, comment_type=comment_type, exclude_reply=args.exclude_reply)
 
         logger.info(f"コメントの件数: {len(comment_list)}")
 
@@ -95,9 +93,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--comment_type",
         choices=[CommentType.INSPECTION.value, CommentType.ONHOLD.value],
         help=(
-            "コメントの種類で絞り込みます。\n\n"
-            f" * {CommentType.INSPECTION.value}: 検査コメント\n"
-            f" * {CommentType.ONHOLD.value}: 保留コメント\n"
+            "コメントの種類で絞り込みます。\n\n" f" * {CommentType.INSPECTION.value}: 検査コメント\n" f" * {CommentType.ONHOLD.value}: 保留コメント\n"
         ),
     )
 

--- a/annofabcli/comment/put_comment.py
+++ b/annofabcli/comment/put_comment.py
@@ -131,7 +131,7 @@ class PutCommentMain(AbstractCommandLineWithConfirmInterface):
 
         if task["status"] not in [TaskStatus.NOT_STARTED.value, TaskStatus.WORKING.value, TaskStatus.BREAK.value]:
             logger.warning(
-                f"task_id='{task_id}' : タスクの状態が未着手,作業中,休憩中 以外の状態なので、コメントを付与できません。（task_status='{task['status']}'）"
+                f"task_id='{task_id}' : タスクの状態が未着手,作業中,休憩中 以外の状態なので、コメントを付与できません。（task_status='{task['status']}'）"  # noqa: E501
             )
             return False
         return True

--- a/annofabcli/comment/put_comment.py
+++ b/annofabcli/comment/put_comment.py
@@ -52,9 +52,7 @@ keyはtask_id
 
 
 class PutCommentMain(AbstractCommandLineWithConfirmInterface):
-    def __init__(
-        self, service: annofabapi.Resource, project_id: str, comment_type: CommentType, all_yes: bool = False
-    ) -> None:
+    def __init__(self, service: annofabapi.Resource, project_id: str, comment_type: CommentType, all_yes: bool = False) -> None:
         self.service = service
         self.facade = AnnofabApiFacade(service)
         self.project_id = project_id
@@ -64,9 +62,7 @@ class PutCommentMain(AbstractCommandLineWithConfirmInterface):
 
         AbstractCommandLineWithConfirmInterface.__init__(self, all_yes)
 
-    def _create_request_body(
-        self, task: Dict[str, Any], input_data_id: str, comments: List[AddedComment]
-    ) -> List[Dict[str, Any]]:
+    def _create_request_body(self, task: Dict[str, Any], input_data_id: str, comments: List[AddedComment]) -> List[Dict[str, Any]]:
         """batch_update_comments に渡すリクエストボディを作成する。"""
 
         def _create_dict_annotation_id() -> Dict[str, str]:
@@ -87,9 +83,7 @@ class PutCommentMain(AbstractCommandLineWithConfirmInterface):
                 "comment_node": {
                     "data": comment.data,
                     "annotation_id": comment.annotation_id,
-                    "label_id": dict_annotation_id_label_id.get(comment.annotation_id)
-                    if comment.annotation_id is not None
-                    else None,
+                    "label_id": dict_annotation_id_label_id.get(comment.annotation_id) if comment.annotation_id is not None else None,
                     "status": "open",
                     "_type": "Root",
                 },
@@ -166,11 +160,7 @@ class PutCommentMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{logging_prefix} : task_id='{task_id}' のタスクは存在しないので、スキップします。")
             return 0
 
-        logger.debug(
-            f"{logging_prefix} : task_id = {task['task_id']}, "
-            f"status = {task['status']}, "
-            f"phase = {task['phase']}, "
-        )
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
 
         if not self._can_add_comment(
             task=task,
@@ -185,23 +175,14 @@ class PutCommentMain(AbstractCommandLineWithConfirmInterface):
         added_comments_count = 0
         for input_data_id, comments in comments_for_task.items():
             if input_data_id not in task["input_data_id_list"]:
-                logger.warning(
-                    f"{logging_prefix} : task_id='{task_id}'のタスクに input_data_id='{input_data_id}'の入力データは存在しません。"
-                )
+                logger.warning(f"{logging_prefix} : task_id='{task_id}'のタスクに input_data_id='{input_data_id}'の入力データは存在しません。")
                 continue
             try:
                 # コメントを付与する
-                request_body = self._create_request_body(
-                    task=changed_task, input_data_id=input_data_id, comments=comments
-                )
-                self.service.api.batch_update_comments(
-                    self.project_id, task_id, input_data_id, request_body=request_body
-                )
+                request_body = self._create_request_body(task=changed_task, input_data_id=input_data_id, comments=comments)
+                self.service.api.batch_update_comments(self.project_id, task_id, input_data_id, request_body=request_body)
                 added_comments_count += 1
-                logger.debug(
-                    f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: "
-                    f"{len(comments)}件のコメントを付与しました。"
-                )
+                logger.debug(f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: " f"{len(comments)}件のコメントを付与しました。")
             except Exception:  # pylint: disable=broad-except
                 logger.warning(
                     f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: コメントの付与に失敗しました。",
@@ -236,9 +217,7 @@ class PutCommentMain(AbstractCommandLineWithConfirmInterface):
 
         if parallelism is not None:
             with multiprocessing.Pool(parallelism) as pool:
-                result_bool_list = pool.map(
-                    self.add_comments_for_task_wrapper, enumerate(comments_for_task_list.items())
-                )
+                result_bool_list = pool.map(self.add_comments_for_task_wrapper, enumerate(comments_for_task_list.items()))
                 added_comments_count = sum(e for e in result_bool_list)
 
         else:

--- a/annofabcli/comment/put_comment_simply.py
+++ b/annofabcli/comment/put_comment_simply.py
@@ -33,9 +33,7 @@ class AddedSimpleComment:
 
 
 class PutCommentSimplyMain(AbstractCommandLineWithConfirmInterface):
-    def __init__(
-        self, service: annofabapi.Resource, project_id: str, comment_type: CommentType, all_yes: bool = False
-    ) -> None:
+    def __init__(self, service: annofabapi.Resource, project_id: str, comment_type: CommentType, all_yes: bool = False) -> None:
         self.service = service
         self.facade = AnnofabApiFacade(service)
         self.project_id = project_id
@@ -126,11 +124,7 @@ class PutCommentSimplyMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{logging_prefix} : task_id='{task_id}' のタスクは存在しないので、スキップします。")
             return False
 
-        logger.debug(
-            f"{logging_prefix} : task_id = {task['task_id']}, "
-            f"status = {task['status']}, "
-            f"phase = {task['phase']}, "
-        )
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
 
         if not self._can_add_comment(
             task=task,
@@ -152,9 +146,7 @@ class PutCommentSimplyMain(AbstractCommandLineWithConfirmInterface):
             logger.debug(f"{logging_prefix} : task_id={task_id} のタスクにコメントを付与しました。")
             return True
         except Exception:  # pylint: disable=broad-except
-            logger.warning(
-                f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: コメントの付与に失敗しました。", exc_info=True
-            )
+            logger.warning(f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: コメントの付与に失敗しました。", exc_info=True)
             return False
         finally:
             self.service.wrapper.change_task_status_to_break(self.project_id, task_id)

--- a/annofabcli/comment/put_comment_simply.py
+++ b/annofabcli/comment/put_comment_simply.py
@@ -95,7 +95,7 @@ class PutCommentSimplyMain(AbstractCommandLineWithConfirmInterface):
 
         if task["status"] not in [TaskStatus.NOT_STARTED.value, TaskStatus.WORKING.value, TaskStatus.BREAK.value]:
             logger.warning(
-                f"task_id='{task_id}' : タスクの状態が未着手,作業中,休憩中 以外の状態なので、コメントを付与できません。（task_status='{task['status']}'）"
+                f"task_id='{task_id}' : タスクの状態が未着手,作業中,休憩中 以外の状態なので、コメントを付与できません。（task_status='{task['status']}'）"  # noqa: E501
             )
             return False
         return True

--- a/annofabcli/comment/put_inspection_comment.py
+++ b/annofabcli/comment/put_inspection_comment.py
@@ -77,7 +77,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_inspection_comment.py
+++ b/annofabcli/comment/put_inspection_comment.py
@@ -45,9 +45,7 @@ class PutInspectionComment(AbstractCommandLineInterface):
         dict_comments = annofabcli.common.cli.get_json_from_args(args.json)
         comments_for_task_list = convert_cli_comments(dict_comments, comment_type=CommentType.INSPECTION)
 
-        main_obj = PutCommentMain(
-            self.service, project_id=args.project_id, comment_type=CommentType.INSPECTION, all_yes=self.all_yes
-        )
+        main_obj = PutCommentMain(self.service, project_id=args.project_id, comment_type=CommentType.INSPECTION, all_yes=self.all_yes)
         main_obj.add_comments_for_task_list(
             comments_for_task_list=comments_for_task_list,
             parallelism=args.parallelism,
@@ -65,9 +63,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     argument_parser.add_project_id()
 
-    SAMPLE_JSON = {
-        "task1": {"input_data1": [{"comment": "type属性が間違っています。", "data": {"x": 10, "y": 20, "_type": "Point"}}]}
-    }
+    SAMPLE_JSON = {"task1": {"input_data1": [{"comment": "type属性が間違っています。", "data": {"x": 10, "y": 20, "_type": "Point"}}]}}
     parser.add_argument(
         "--json",
         type=str,
@@ -79,7 +75,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_inspection_comment_simply.py
+++ b/annofabcli/comment/put_inspection_comment_simply.py
@@ -124,13 +124,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--custom_project_type",
         type=str,
         choices=[e.value for e in CustomProjectType],
-        help="[BETA] ビルトインのエディタプラグインを使用していないカスタムプロジェクトの種類を指定します。カスタムプロジェクトに対して、検査コメントの位置を指定しない場合は必須です。\n",
+        help="[BETA] ビルトインのエディタプラグインを使用していないカスタムプロジェクトの種類を指定します。カスタムプロジェクトに対して、検査コメントの位置を指定しない場合は必須です。\n",  # noqa: E501
     )
 
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_inspection_comment_simply.py
+++ b/annofabcli/comment/put_inspection_comment_simply.py
@@ -43,9 +43,7 @@ class PutInspectionCommentSimply(AbstractCommandLineInterface):
         super().validate_project(args.project_id, [ProjectMemberRole.ACCEPTER, ProjectMemberRole.OWNER])
 
         comment_data = annofabcli.common.cli.get_json_from_args(args.comment_data)
-        custom_project_type = (
-            CustomProjectType(args.custom_project_type) if args.custom_project_type is not None else None
-        )
+        custom_project_type = CustomProjectType(args.custom_project_type) if args.custom_project_type is not None else None
 
         project, _ = self.service.api.get_project(args.project_id)
         if comment_data is None:
@@ -56,10 +54,7 @@ class PutInspectionCommentSimply(AbstractCommandLineInterface):
                 comment_data = {"start": 0, "end": 100, "_type": "Time"}
             elif project["input_data_type"] == InputDataType.CUSTOM.value:
                 editor_plugin_id = project["configuration"]["plugin_id"]
-                if (
-                    editor_plugin_id == EditorPluginId.THREE_DIMENSION.value
-                    or custom_project_type == CustomProjectType.THREE_DIMENSION_POINT_CLOUD
-                ):
+                if editor_plugin_id == EditorPluginId.THREE_DIMENSION.value or custom_project_type == CustomProjectType.THREE_DIMENSION_POINT_CLOUD:
                     comment_data = {
                         "data": '{"kind": "CUBOID", "shape": {"dimensions": {"width": 1.0, "height": 1.0, "depth": 1.0}, "location": {"x": 0.0, "y": 0.0, "z": 0.0}, "rotation": {"x": 0.0, "y": 0.0, "z": 0.0}, "direction": {"front": {"x": 1.0, "y": 0.0, "z": 0.0}, "up": {"x": 0.0, "y": 0.0, "z": 1.0}}}, "version": "2"}',  # noqa: E501
                         "_type": "Custom",
@@ -73,9 +68,7 @@ class PutInspectionCommentSimply(AbstractCommandLineInterface):
 
         task_id_list = get_list_from_args(args.task_id)
         phrase_id_list = get_list_from_args(args.phrase_id)
-        main_obj = PutCommentSimplyMain(
-            self.service, project_id=args.project_id, comment_type=CommentType.INSPECTION, all_yes=self.all_yes
-        )
+        main_obj = PutCommentSimplyMain(self.service, project_id=args.project_id, comment_type=CommentType.INSPECTION, all_yes=self.all_yes)
         main_obj.put_comment_for_task_list(
             task_ids=task_id_list,
             comment_info=AddedSimpleComment(comment=args.comment, data=comment_data, phrases=phrase_id_list),
@@ -100,7 +93,10 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         nargs="+",
         required=True,
-        help=("検査コメントを付与するタスクのtask_idを指定してください。\n" "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
+        help=(
+            "検査コメントを付与するタスクのtask_idを指定してください。\n"
+            "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"
+        ),
     )
 
     parser.add_argument(
@@ -132,7 +128,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_onhold_comment.py
+++ b/annofabcli/comment/put_onhold_comment.py
@@ -77,7 +77,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_onhold_comment.py
+++ b/annofabcli/comment/put_onhold_comment.py
@@ -45,9 +45,7 @@ class PutInspectionComment(AbstractCommandLineInterface):
             dict_comments,
             comment_type=CommentType.ONHOLD,
         )
-        main_obj = PutCommentMain(
-            self.service, project_id=args.project_id, comment_type=CommentType.ONHOLD, all_yes=self.all_yes
-        )
+        main_obj = PutCommentMain(self.service, project_id=args.project_id, comment_type=CommentType.ONHOLD, all_yes=self.all_yes)
         main_obj.add_comments_for_task_list(
             comments_for_task_list=comments_for_task_list,
             parallelism=args.parallelism,
@@ -77,7 +75,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_onhold_comment_simply.py
+++ b/annofabcli/comment/put_onhold_comment_simply.py
@@ -41,9 +41,7 @@ class PutOnholdCommentSimply(AbstractCommandLineInterface):
         super().validate_project(args.project_id)
 
         task_id_list = get_list_from_args(args.task_id)
-        main_obj = PutCommentSimplyMain(
-            self.service, project_id=args.project_id, comment_type=CommentType.ONHOLD, all_yes=self.all_yes
-        )
+        main_obj = PutCommentSimplyMain(self.service, project_id=args.project_id, comment_type=CommentType.ONHOLD, all_yes=self.all_yes)
         main_obj.put_comment_for_task_list(
             task_ids=task_id_list,
             comment_info=AddedSimpleComment(comment=args.comment, data=None, phrases=None),
@@ -68,7 +66,10 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         nargs="+",
         required=True,
-        help=("コメントを付与するタスクのtask_idを指定してください。\n" "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
+        help=(
+            "コメントを付与するタスクのtask_idを指定してください。\n"
+            "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"
+        ),
     )
 
     parser.add_argument(
@@ -79,7 +80,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/put_onhold_comment_simply.py
+++ b/annofabcli/comment/put_onhold_comment_simply.py
@@ -82,7 +82,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/comment/subcommand_comment.py
+++ b/annofabcli/comment/subcommand_comment.py
@@ -31,8 +31,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_name = "comment"
     subcommand_help = "コメント関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=subcommand_help, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -498,7 +498,7 @@ class ArgumentParser:
         self.parser.add_argument("-tq", "--task_query", type=str, required=required, help=help_message)
 
 
-class AbstractCommandLineWithConfirmInterface(abc.ABC):  # noqa: abstract-base-class-without-abstract-method
+class AbstractCommandLineWithConfirmInterface(abc.ABC):  # noqa: B024
     """
     コマンドライン上でpromptを表示するときのインターフェイス
     """

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -151,7 +151,7 @@ def add_parser(
     )
     parser.set_defaults(command_help=parser.print_help)
 
-    # 引数グループに"global optional group"がある場合は、"--help"オプションをデフォルトの"optional"グループから、"global optional arguments"グループに移動する
+    # 引数グループに"global optional group"がある場合は、"--help"オプションをデフォルトの"optional"グループから、"global optional arguments"グループに移動する  # noqa: E501
     # https://ja.stackoverflow.com/a/57313/19524
     global_optional_argument_group = first_true(parser._action_groups, pred=lambda e: e.title == GLOBAL_OPTIONAL_ARGUMENTS_TITLE)
     if global_optional_argument_group is not None:

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -647,9 +647,9 @@ class PrettyHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaul
 
     def _get_help_string(self, action):  # noqa: ANN001
         # 必須な引数には、引数の説明の後ろに"(required)"を付ける
-        help = action.help  # noqa: builtin-variable-shadowing # pylint: disable=redefined-builtin
+        help = action.help  # noqa: A001 # pylint: disable=redefined-builtin
         if action.required:
-            help += " (required)"  # noqa: builtin-variable-shadowing
+            help += " (required)"  # noqa: A001
 
         # 不要なデフォルト値（--debug や オプショナルな引数）を表示させないようにする
         # super()._get_help_string の中身を、そのまま持ってきた。
@@ -660,7 +660,7 @@ class PrettyHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaul
                 if action.option_strings or action.nargs in defaulting_nargs:
                     # 以下の条件だけ、annofabcli独自の設定
                     if action.default is not None and not action.const:
-                        help += " (default: %(default)s)"  # noqa: builtin-variable-shadowing
+                        help += " (default: %(default)s)"  # noqa: A001
         return help
 
 

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -116,9 +116,7 @@ def add_parser(
 
         group.add_argument("--yes", action="store_true", help="処理中に現れる問い合わせに対して、常に ``yes`` と回答します。")
 
-        group.add_argument(
-            "--endpoint_url", type=str, help="Annofab WebAPIのエンドポイントを指定します。", default=DEFAULT_ENDPOINT_URL
-        )
+        group.add_argument("--endpoint_url", type=str, help="Annofab WebAPIのエンドポイントを指定します。", default=DEFAULT_ENDPOINT_URL)
 
         group.add_argument("--annofab_user_id", type=str, help="Annofabにログインする際のユーザーID")
         group.add_argument("--annofab_password", type=str, help="Annofabにログインする際のパスワード")
@@ -133,7 +131,9 @@ def add_parser(
 
         group.add_argument("--disable_log", action="store_true", help="ログを無効にします。")
 
-        group.add_argument("--debug", action="store_true", help="HTTPリクエストの内容やレスポンスのステータスコードなど、デバッグ用のログが出力されます。")
+        group.add_argument(
+            "--debug", action="store_true", help="HTTPリクエストの内容やレスポンスのステータスコードなど、デバッグ用のログが出力されます。"
+        )
 
         return parent_parser
 
@@ -153,9 +153,7 @@ def add_parser(
 
     # 引数グループに"global optional group"がある場合は、"--help"オプションをデフォルトの"optional"グループから、"global optional arguments"グループに移動する
     # https://ja.stackoverflow.com/a/57313/19524
-    global_optional_argument_group = first_true(
-        parser._action_groups, pred=lambda e: e.title == GLOBAL_OPTIONAL_ARGUMENTS_TITLE
-    )
+    global_optional_argument_group = first_true(parser._action_groups, pred=lambda e: e.title == GLOBAL_OPTIONAL_ARGUMENTS_TITLE)
     if global_optional_argument_group is not None:
         # optional グループの 0番目が help なので取り出す
         help_action = parser._optionals._group_actions.pop(0)
@@ -231,9 +229,7 @@ def get_input_data_size(str_input_data_size: str) -> Optional[InputDataSize]:
     return (int(splitted_list[0]), int(splitted_list[1]))
 
 
-def get_wait_options_from_args(
-    dict_wait_options: Optional[Dict[str, Any]], default_wait_options: WaitOptions
-) -> WaitOptions:
+def get_wait_options_from_args(dict_wait_options: Optional[Dict[str, Any]], default_wait_options: WaitOptions) -> WaitOptions:
     """
     デフォルト値とマージして、wait_optionsを取得する。
 
@@ -438,7 +434,10 @@ class ArgumentParser:
         '--input_data_id` 引数を追加
         """
         if help_message is None:
-            help_message = "対象の入力データのinput_data_idを指定します。" + " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
+            help_message = (
+                "対象の入力データのinput_data_idを指定します。"
+                + " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
+            )
 
         self.parser.add_argument("-i", "--input_data_id", type=str, required=required, nargs="+", help=help_message)
 
@@ -449,9 +448,7 @@ class ArgumentParser:
         if help_message is None:
             help_message = "出力フォーマットを指定します。"
 
-        self.parser.add_argument(
-            "-f", "--format", type=str, choices=[e.value for e in choices], default=default.value, help=help_message
-        )
+        self.parser.add_argument("-f", "--format", type=str, choices=[e.value for e in choices], default=default.value, help=help_message)
 
     def add_csv_format(self, help_message: Optional[str] = None):
         """
@@ -639,9 +636,7 @@ class AbstractCommandLineWithoutWebapiInterface(abc.ABC):
     def print_according_to_format(self, target: Any) -> None:  # noqa: ANN401
         target = self.search_with_jmespath_expression(target)
 
-        print_according_to_format(
-            target, arg_format=FormatArgument(self.str_format), output=self.output, csv_format=self.csv_format
-        )
+        print_according_to_format(target, arg_format=FormatArgument(self.str_format), output=self.output, csv_format=self.csv_format)
 
 
 class PrettyHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):

--- a/annofabcli/common/download.py
+++ b/annofabcli/common/download.py
@@ -113,9 +113,7 @@ class DownloadingFile:
             else:
                 raise e
 
-        self._wait_for_completion(
-            project_id, job_type=ProjectJobType.GEN_ANNOTATION, wait_options=wait_options, job_id=job_id
-        )
+        self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_ANNOTATION, wait_options=wait_options, job_id=job_id)
 
     async def download_input_data_json_with_async(
         self, project_id: str, dest_path: str, is_latest: bool = False, wait_options: Optional[WaitOptions] = None
@@ -125,9 +123,7 @@ class DownloadingFile:
         result = await loop.run_in_executor(None, partial_func)
         return result
 
-    def download_input_data_json(
-        self, project_id: str, dest_path: str, is_latest: bool = False, wait_options: Optional[WaitOptions] = None
-    ):
+    def download_input_data_json(self, project_id: str, dest_path: str, is_latest: bool = False, wait_options: Optional[WaitOptions] = None):
         if is_latest:
             self.wait_until_updated_input_data_json(project_id, wait_options)
             self.service.wrapper.download_project_inputs_url(project_id, dest_path)
@@ -157,9 +153,7 @@ class DownloadingFile:
             else:
                 raise e
 
-        self._wait_for_completion(
-            project_id, job_type=ProjectJobType.GEN_INPUTS_LIST, wait_options=wait_options, job_id=job_id
-        )
+        self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_INPUTS_LIST, wait_options=wait_options, job_id=job_id)
 
     async def download_task_json_with_async(
         self, project_id: str, dest_path: str, is_latest: bool = False, wait_options: Optional[WaitOptions] = None
@@ -169,9 +163,7 @@ class DownloadingFile:
         result = await loop.run_in_executor(None, partial_func)
         return result
 
-    def download_task_json(
-        self, project_id: str, dest_path: str, is_latest: bool = False, wait_options: Optional[WaitOptions] = None
-    ):
+    def download_task_json(self, project_id: str, dest_path: str, is_latest: bool = False, wait_options: Optional[WaitOptions] = None):
         if is_latest:
             self.wait_until_updated_task_json(project_id, wait_options)
             self.service.wrapper.download_project_tasks_url(project_id, dest_path)
@@ -201,9 +193,7 @@ class DownloadingFile:
             else:
                 raise e
 
-        self._wait_for_completion(
-            project_id, job_type=ProjectJobType.GEN_TASKS_LIST, wait_options=wait_options, job_id=job_id
-        )
+        self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_TASKS_LIST, wait_options=wait_options, job_id=job_id)
 
     async def download_task_history_json_with_async(self, project_id: str, dest_path: str):
         """

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -250,7 +250,7 @@ class AnnofabApiFacade:
     #: 組織メンバ一覧のキャッシュ
     _organization_members: Optional[Tuple[str, List[OrganizationMember]]] = None
 
-    _project_members_dict: Dict[str, List[ProjectMember]] = {}
+    _project_members_dict: Dict[str, List[ProjectMember]] = {}  # noqa: RUF012
     """プロジェクトメンバ一覧の情報。key:project_id, value:プロジェクトメンバ一覧"""
 
     def __init__(self, service: annofabapi.Resource) -> None:

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -196,14 +196,10 @@ def match_input_data_with_query(  # pylint: disable=too-many-return-statements
     if input_data_query is None:
         return True
 
-    if input_data_query.input_data_id is not None and not match_str(
-        input_data.input_data_id, input_data_query.input_data_id, ignore_case=True
-    ):
+    if input_data_query.input_data_id is not None and not match_str(input_data.input_data_id, input_data_query.input_data_id, ignore_case=True):
         return False
 
-    if input_data_query.input_data_name is not None and not match_str(
-        input_data.input_data_name, input_data_query.input_data_name, ignore_case=True
-    ):
+    if input_data_query.input_data_name is not None and not match_str(input_data.input_data_name, input_data_query.input_data_name, ignore_case=True):
         return False
 
     if input_data_query.input_data_path is not None and not match_str(
@@ -214,9 +210,7 @@ def match_input_data_with_query(  # pylint: disable=too-many-return-statements
     return True
 
 
-def convert_annotation_specs_labels_v2_to_v1(
-    labels_v2: List[Dict[str, Any]], additionals_v2: List[Dict[str, Any]]
-) -> List[Dict[str, Any]]:
+def convert_annotation_specs_labels_v2_to_v1(labels_v2: List[Dict[str, Any]], additionals_v2: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """アノテーション仕様のV2版からV1版に変換する。V1版の方が扱いやすいので。
 
     Args:
@@ -228,9 +222,7 @@ def convert_annotation_specs_labels_v2_to_v1(
     """
 
     def get_additional(additional_data_definition_id: str) -> Optional[Dict[str, Any]]:
-        return more_itertools.first_true(
-            additionals_v2, pred=lambda e: e["additional_data_definition_id"] == additional_data_definition_id
-        )
+        return more_itertools.first_true(additionals_v2, pred=lambda e: e["additional_data_definition_id"] == additional_data_definition_id)
 
     def to_label_v1(label_v2: dict[str, Any]) -> Dict[str, Any]:
         additional_data_definition_id_list = label_v2["additional_data_definitions"]
@@ -310,9 +302,7 @@ class AnnofabApiFacade:
         project, _ = self.service.api.get_project(project_id)
         return project["title"]
 
-    def _get_organization_member_with_predicate(
-        self, project_id: str, predicate: Callable[[Any], bool]
-    ) -> Optional[OrganizationMember]:
+    def _get_organization_member_with_predicate(self, project_id: str, predicate: Callable[[Any], bool]) -> Optional[OrganizationMember]:
         """
         account_idから組織メンバを取得する。
         インスタンス変数に組織メンバがあれば、WebAPIは実行しない。
@@ -344,9 +334,7 @@ class AnnofabApiFacade:
             update_organization_members()
             return self._get_organization_member_with_predicate(project_id, predicate)
 
-    def _get_project_member_with_predicate(
-        self, project_id: str, predicate: Callable[[Any], bool]
-    ) -> Optional[ProjectMember]:
+    def _get_project_member_with_predicate(self, project_id: str, predicate: Callable[[Any], bool]) -> Optional[ProjectMember]:
         """
         project_memberを取得する
 
@@ -359,9 +347,7 @@ class AnnofabApiFacade:
         """
         project_member_list = self._project_members_dict.get(project_id)
         if project_member_list is None:
-            project_member_list = self.service.wrapper.get_all_project_members(
-                project_id, query_params={"include_inactive_member": True}
-            )
+            project_member_list = self.service.wrapper.get_all_project_members(project_id, query_params={"include_inactive_member": True})
             self._project_members_dict[project_id] = project_member_list
         return more_itertools.first_true(project_member_list, pred=predicate)
 
@@ -473,9 +459,7 @@ class AnnofabApiFacade:
         my_role = ProjectMemberRole(my_member["member_role"])
         return my_role in roles
 
-    def contains_any_organization_member_role(
-        self, organization_name: str, roles: List[OrganizationMemberRole]
-    ) -> bool:
+    def contains_any_organization_member_role(self, organization_name: str, roles: List[OrganizationMemberRole]) -> bool:
         """
         自分自身の組織メンバとしてのロールが、指定されたロールのいずれかに合致するかどうか
         Args:

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -278,19 +278,19 @@ class AnnofabApiFacade:
     def get_label_name_en(label: Dict[str, Any]) -> str:
         """label情報から英語名を取得する"""
         label_name_messages = label["label_name"]["messages"]
-        return [e["message"] for e in label_name_messages if e["lang"] == "en-US"][0]
+        return [e["message"] for e in label_name_messages if e["lang"] == "en-US"][0]  # noqa: RUF015
 
     @staticmethod
     def get_additional_data_definition_name_en(additional_data_definition: Dict[str, Any]) -> str:
         """additional_data_definitionから英語名を取得する"""
         messages = additional_data_definition["name"]["messages"]
-        return [e["message"] for e in messages if e["lang"] == "en-US"][0]
+        return [e["message"] for e in messages if e["lang"] == "en-US"][0]  # noqa: RUF015
 
     @staticmethod
     def get_choice_name_en(choice: Dict[str, Any]) -> str:
         """choiceから英語名を取得する"""
         messages = choice["name"]["messages"]
-        return [e["message"] for e in messages if e["lang"] == "en-US"][0]
+        return [e["message"] for e in messages if e["lang"] == "en-US"][0]  # noqa: RUF015
 
     def get_project_title(self, project_id: str) -> str:
         """

--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -84,9 +84,7 @@ def fill_annotation(
         if outer_image is not None:
             draw.bitmap([0, 0], outer_image, fill=color)
         else:
-            logger.warning(
-                f"アノテーション種類が`{data_type}`ですが、`outer_image`がNoneです。 " f"annotation_id={annotation.annotation_id}"
-            )
+            logger.warning(f"アノテーション種類が`{data_type}`ですが、`outer_image`がNoneです。 " f"annotation_id={annotation.annotation_id}")
 
     return draw
 
@@ -126,9 +124,7 @@ def fill_annotation_list(
                 with parser.open_outer_file(data_uri_outer_image) as f:
                     outer_image = PIL.Image.open(f)
                     # アノテーション情報を描画する
-                    fill_annotation(
-                        draw=draw, annotation=annotation, label_color_dict=label_color_dict, outer_image=outer_image
-                    )
+                    fill_annotation(draw=draw, annotation=annotation, label_color_dict=label_color_dict, outer_image=outer_image)
 
             except AnnotationOuterFileNotFoundError as e:
                 logger.warning(str(e))
@@ -179,7 +175,7 @@ def write_annotation_image(
             write_annotation_image(parser=parser, image_size=(64,64), label_color_dict=label_color_dict,
                                output_image_file=Path("out.png"), background_color=(64,64,64))
 
-    """  # noqa: E501
+    """
 
     image = PIL.Image.new(mode="RGB", size=image_size, color=background_color)
     draw = PIL.ImageDraw.Draw(image)
@@ -223,17 +219,13 @@ def write_annotation_grayscale_image(
     # 下層レイヤにあるアノテーションから順に画像化する
     # reversed関数を使う理由：`simple_annotation.details`は上層レイヤのアノテーションから順に格納されているため
     if label_name_list is not None:
-        annotation_list = [
-            elm for elm in reversed(simple_annotation["details"]) if elm["label"] in set(label_name_list)
-        ]
+        annotation_list = [elm for elm in reversed(simple_annotation["details"]) if elm["label"] in set(label_name_list)]
     else:
         annotation_list = list(reversed(simple_annotation["details"]))
 
     # 描画対象のアノテーションを絞り込む
     annotation_list = [
-        e
-        for e in annotation_list
-        if e["data"] is not None and e["data"]["_type"] in ["BoundingBox", "Points", "SegmentationV2", "Segmentation"]
+        e for e in annotation_list if e["data"] is not None and e["data"]["_type"] in ["BoundingBox", "Points", "SegmentationV2", "Segmentation"]
     ]
 
     if len(annotation_list) > 255:
@@ -310,9 +302,7 @@ def write_annotation_images_from_path(
         def _get_image_size_from_system_metadata(arg_input_data: Dict[str, Any]):
             # 入力データの`input_data.system_metadata.original_resolution`を参照して、画像サイズを決める。
             original_resolution = arg_input_data["system_metadata"]["original_resolution"]
-            if original_resolution is not None and (
-                original_resolution.get("width") is not None and original_resolution.get("height") is not None
-            ):
+            if original_resolution is not None and (original_resolution.get("width") is not None and original_resolution.get("height") is not None):
                 return original_resolution.get("width"), original_resolution.get("height")
             else:
                 logger.warning(
@@ -366,8 +356,8 @@ def write_annotation_images_from_path(
             output_image_file=output_image_file,
             label_name_list=label_name_list,
         )
-        logger.debug(f"画像ファイル '{str(output_image_file)}' を生成しました。")
+        logger.debug(f"画像ファイル '{output_image_file!s}' を生成しました。")
         count_created_image += 1
 
-    logger.info(f"{str(output_dir_path)} に、{count_created_image} 件の画像ファイルを生成しました。")
+    logger.info(f"{output_dir_path!s} に、{count_created_image} 件の画像ファイルを生成しました。")
     return True

--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -44,7 +44,7 @@ def fill_annotation(
     draw: PIL.ImageDraw.Draw,
     annotation: SimpleAnnotationDetail,
     label_color_dict: Dict[str, RGB],
-    outer_image: Optional[Any] = None,
+    outer_image: Optional[Any] = None,  # noqa: ANN401
 ) -> PIL.ImageDraw.Draw:
     """
     1個のアノテーションを、塗りつぶしで描画する。（矩形、ポリゴン、塗りつぶし、塗りつぶしv2）
@@ -141,7 +141,7 @@ def write_annotation_image(
     image_size: InputDataSize,
     label_color_dict: Dict[str, RGB],
     output_image_file: Path,
-    background_color: Optional[Any] = None,
+    background_color: Optional[Any] = None,  # noqa: ANN401
     label_name_list: Optional[List[str]] = None,
 ):
     """
@@ -271,7 +271,7 @@ def write_annotation_images_from_path(
     image_size: Optional[InputDataSize] = None,
     input_data_dict: Optional[Dict[str, InputData]] = None,
     output_image_extension: str = "png",
-    background_color: Optional[Any] = None,
+    background_color: Optional[Any] = None,  # noqa: ANN401
     label_name_list: Optional[List[str]] = None,
     is_target_parser_func: Optional[IsParserFunc] = None,
 ) -> bool:

--- a/annofabcli/common/utils.py
+++ b/annofabcli/common/utils.py
@@ -84,9 +84,7 @@ def print_json(target: Any, is_pretty: bool = False, output: Optional[Union[str,
         output_string(json.dumps(target, ensure_ascii=False), output)
 
 
-def print_csv(
-    df: pandas.DataFrame, output: Optional[Union[str, Path]] = None, to_csv_kwargs: Optional[Dict[str, Any]] = None
-):
+def print_csv(df: pandas.DataFrame, output: Optional[Union[str, Path]] = None, to_csv_kwargs: Optional[Dict[str, Any]] = None):
     if output is not None:
         Path(output).parent.mkdir(parents=True, exist_ok=True)
 
@@ -247,7 +245,7 @@ def read_multiheader_csv(csv_file: str, header_row_count: int = 2, **kwargs) -> 
     """
     kwargs["header"] = list(range(header_row_count))
     df = pandas.read_csv(csv_file, **kwargs)
-    for level in range(0, header_row_count):
+    for level in range(header_row_count):
         columns = df.columns.levels[level]
         rename_columns = {c: "" for c in columns if re.fullmatch(r"Unnamed: .*", c) is not None}
         df.rename(
@@ -304,11 +302,7 @@ def add_dryrun_prefix(lgr: logging.Logger) -> None:
     # オリジナルのフォーマットを探す
     fmt_original = logging.BASIC_FORMAT
     for handler in parent.handlers:
-        if (
-            isinstance(handler, logging.StreamHandler)
-            and handler.formatter is not None
-            and handler.formatter._fmt is not None
-        ):
+        if isinstance(handler, logging.StreamHandler) and handler.formatter is not None and handler.formatter._fmt is not None:
             fmt_original = handler.formatter._fmt
 
     log_formatter = logging.Formatter(fmt_original.replace("%(message)s", "[DRYRUN] %(message)s"))

--- a/annofabcli/common/visualize.py
+++ b/annofabcli/common/visualize.py
@@ -117,9 +117,7 @@ class AddProps:
 
     def get_project_member_from_account_id(self, account_id: str) -> Optional[ProjectMember]:
         if self._project_member_list is None:
-            project_member_list = self.service.wrapper.get_all_project_members(
-                self.project_id, query_params={"include_inactive_member": True}
-            )
+            project_member_list = self.service.wrapper.get_all_project_members(self.project_id, query_params={"include_inactive_member": True})
             self._project_member_list = project_member_list
         else:
             project_member_list = self._project_member_list
@@ -134,9 +132,7 @@ class AddProps:
         return organization["organization_name"]
 
     def get_phrase_name(self, phrase_id: str, locale: MessageLocale) -> Optional[str]:
-        phrase: Optional[Dict[str, Any]] = more_itertools.first_true(
-            self.specs_inspection_phrases, pred=lambda e: e["id"] == phrase_id
-        )
+        phrase: Optional[Dict[str, Any]] = more_itertools.first_true(self.specs_inspection_phrases, pred=lambda e: e["id"] == phrase_id)
         if phrase is None:
             return None
 
@@ -149,9 +145,7 @@ class AddProps:
 
         return self.get_message(label["label_name"], locale)
 
-    def get_additional_data_name(
-        self, additional_data_definition_id: str, locale: MessageLocale, label_id: Optional[str] = None
-    ) -> Optional[str]:
+    def get_additional_data_name(self, additional_data_definition_id: str, locale: MessageLocale, label_id: Optional[str] = None) -> Optional[str]:
         def _get_additional_data_name(arg_additional_data_definitions: List[Dict[str, Any]]) -> Optional[str]:
             additional_data = more_itertools.first_true(
                 arg_additional_data_definitions,
@@ -175,9 +169,7 @@ class AddProps:
 
             return None
 
-    def add_properties_to_annotation_specs_history(
-        self, annotation_specs_history: AnnotationSpecsHistory
-    ) -> AnnotationSpecsHistory:
+    def add_properties_to_annotation_specs_history(self, annotation_specs_history: AnnotationSpecsHistory) -> AnnotationSpecsHistory:
         """
         アノテーション仕様の履歴に、以下のキーを追加する.
         user_id
@@ -205,9 +197,7 @@ class AddProps:
         """
         return self._add_user_info(instruction_history)
 
-    def add_properties_to_inspection(
-        self, inspection: Inspection, detail: Optional[Dict[str, Any]] = None
-    ) -> Inspection:
+    def add_properties_to_inspection(self, inspection: Inspection, detail: Optional[Dict[str, Any]] = None) -> Inspection:
         """
         検査コメントに、以下のキーを追加する.
         commenter_user_id

--- a/annofabcli/common/visualize.py
+++ b/annofabcli/common/visualize.py
@@ -346,7 +346,7 @@ class AddProps:
         task["number_of_rejections_by_inspection"] = get_number_of_rejections(histories, TaskPhase.INSPECTION)
         task["number_of_rejections_by_acceptance"] = get_number_of_rejections(histories, TaskPhase.ACCEPTANCE)
 
-        # number_of_rejectionsは非推奨なプロパティで、number_of_rejections_by_inspection/number_of_rejections_by_acceptanceと矛盾する場合があるので、削除する
+        # number_of_rejectionsは非推奨なプロパティで、number_of_rejections_by_inspection/number_of_rejections_by_acceptanceと矛盾する場合があるので、削除する  # noqa: E501
         task.pop("number_of_rejections", None)
 
         task["input_data_count"] = len(task["input_data_id_list"])

--- a/annofabcli/experimental/list_out_of_range_annotation_for_movie.py
+++ b/annofabcli/experimental/list_out_of_range_annotation_for_movie.py
@@ -66,16 +66,14 @@ class ListOutOfRangeAnnotationForMovieMain:
             for task_index, task in enumerate(task_list):
                 task["worktime_hour"] = _millisecond_to_hour(task["work_time_span"])
                 task["input_data_id"] = task["input_data_id_list"][0]
-                annotation, _ = self.service.api.get_editor_annotation(
-                    project_id, task["task_id"], task["input_data_id"]
-                )
+                annotation, _ = self.service.api.get_editor_annotation(project_id, task["task_id"], task["input_data_id"])
                 max_seconds = self.get_max_seconds_for_webapi(annotation)
                 task["max_begin_second"] = max_seconds[0]
                 task["max_end_second"] = max_seconds[1]
                 if (task_index + 1) % 100 == 0:
                     logger.info(f"{task_index+1} 件のアノテーション情報を取得しました。")
         else:
-            logger.info(f"{len(task_list)} 件のアノテーション情報を {str(annotation_zip)} から取得します。")
+            logger.info(f"{len(task_list)} 件のアノテーション情報を {annotation_zip!s} から取得します。")
             with zipfile.ZipFile(str(annotation_zip), "r") as zip_file:
                 for task_index, task in enumerate(task_list):
                     task["worktime_hour"] = _millisecond_to_hour(task["work_time_span"])
@@ -160,9 +158,7 @@ class ListOutOfRangeAnnotationForMovieMain:
             if task_id_list is not None:
                 task_list = self.filter_task_list(task_list, task_id_list)
 
-        df = self.create_dataframe(
-            project_id, task_list=task_list, input_data_list=input_data_list, annotation_zip=annotation_zip_path
-        )
+        df = self.create_dataframe(project_id, task_list=task_list, input_data_list=input_data_list, annotation_zip=annotation_zip_path)
         return df
 
 
@@ -189,7 +185,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_output()
 
     parser.add_argument(
-        "--parse_annotation_zip", action="store_true", help="アノテーションzipから範囲外のアノテーション情報を取得します。ただし、範囲外の終了時間は存在しません。"
+        "--parse_annotation_zip",
+        action="store_true",
+        help="アノテーションzipから範囲外のアノテーション情報を取得します。ただし、範囲外の終了時間は存在しません。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/experimental/subcommand_experimental.py
+++ b/annofabcli/experimental/subcommand_experimental.py
@@ -18,8 +18,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "アルファ版のサブコマンド"
     description = "アルファ版のサブコマンド。予告なしに削除されたり、コマンドライン引数が変わったりします。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/filesystem/draw_annotation.py
+++ b/annofabcli/filesystem/draw_annotation.py
@@ -37,7 +37,7 @@ class DrawingOptions(DataClassJsonMixin):
 
 
 class DrawingAnnotationForOneImage:
-    _COLOR_PALETTE = [
+    _COLOR_PALETTE = [  # noqa: RUF012
         "red",
         "maroon",
         "yellow",

--- a/annofabcli/filesystem/draw_annotation.py
+++ b/annofabcli/filesystem/draw_annotation.py
@@ -128,9 +128,7 @@ class DrawingAnnotationForOneImage:
         # 下層レイヤにあるアノテーションから順に画像化する
         # reversed関数を使う理由：`simple_annotation.details`は上層レイヤのアノテーションから順に格納されているため
         if self.target_label_names is not None:
-            annotation_list = [
-                e for e in reversed(simple_annotation["details"]) if e["label"] in self.target_label_names
-            ]
+            annotation_list = [e for e in reversed(simple_annotation["details"]) if e["label"] in self.target_label_names]
         else:
             annotation_list = list(reversed(simple_annotation["details"]))
         for annotation in annotation_list:
@@ -268,8 +266,7 @@ def draw_annotation_all(
         try:
             drawing.main(parser, image_file=image_file, output_file=output_file, image_size=default_image_size)
             logger.debug(
-                f"{success_count+1}件目: {str(output_file)} を出力しました。image_file={image_file}, "
-                f"アノテーションJSON={parser.json_file_path}"
+                f"{success_count+1}件目: {output_file!s} を出力しました。image_file={image_file}, " f"アノテーションJSON={parser.json_file_path}"
             )
             success_count += 1
         except Exception:  # pylint: disable=broad-except
@@ -278,8 +275,7 @@ def draw_annotation_all(
     logger.info(f"{success_count} / {total_count} 件、アノテーションを描画しました。")
 
     new_label_color_dict = {
-        label_name: ImageColor.getrgb(color) if isinstance(color, str) else color
-        for label_name, color in drawing.label_color_dict.items()
+        label_name: ImageColor.getrgb(color) if isinstance(color, str) else color for label_name, color in drawing.label_color_dict.items()
     }
     logger.info(f"label_color={json.dumps(new_label_color_dict, ensure_ascii=False)}")
 
@@ -339,11 +335,7 @@ class DrawAnnotation(AbstractCommandLineWithoutWebapiInterface):
             )
             input_data_id_relation_dict = dict(zip(df["input_data_id"], df["image_path"]))
 
-        task_query = (
-            TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query))
-            if args.task_query is not None
-            else None
-        )
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
         draw_annotation_all(
             iter_parser=iter_parser,
@@ -355,9 +347,7 @@ class DrawAnnotation(AbstractCommandLineWithoutWebapiInterface):
             label_color_dict=self._create_label_color(args.label_color) if args.label_color is not None else None,
             target_label_names=get_list_from_args(args.label_name) if args.label_name is not None else None,
             polyline_labels=get_list_from_args(args.polyline_label) if args.polyline_label is not None else None,
-            drawing_options=DrawingOptions.from_dict(get_json_from_args(args.drawing_options))
-            if args.drawing_options is not None
-            else None,
+            drawing_options=DrawingOptions.from_dict(get_json_from_args(args.drawing_options)) if args.drawing_options is not None else None,
             default_image_size=default_image_size,
         )
 
@@ -370,10 +360,15 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser = ArgumentParser(parser)
 
     parser.add_argument(
-        "--annotation", type=Path, required=True, help="Annofabからダウンロードしたアノテーションzip、またはzipを展開したディレクトリを指定してください。"
+        "--annotation",
+        type=Path,
+        required=True,
+        help="Annofabからダウンロードしたアノテーションzip、またはzipを展開したディレクトリを指定してください。",
     )
 
-    parser.add_argument("--image_dir", type=Path, help="画像が存在するディレクトリを指定してください。\n" "'--input_data_id_csv'を指定したときは必須です。")
+    parser.add_argument(
+        "--image_dir", type=Path, help="画像が存在するディレクトリを指定してください。\n" "'--input_data_id_csv'を指定したときは必須です。"
+    )
 
     parser.add_argument(
         "--input_data_id_csv",
@@ -398,7 +393,11 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "-o", "--output_dir", type=Path, required=True, help="出力先ディレクトリのパスを指定してください。ディレクトリの構造はアノテーションzipと同じです。"
+        "-o",
+        "--output_dir",
+        type=Path,
+        required=True,
+        help="出力先ディレクトリのパスを指定してください。ディレクトリの構造はアノテーションzipと同じです。",
     )
 
     parser.add_argument(

--- a/annofabcli/filesystem/filter_annotation.py
+++ b/annofabcli/filesystem/filter_annotation.py
@@ -33,9 +33,7 @@ class FilterQuery:
 def match_query(  # pylint: disable=too-many-return-statements
     annotation: Dict[str, Any], filter_query: FilterQuery
 ) -> bool:
-    if filter_query.task_query is not None and not match_annotation_with_task_query(
-        annotation, filter_query.task_query
-    ):
+    if filter_query.task_query is not None and not match_annotation_with_task_query(annotation, filter_query.task_query):
         return False
 
     # xxx_set は1個のみ指定されていること前提なので、elif を羅列する
@@ -43,24 +41,13 @@ def match_query(  # pylint: disable=too-many-return-statements
         return False
     elif filter_query.exclude_task_id_set is not None and annotation["task_id"] in filter_query.exclude_task_id_set:
         return False
-    elif (
-        filter_query.input_data_id_set is not None and annotation["input_data_id"] not in filter_query.input_data_id_set
-    ):
+    elif filter_query.input_data_id_set is not None and annotation["input_data_id"] not in filter_query.input_data_id_set:
         return False
-    elif (
-        filter_query.exclude_input_data_id_set is not None
-        and annotation["input_data_id"] in filter_query.exclude_input_data_id_set
-    ):
+    elif filter_query.exclude_input_data_id_set is not None and annotation["input_data_id"] in filter_query.exclude_input_data_id_set:
         return False
-    elif (
-        filter_query.input_data_name_set is not None
-        and annotation["input_data_name"] not in filter_query.input_data_name_set
-    ):
+    elif filter_query.input_data_name_set is not None and annotation["input_data_name"] not in filter_query.input_data_name_set:
         return False
-    elif (
-        filter_query.exclude_input_data_name_set is not None
-        and annotation["input_data_name"] in filter_query.exclude_input_data_name_set
-    ):
+    elif filter_query.exclude_input_data_name_set is not None and annotation["input_data_name"] in filter_query.exclude_input_data_name_set:
         return False
 
     return True
@@ -134,37 +121,17 @@ class FilterAnnotation:
 
     @staticmethod
     def create_filter_query(args: argparse.Namespace) -> FilterQuery:
-        task_query = (
-            TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query))
-            if args.task_query is not None
-            else None
-        )
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
         task_id_set = set(annofabcli.common.cli.get_list_from_args(args.task_id)) if args.task_id is not None else None
-        exclude_task_id_set = (
-            set(annofabcli.common.cli.get_list_from_args(args.exclude_task_id))
-            if args.exclude_task_id is not None
-            else None
-        )
-        input_data_id_set = (
-            set(annofabcli.common.cli.get_list_from_args(args.input_data_id))
-            if args.input_data_id is not None
-            else None
-        )
+        exclude_task_id_set = set(annofabcli.common.cli.get_list_from_args(args.exclude_task_id)) if args.exclude_task_id is not None else None
+        input_data_id_set = set(annofabcli.common.cli.get_list_from_args(args.input_data_id)) if args.input_data_id is not None else None
         exclude_input_data_id_set = (
-            set(annofabcli.common.cli.get_list_from_args(args.exclude_input_data_id))
-            if args.exclude_input_data_id is not None
-            else None
+            set(annofabcli.common.cli.get_list_from_args(args.exclude_input_data_id)) if args.exclude_input_data_id is not None else None
         )
-        input_data_name_set = (
-            set(annofabcli.common.cli.get_list_from_args(args.input_data_name))
-            if args.input_data_name is not None
-            else None
-        )
+        input_data_name_set = set(annofabcli.common.cli.get_list_from_args(args.input_data_name)) if args.input_data_name is not None else None
         exclude_input_data_name_set = (
-            set(annofabcli.common.cli.get_list_from_args(args.exclude_input_data_name))
-            if args.exclude_input_data_name is not None
-            else None
+            set(annofabcli.common.cli.get_list_from_args(args.exclude_input_data_name)) if args.exclude_input_data_name is not None else None
         )
 
         return FilterQuery(
@@ -231,26 +198,30 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--input_data_id",
         type=str,
         nargs="+",
-        help="抽出する入力データのinput_data_idを指定してください。" + " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。",
+        help="抽出する入力データのinput_data_idを指定してください。"
+        + " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。",
     )
     id_name_list_group.add_argument(
         "--exclude_input_data_id",
         type=str,
         nargs="+",
-        help="除外する入力データのinput_data_idを指定してください。" + " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。",
+        help="除外する入力データのinput_data_idを指定してください。"
+        + " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。",
     )
 
     id_name_list_group.add_argument(
         "--input_data_name",
         type=str,
         nargs="+",
-        help="抽出する入力データのinput_data_nameを指定してください。" + " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。",
+        help="抽出する入力データのinput_data_nameを指定してください。"
+        + " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。",
     )
     id_name_list_group.add_argument(
         "--exclude_input_data_name",
         type=str,
         nargs="+",
-        help="除外する入力データのinput_data_nameを指定してください。" + " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。",
+        help="除外する入力データのinput_data_nameを指定してください。"
+        + " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument("-o", "--output_dir", type=Path, required=True, help="出力先ディレクトリのパス")

--- a/annofabcli/filesystem/mask_user_info.py
+++ b/annofabcli/filesystem/mask_user_info.py
@@ -98,9 +98,7 @@ def create_masked_name(name: str) -> str:
     return _num2alpha(hash_value)
 
 
-def get_replaced_user_id_set_from_biography(
-    df: pandas.DataFrame, not_masked_location_set: Optional[Set[str]] = None
-) -> Set[str]:
+def get_replaced_user_id_set_from_biography(df: pandas.DataFrame, not_masked_location_set: Optional[Set[str]] = None) -> Set[str]:
     if not_masked_location_set is None:
         filtered_df = df
     else:
@@ -220,9 +218,7 @@ def create_replacement_dict_by_user_id(
     keyが置換対象のuser_id、valueが置換後のマスクされたuser_idであるdictを作成する。
     """
     if "biography" in df:
-        replaced_user_id_set = get_replaced_user_id_set_from_biography(
-            df, not_masked_location_set=not_masked_biography_set
-        )
+        replaced_user_id_set = get_replaced_user_id_set_from_biography(df, not_masked_location_set=not_masked_biography_set)
     else:
         replaced_user_id_set = set()
     if not_masked_user_id_set is not None:
@@ -264,9 +260,7 @@ def replace_user_info_by_user_id(df: pandas.DataFrame, replacement_dict_by_user_
     replace_by_columns(df, replacement_dict_by_user_id, main_column=user_id_column, sub_columns=sub_columns)
 
 
-def replace_biography(
-    df: pandas.DataFrame, replacement_dict_by_user_id: Dict[str, str], replacement_dict_by_biography: Dict[str, str]
-):
+def replace_biography(df: pandas.DataFrame, replacement_dict_by_user_id: Dict[str, str], replacement_dict_by_biography: Dict[str, str]):
     """
     biography 列を, マスクする。
 
@@ -278,9 +272,7 @@ def replace_biography(
     user_id_column = _get_tuple_column(df, "user_id")
     biography_column = _get_tuple_column(df, "biography")
 
-    def _get_biography(
-        row: pandas.Series, user_id_column: Union[str, Tuple], biography_column: Union[str, Tuple]
-    ) -> str:
+    def _get_biography(row: pandas.Series, user_id_column: Union[str, Tuple], biography_column: Union[str, Tuple]) -> str:
         if row[user_id_column] in replacement_dict_by_user_id:
             # マスク対象のユーザなら biographyをマスクする
             biography = row[biography_column]
@@ -311,9 +303,7 @@ def create_masked_user_info_df(
     )
 
     if "biography" in df_output:
-        replacement_dict_by_biography = create_replacement_dict_by_biography(
-            df_output, not_masked_biography_set=not_masked_biography_set
-        )
+        replacement_dict_by_biography = create_replacement_dict_by_biography(df_output, not_masked_biography_set=not_masked_biography_set)
         replace_biography(
             df_output,
             replacement_dict_by_biography=replacement_dict_by_biography,
@@ -329,12 +319,8 @@ class MaskUserInfo(AbstractCommandLineWithoutWebapiInterface):
     def main(self) -> None:
         args = self.args
 
-        not_masked_biography_set = (
-            set(get_list_from_args(args.not_masked_biography)) if args.not_masked_biography is not None else None
-        )
-        not_masked_user_id_set = (
-            set(get_list_from_args(args.not_masked_user_id)) if args.not_masked_user_id is not None else None
-        )
+        not_masked_biography_set = set(get_list_from_args(args.not_masked_biography)) if args.not_masked_biography is not None else None
+        not_masked_user_id_set = set(get_list_from_args(args.not_masked_user_id)) if args.not_masked_user_id is not None else None
 
         csv_header_row_count: int = args.csv_header_row_count
         csv_path: Path = args.csv

--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -54,9 +54,7 @@ class MergeAnnotationMain:
     def _is_segmentation(anno: Dict[str, Any]) -> bool:
         return anno["data"]["_type"] in ["Segmentation", "SegmentationV2"]
 
-    def write_merged_annotation(
-        self, parser1: SimpleAnnotationParser, parser2: SimpleAnnotationParser, output_json: Path
-    ):
+    def write_merged_annotation(self, parser1: SimpleAnnotationParser, parser2: SimpleAnnotationParser, output_json: Path):
         simple_annotation1 = parser1.load_json()
         simple_annotation2 = parser2.load_json()
         details1 = simple_annotation1["details"]
@@ -80,9 +78,7 @@ class MergeAnnotationMain:
             merged_details.append(new_anno)
             # 塗りつぶしアノテーションファイルをコピーする
             if self._is_segmentation(new_anno):
-                self._write_outer_file(
-                    parser=(parser2 if adopt_two else parser1), anno=new_anno, output_json=output_json
-                )
+                self._write_outer_file(parser=(parser2 if adopt_two else parser1), anno=new_anno, output_json=output_json)
 
         merged_details.extend(list(details2_dict.values()))
 
@@ -113,9 +109,7 @@ class MergeAnnotationMain:
             json.dump(simple_annotation, f, ensure_ascii=False)
 
     @staticmethod
-    def _get_parser(
-        annotation_path: Path, zip_file: Optional[zipfile.ZipFile], json_path: Path
-    ) -> Optional[SimpleAnnotationParser]:
+    def _get_parser(annotation_path: Path, zip_file: Optional[zipfile.ZipFile], json_path: Path) -> Optional[SimpleAnnotationParser]:
         if annotation_path.is_dir():
             if (annotation_path / json_path).exists():
                 return SimpleAnnotationDirParser(annotation_path / json_path)
@@ -221,9 +215,7 @@ class MergeAnnotation(AbstractCommandLineWithoutWebapiInterface):
 
         main_obj = MergeAnnotationMain()
         target_task_ids = get_list_from_args(args.task_id) if args.task_id is not None else None
-        main_obj.main(
-            args.annotation[0], args.annotation[1], output_dir=args.output_dir, target_task_ids=target_task_ids
-        )
+        main_obj.main(args.annotation[0], args.annotation[1], output_dir=args.output_dir, target_task_ids=target_task_ids)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -246,7 +238,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_id(
         required=False,
         help_message=(
-            "マージ対象であるタスクのtask_idを指定します。" "指定しない場合、すべてのタスクがマージ対象です。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"
+            "マージ対象であるタスクのtask_idを指定します。"
+            "指定しない場合、すべてのタスクがマージ対象です。"
+            " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"
         ),
     )
 

--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -252,7 +252,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
 
     subcommand_help = "2つのアノテーションzip（またはzipを展開したディレクトリ）をマージします。"
 
-    description = "2つのアノテーションzip（またはzipを展開したディレクトリ）をマージします。具体的にはアノテーションjsonの'details'キー配下の情報をマージします。"
+    description = "2つのアノテーションzip（またはzipを展開したディレクトリ）をマージします。具体的にはアノテーションjsonの'details'キー配下の情報をマージします。"  # noqa: E501
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
     parse_args(parser)

--- a/annofabcli/filesystem/subcommand_filesystem.py
+++ b/annofabcli/filesystem/subcommand_filesystem.py
@@ -24,8 +24,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "ファイル操作関係（Web APIにアクセスしない）のサブコマンド"
     description = "ファイル操作関係（Web APIにアクセスしない）のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/input_data/change_input_data_name.py
+++ b/annofabcli/input_data/change_input_data_name.py
@@ -55,8 +55,7 @@ class ChangeInputDataNameMain(AbstractCommandLineWithConfirmInterface):
             return False
 
         if not self.confirm_processing(
-            f"input_data_id='{input_data_id}' :: "
-            f"input_data_name='{old_input_data['input_data_name']}'を'{new_input_data_name}'に変更しますか？"
+            f"input_data_id='{input_data_id}' :: " f"input_data_name='{old_input_data['input_data_name']}'を'{new_input_data_name}'に変更しますか？"
         ):
             return False
 
@@ -90,9 +89,7 @@ class ChangeInputDataNameMain(AbstractCommandLineWithConfirmInterface):
                 if result:
                     success_count += 1
             except Exception:
-                logger.warning(
-                    f"input_data_id='{changed_input_data.input_data_id}'の入力データの名前を変更するのに失敗しました。", exc_info=True
-                )
+                logger.warning(f"input_data_id='{changed_input_data.input_data_id}'の入力データの名前を変更するのに失敗しました。", exc_info=True)
                 continue
 
         logger.info(f"{success_count} / {len(changed_input_data_list)} 件の入力データの名前を変更しました。")
@@ -190,9 +187,7 @@ class ChangeInputDataName(AbstractCommandLineInterface):
                 project_id, changed_input_data_list=changed_input_data_list, parallelism=args.parallelism
             )
         else:
-            main_obj.change_input_data_name_list_sequentially(
-                project_id, changed_input_data_list=changed_input_data_list
-            )
+            main_obj.change_input_data_name_list_sequentially(project_id, changed_input_data_list=changed_input_data_list)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -232,7 +227,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/input_data/change_input_data_name.py
+++ b/annofabcli/input_data/change_input_data_name.py
@@ -229,7 +229,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/input_data/delete_input_data.py
+++ b/annofabcli/input_data/delete_input_data.py
@@ -36,9 +36,7 @@ class DeleteInputData(AbstractCommandLineInterface):
         for supplementary_data in supplementary_data_list:
             supplementary_data_id = supplementary_data["supplementary_data_id"]
             try:
-                self.service.api.delete_supplementary_data(
-                    project_id, input_data_id=input_data_id, supplementary_data_id=supplementary_data_id
-                )
+                self.service.api.delete_supplementary_data(project_id, input_data_id=input_data_id, supplementary_data_id=supplementary_data_id)
                 logger.debug(
                     f"補助情報を削除しました。input_data_id={input_data_id}, supplementary_data_id={supplementary_data_id}, "
                     f"supplementary_data_name={supplementary_data['supplementary_data_name']}"
@@ -55,16 +53,12 @@ class DeleteInputData(AbstractCommandLineInterface):
         return deleted_count
 
     def confirm_delete_input_data(self, input_data_id: str, input_data_name: str, used_task_id_list: List[str]) -> bool:
-        message_for_confirm = (
-            f"入力データ(input_data_id='{input_data_id}', " f"input_data_name='{input_data_name}') を削除しますか？"
-        )
+        message_for_confirm = f"入力データ(input_data_id='{input_data_id}', " f"input_data_name='{input_data_name}') を削除しますか？"
         if len(used_task_id_list) > 0:
             message_for_confirm += f"タスク{used_task_id_list}に使われています。"
         return self.confirm_processing(message_for_confirm)
 
-    def confirm_delete_supplementary(
-        self, input_data_id: str, input_data_name: str, supplementary_data_list: List[Dict[str, Any]]
-    ) -> bool:
+    def confirm_delete_supplementary(self, input_data_id: str, input_data_name: str, supplementary_data_list: List[Dict[str, Any]]) -> bool:
         message_for_confirm = (
             f"入力データに紐づく補助情報 {len(supplementary_data_list)} 件を削除しますか？ "
             f"(input_data_id='{input_data_id}', "
@@ -72,9 +66,7 @@ class DeleteInputData(AbstractCommandLineInterface):
         )
         return self.confirm_processing(message_for_confirm)
 
-    def delete_input_data(
-        self, project_id: str, input_data_id: str, input_data_index: int, delete_supplementary: bool, force: bool
-    ):
+    def delete_input_data(self, project_id: str, input_data_id: str, input_data_index: int, delete_supplementary: bool, force: bool):
         input_data = self.service.wrapper.get_input_data_or_none(project_id, input_data_id)
         if input_data is None:
             logger.info(f"input_data_id={input_data_id} は存在しません。")
@@ -105,8 +97,7 @@ class DeleteInputData(AbstractCommandLineInterface):
 
         self.service.api.delete_input_data(project_id, input_data_id)
         logger.debug(
-            f"{str(input_data_index+1)} 件目: 入力データ(input_data_id='{input_data_id}', "
-            f"input_data_name='{input_data_name}') を削除しました。"
+            f"{input_data_index+1!s} 件目: 入力データ(input_data_id='{input_data_id}', " f"input_data_name='{input_data_name}') を削除しました。"
         )
 
         if delete_supplementary:
@@ -118,15 +109,13 @@ class DeleteInputData(AbstractCommandLineInterface):
                     project_id, input_data_id, supplementary_data_list=supplementary_data_list
                 )
                 logger.debug(
-                    f"{str(input_data_index + 1)} 件目: 入力データ(input_data_id='{input_data_id}', "
+                    f"{input_data_index + 1!s} 件目: 入力データ(input_data_id='{input_data_id}', "
                     f"input_data_name='{input_data_name}') に紐づく補助情報を"
                     f" {deleted_supplementary_data} / {len(supplementary_data_list)} 件削除しました。"
                 )
         return True
 
-    def delete_input_data_list(
-        self, project_id: str, input_data_id_list: List[str], delete_supplementary: bool, force: bool
-    ):
+    def delete_input_data_list(self, project_id: str, input_data_id_list: List[str], delete_supplementary: bool, force: bool):
         """
         タスクに使われていない入力データを削除する。
         """
@@ -182,7 +171,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         required=True,
         nargs="+",
-        help="削除対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
+        help="削除対象の入力データのinput_data_idを指定します。"
+        " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument("--force", action="store_true", help="タスクに使われている入力データも削除します。")

--- a/annofabcli/input_data/download_input_data_json.py
+++ b/annofabcli/input_data/download_input_data_json.py
@@ -63,8 +63,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "入力データ全件ファイルをダウンロードします。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/input_data/list_all_input_data.py
+++ b/annofabcli/input_data/list_all_input_data.py
@@ -69,9 +69,7 @@ class ListInputDataWithJsonMain:
         logger.debug("入力データを絞り込み中")
         input_data_id_set = set(input_data_id_list) if input_data_id_list is not None else None
         filtered_input_data_list = [
-            e
-            for e in input_data_list
-            if self.filter_input_data_list(e, input_data_query=input_data_query, input_data_id_set=input_data_id_set)
+            e for e in input_data_list if self.filter_input_data_list(e, input_data_query=input_data_query, input_data_id_set=input_data_id_set)
         ]
         return filtered_input_data_list
 
@@ -80,19 +78,13 @@ class ListInputDataWithJson(AbstractCommandLineInterface):
     def main(self) -> None:
         args = self.args
 
-        input_data_id_list = (
-            annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
-        )
+        input_data_id_list = annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
         input_data_query = (
-            InputDataQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.input_data_query))
-            if args.input_data_query is not None
-            else None
+            InputDataQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.input_data_query)) if args.input_data_query is not None else None
         )
 
         project_id = args.project_id
-        super().validate_project(
-            project_id, project_member_roles=[ProjectMemberRole.TRAINING_DATA_USER, ProjectMemberRole.OWNER]
-        )
+        super().validate_project(project_id, project_member_roles=[ProjectMemberRole.TRAINING_DATA_USER, ProjectMemberRole.OWNER])
 
         main_obj = ListInputDataWithJsonMain(self.service)
         input_data_list = main_obj.get_input_data_list(

--- a/annofabcli/input_data/list_all_input_data.py
+++ b/annofabcli/input_data/list_all_input_data.py
@@ -169,7 +169,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "list_all"
     subcommand_help = "すべての入力データの一覧を出力します。"
-    description = "すべての入力データの一覧を出力します。\n出力される入力データは、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力したい場合は、 ``--latest`` を指定してください。"
+    description = "すべての入力データの一覧を出力します。\n出力される入力データは、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力したい場合は、 ``--latest`` を指定してください。"  # noqa: E501
     epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/input_data/list_input_data.py
+++ b/annofabcli/input_data/list_input_data.py
@@ -36,7 +36,7 @@ class ListInputData(AbstractCommandLineInterface):
         task_id_list = []
         for task in task_list:
             if input_data_id in task["input_data_id_list"]:
-                task_id_list.append(task["task_id"])
+                task_id_list.append(task["task_id"])  # noqa: PERF401
         return task_id_list
 
     def get_input_data_from_input_data_id(self, project_id: str, input_data_id_list: List[str]) -> List[InputData]:

--- a/annofabcli/input_data/list_input_data.py
+++ b/annofabcli/input_data/list_input_data.py
@@ -95,9 +95,7 @@ class ListInputData(AbstractCommandLineInterface):
                 continue
 
             logger.debug(f"input_data_list[{initial_index}:{initial_index+chunk_size}] を使用しているタスクを取得する。")
-            task_list = self.service.wrapper.get_all_tasks(
-                project_id, query_params={"input_data_ids": str_input_data_id_list}
-            )
+            task_list = self.service.wrapper.get_all_tasks(project_id, query_params={"input_data_ids": str_input_data_id_list})
 
             for input_data in sub_input_data_list:
                 # input_data_idで絞り込んでいるが、大文字小文字を区別しない。
@@ -170,9 +168,7 @@ class ListInputData(AbstractCommandLineInterface):
 
     def main(self) -> None:
         args = self.args
-        input_data_id_list = (
-            annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
-        )
+        input_data_id_list = annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
 
         input_data_query = annofabcli.common.cli.get_json_from_args(args.input_data_query)
         self.print_input_data(
@@ -224,7 +220,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=36,
         help=(
-            "入力データIDの平均長さを指定します。 ``add_details`` がTrueのときのみ有効です。" "デフォルトはUUIDv4の長さです。" "この値を元にして、タスク一括取得APIの実行回数を決めます。"
+            "入力データIDの平均長さを指定します。 ``add_details`` がTrueのときのみ有効です。"
+            "デフォルトはUUIDv4の長さです。"
+            "この値を元にして、タスク一括取得APIの実行回数を決めます。"
         ),
     )
 

--- a/annofabcli/input_data/list_input_data_merged_task.py
+++ b/annofabcli/input_data/list_input_data_merged_task.py
@@ -66,10 +66,7 @@ class ListInputDataMergedTaskMain:
 
         if input_data_name_list is not None:
             df = pandas.concat(
-                [
-                    df[df["input_data_name"].str.lower().str.contains(input_data_name.lower())]
-                    for input_data_name in input_data_name_list
-                ]
+                [df[df["input_data_name"].str.lower().str.contains(input_data_name.lower())] for input_data_name in input_data_name_list]
             )
         return df
 
@@ -125,9 +122,7 @@ class ListInputDataMergedTask(AbstractCommandLineInterface):
             )
             return False
 
-        if (args.input_data_json is None and args.task_json is not None) or (
-            args.input_data_json is not None and args.task_json is None
-        ):
+        if (args.input_data_json is None and args.task_json is not None) or (args.input_data_json is not None and args.task_json is None):
             print(
                 f"{COMMON_MESSAGE} '--task_json'と'--input_data_json'の両方を指定する必要があります。",
                 file=sys.stderr,
@@ -179,14 +174,10 @@ class ListInputDataMergedTask(AbstractCommandLineInterface):
 
         input_data_id_set = set(get_list_from_args(args.input_data_id)) if args.input_data_id is not None else None
         input_data_query = (
-            InputDataQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.input_data_query))
-            if args.input_data_query is not None
-            else None
+            InputDataQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.input_data_query)) if args.input_data_query is not None else None
         )
         filtered_input_data_list = [
-            e
-            for e in input_data_list
-            if match_input_data(e, input_data_query=input_data_query, input_data_id_set=input_data_id_set)
+            e for e in input_data_list if match_input_data(e, input_data_query=input_data_query, input_data_id_set=input_data_id_set)
         ]
 
         main_obj = ListInputDataMergedTaskMain(self.service)
@@ -216,7 +207,10 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser = ArgumentParser(parser)
 
     parser.add_argument(
-        "-p", "--project_id", type=str, help="対象のプロジェクトのproject_idを指定してください。" "指定すると、入力データ一覧ファイル、タスク一覧ファイルをダウンロードします。"
+        "-p",
+        "--project_id",
+        type=str,
+        help="対象のプロジェクトのproject_idを指定してください。" "指定すると、入力データ一覧ファイル、タスク一覧ファイルをダウンロードします。",
     )
 
     parser.add_argument("-i", "--input_data_id", type=str, nargs="+", help="指定したinput_data_idに完全一致する入力データを絞り込みます。")
@@ -264,7 +258,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--latest",
         action="store_true",
-        help="入力データ一覧ファイル、タスク一覧ファイルの更新が完了するまで待って、最新のファイルをダウンロードします。" " ``--project_id`` を指定したときのみ有効です。",
+        help="入力データ一覧ファイル、タスク一覧ファイルの更新が完了するまで待って、最新のファイルをダウンロードします。"
+        " ``--project_id`` を指定したときのみ有効です。",
     )
 
     parser.add_argument(

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -120,16 +120,12 @@ class SubPutInputData:
         self.facade = facade
         self.all_yes = all_yes
 
-    def put_input_data(
-        self, project_id: str, csv_input_data: InputDataForPut, last_updated_datetime: Optional[str] = None
-    ):
+    def put_input_data(self, project_id: str, csv_input_data: InputDataForPut, last_updated_datetime: Optional[str] = None):
         request_body: Dict[str, Any] = {"last_updated_datetime": last_updated_datetime}
 
         file_path = get_file_scheme_path(csv_input_data.input_data_path)
         if file_path is not None:
-            request_body.update(
-                {"input_data_name": csv_input_data.input_data_name, "sign_required": csv_input_data.sign_required}
-            )
+            request_body.update({"input_data_name": csv_input_data.input_data_name, "sign_required": csv_input_data.sign_required})
             logger.debug(f"'{file_path}'を入力データとして登録します。input_data_name={csv_input_data.input_data_name}")
             self.service.wrapper.put_input_data_from_file(
                 project_id, input_data_id=csv_input_data.input_data_id, file_path=file_path, request_body=request_body
@@ -174,9 +170,13 @@ class SubPutInputData:
             f"input_data_name='{input_data.input_data_name}', input_data_id='{input_data.input_data_id}' の入力データを登録しますか？"
         )
         if already_exists:
-            message_for_confirm = f"input_data_name='{input_data.input_data_name}', input_data_id='{input_data.input_data_id}' の入力データを上書きして登録しますか？"  # noqa: E501
+            message_for_confirm = (
+                f"input_data_name='{input_data.input_data_name}', input_data_id='{input_data.input_data_id}' の入力データを上書きして登録しますか？"
+            )
         else:
-            message_for_confirm = f"input_data_name='{input_data.input_data_name}', input_data_id='{input_data.input_data_id}' の入力データを登録しますか？"  # noqa: E501
+            message_for_confirm = (
+                f"input_data_name='{input_data.input_data_name}', input_data_id='{input_data.input_data_id}' の入力データを登録しますか？"
+            )
 
         return self.confirm_processing(message_for_confirm)
 
@@ -184,9 +184,7 @@ class SubPutInputData:
         input_data = InputDataForPut(
             input_data_name=csv_input_data.input_data_name,
             input_data_path=csv_input_data.input_data_path,
-            input_data_id=csv_input_data.input_data_id
-            if csv_input_data.input_data_id is not None
-            else str(uuid.uuid4()),
+            input_data_id=csv_input_data.input_data_id if csv_input_data.input_data_id is not None else str(uuid.uuid4()),
             sign_required=csv_input_data.sign_required,
         )
 
@@ -214,17 +212,13 @@ class SubPutInputData:
         try:
             self.put_input_data(project_id, input_data, last_updated_datetime=last_updated_datetime)
             logger.debug(
-                f"入力データを登録しました。 :: "
-                f"input_data_id='{input_data.input_data_id}', "
-                f"input_data_name='{input_data.input_data_name}'"
+                f"入力データを登録しました。 :: " f"input_data_id='{input_data.input_data_id}', " f"input_data_name='{input_data.input_data_name}'"
             )
             return True
 
         except requests.exceptions.HTTPError:
             logger.warning(
-                f"入力データの登録に失敗しました。"
-                f"input_data_id='{input_data.input_data_id}', "
-                f"input_data_name='{input_data.input_data_name}'",
+                f"入力データの登録に失敗しました。" f"input_data_id='{input_data.input_data_id}', " f"input_data_name='{input_data.input_data_name}'",
                 exc_info=True,
             )
             return False
@@ -300,24 +294,18 @@ class PutInputData(AbstractCommandLineInterface):
         return input_data_list
 
     @staticmethod
-    def get_input_data_list_from_dict(
-        input_data_dict_list: List[Dict[str, Any]], allow_duplicated_input_data: bool
-    ) -> List[CsvInputData]:
+    def get_input_data_list_from_dict(input_data_dict_list: List[Dict[str, Any]], allow_duplicated_input_data: bool) -> List[CsvInputData]:
         # 重複チェック
         df = pandas.DataFrame(input_data_dict_list)
         df_duplicated_input_data_name = df[df["input_data_name"].duplicated()]
         if len(df_duplicated_input_data_name) > 0:
-            logger.warning(
-                f"`input_data_name`が重複しています。\n" f"{df_duplicated_input_data_name['input_data_name'].unique()}"
-            )
+            logger.warning(f"`input_data_name`が重複しています。\n" f"{df_duplicated_input_data_name['input_data_name'].unique()}")
             if not allow_duplicated_input_data:
                 raise RuntimeError("`input_data_name`が重複しています。")
 
         df_duplicated_input_data_path = df[df["input_data_path"].duplicated()]
         if len(df_duplicated_input_data_path) > 0:
-            logger.warning(
-                f"`input_data_path`が重複しています。\n" f"{df_duplicated_input_data_path['input_data_path'].unique()}"
-            )
+            logger.warning(f"`input_data_path`が重複しています。\n" f"{df_duplicated_input_data_path['input_data_path'].unique()}")
             if not allow_duplicated_input_data:
                 raise RuntimeError("`input_data_path`が重複しています。")
 
@@ -359,18 +347,12 @@ class PutInputData(AbstractCommandLineInterface):
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
             input_data_list = self.get_input_data_list_from_df(df)
-            self.put_input_data_list(
-                project_id, input_data_list=input_data_list, overwrite=args.overwrite, parallelism=args.parallelism
-            )
+            self.put_input_data_list(project_id, input_data_list=input_data_list, overwrite=args.overwrite, parallelism=args.parallelism)
 
         elif args.json is not None:
             input_data_dict_list = get_json_from_args(args.json)
-            input_data_list = self.get_input_data_list_from_dict(
-                input_data_dict_list, allow_duplicated_input_data=args.allow_duplicated_input_data
-            )
-            self.put_input_data_list(
-                project_id, input_data_list=input_data_list, overwrite=args.overwrite, parallelism=args.parallelism
-            )
+            input_data_list = self.get_input_data_list_from_dict(input_data_dict_list, allow_duplicated_input_data=args.allow_duplicated_input_data)
+            self.put_input_data_list(project_id, input_data_list=input_data_list, overwrite=args.overwrite, parallelism=args.parallelism)
 
         else:
             print("引数が不正です。", file=sys.stderr)
@@ -419,7 +401,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="指定した場合、input_data_idがすでに存在していたら上書きします。指定しなければ、スキップします。" " ``--csv`` , ``--json`` を指定したときのみ有効なオプションです。",
+        help="指定した場合、input_data_idがすでに存在していたら上書きします。指定しなければ、スキップします。"
+        " ``--csv`` , ``--json`` を指定したときのみ有効なオプションです。",
     )
 
     parser.add_argument(
@@ -434,7 +417,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="並列度。指定しない場合は、逐次的に処理します。" "``--csv`` , ``--json`` を指定したときのみ有効なオプションです。また、必ず ``--yes`` を指定してください。",
+        help="並列度。指定しない場合は、逐次的に処理します。"
+        "``--csv`` , ``--json`` を指定したときのみ有効なオプションです。また、必ず ``--yes`` を指定してください。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/input_data/put_input_data_with_zip.py
+++ b/annofabcli/input_data/put_input_data_with_zip.py
@@ -50,7 +50,7 @@ class PutInputData(AbstractCommandLineInterface):
         """
 
         project_title = self.facade.get_project_title(project_id)
-        logger.info(f"{project_title} に、{str(zip_file)} を登録します。")
+        logger.info(f"{project_title} に、{zip_file!s} を登録します。")
 
         request_body = {}
         if input_data_name_prefix is not None:

--- a/annofabcli/input_data/subcommand_input_data.py
+++ b/annofabcli/input_data/subcommand_input_data.py
@@ -34,8 +34,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "入力データ関係のサブコマンド"
     description = "入力データ関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -162,13 +162,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="指定した場合、メタデータを上書きして更新します（すでに設定されているメタデータは削除されます）。指定しない場合、 ``--metadata`` に指定されたキーのみ更新されます。",
+        help="指定した場合、メタデータを上書きして更新します（すでに設定されているメタデータは削除されます）。指定しない場合、 ``--metadata`` に指定されたキーのみ更新されます。",  # noqa: E501
     )
 
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -42,10 +42,7 @@ class UpdateMetadataMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{logging_prefix} 入力データは存在しないのでスキップします。input_data_id={input_data_id}")
             return False
 
-        logger.debug(
-            f"{logging_prefix} input_data_id={input_data['input_data_id']}, "
-            f"input_data_name={input_data['input_data_name']}"
-        )
+        logger.debug(f"{logging_prefix} input_data_id={input_data['input_data_id']}, " f"input_data_name={input_data['input_data_name']}")
         if not self.confirm_processing(f"入力データのメタデータを更新しますか？ input_data_id={input_data['input_data_id']}"):
             return False
 
@@ -59,9 +56,7 @@ class UpdateMetadataMain(AbstractCommandLineWithConfirmInterface):
         logger.debug(f"{logging_prefix} 入力データを更新しました。input_data_id={input_data['input_data_id']}")
         return True
 
-    def set_metadata_to_input_data_wrapper(
-        self, tpl: Tuple[int, str], project_id: str, metadata: Dict[str, Any], overwrite_metadata: bool = False
-    ):
+    def set_metadata_to_input_data_wrapper(self, tpl: Tuple[int, str], project_id: str, metadata: Dict[str, Any], overwrite_metadata: bool = False):
         input_data_index, input_data_id = tpl
         return self.set_metadata_to_input_data(
             project_id,
@@ -160,7 +155,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--metadata",
         required=True,
         type=str,
-        help="入力データに設定する ``metadata`` をJSON形式で指定してください。メタデータの値は文字列です。" " ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
+        help="入力データに設定する ``metadata`` をJSON形式で指定してください。メタデータの値は文字列です。"
+        " ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
     )
 
     parser.add_argument(
@@ -170,7 +166,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)
@@ -181,8 +179,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "入力データのメタデータを更新します。"
     description = "入力データのメタデータを更新します。"
     epilog = "オーナロールを持つユーザで実行してください。"
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/instruction/copy_instruction.py
+++ b/annofabcli/instruction/copy_instruction.py
@@ -27,9 +27,7 @@ class CopyInstruction(AbstractCommandLineInterface):
              AuthorizationError: 自分自身のRoleがいずれかのRoleにも合致しなければ、AuthorizationErrorが発生する。
         """
         super().validate_project(src_project_id, project_member_roles=None)
-        super().validate_project(
-            dest_project_id, project_member_roles=[ProjectMemberRole.ACCEPTER, ProjectMemberRole.OWNER]
-        )
+        super().validate_project(dest_project_id, project_member_roles=[ProjectMemberRole.ACCEPTER, ProjectMemberRole.OWNER])
 
     @staticmethod
     def get_instruction_image_id_from_url(url: str) -> str:

--- a/annofabcli/instruction/download_instruction.py
+++ b/annofabcli/instruction/download_instruction.py
@@ -81,9 +81,7 @@ class DownloadInstructionMain:
 
         return pq.outer_html()
 
-    def download_instruction(
-        self, project_id: str, output_dir: Path, history_id: Optional[str] = None, is_download_image: bool = False
-    ):
+    def download_instruction(self, project_id: str, output_dir: Path, history_id: Optional[str] = None, is_download_image: bool = False):
         """
         作業ガイドをダウンロードする
 
@@ -107,9 +105,7 @@ class DownloadInstructionMain:
 
         output_dir.mkdir(exist_ok=True, parents=True)
         if is_download_image:
-            str_instruction_html = self.download_images(
-                project_id, str_instruction_html=str_instruction_html, output_dir=output_dir
-            )
+            str_instruction_html = self.download_images(project_id, str_instruction_html=str_instruction_html, output_dir=output_dir)
 
         output_html = output_dir / "index.html"
         output_html.write_text(str_instruction_html, encoding="utf-8")
@@ -146,9 +142,7 @@ class DownloadInstruction(AbstractCommandLineInterface):
             history_id = args.history_id
 
         main_obj = DownloadInstructionMain(self.service)
-        main_obj.download_instruction(
-            project_id, output_dir=args.output_dir, history_id=history_id, is_download_image=args.download_image
-        )
+        main_obj.download_instruction(project_id, output_dir=args.output_dir, history_id=history_id, is_download_image=args.download_image)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -186,7 +180,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--download_image", action="store_true", help="作業ガイド画像もダウンロードします。指定した場合、img要素のsrc属性はローカルのファイルを参照するようになります。"
+        "--download_image",
+        action="store_true",
+        help="作業ガイド画像もダウンロードします。指定した場合、img要素のsrc属性はローカルのファイルを参照するようになります。",
     )
 
     parser.add_argument("-o", "--output_dir", type=Path, required=True, help="出力先ディレクトリのパスを指定してください。")

--- a/annofabcli/instruction/list_instruction_history.py
+++ b/annofabcli/instruction/list_instruction_history.py
@@ -40,9 +40,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     argument_parser.add_output()
 
-    argument_parser.add_format(
-        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV
-    )
+    argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)
     argument_parser.add_csv_format()
     argument_parser.add_query()
 

--- a/annofabcli/instruction/subcommand_instruction.py
+++ b/annofabcli/instruction/subcommand_instruction.py
@@ -24,8 +24,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "作業ガイド関係のサブコマンド"
     description = "作業ガイド関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/instruction/upload_instruction.py
+++ b/annofabcli/instruction/upload_instruction.py
@@ -39,7 +39,7 @@ def save_image_from_data_uri_scheme(value: str, temp_dir: Path) -> Path:
     with Image.open(io.BytesIO(uri.data)) as img:
         image_file_path = temp_dir / image_file_name
         img.save(str(image_file_path), extension.upper())
-        logger.debug(f"Data URI Schemeの画像を {str(image_file_path)} に保存しました。")
+        logger.debug(f"Data URI Schemeの画像を {image_file_path!s} に保存しました。")
         return image_file_path
 
 
@@ -132,7 +132,10 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_project_id()
 
     parser.add_argument(
-        "--html", type=str, required=True, help="作業ガイドとして登録するHTMLファイルのパスを指定します。body要素があればbody要素の中身をアップロードします。"
+        "--html",
+        type=str,
+        required=True,
+        help="作業ガイドとして登録するHTMLファイルのパスを指定します。body要素があればbody要素の中身をアップロードします。",
     )
 
     parser.set_defaults(subcommand_func=main)
@@ -142,7 +145,9 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_name = "upload"
     subcommand_help = "HTMLファイルを作業ガイドとして登録します。"
     description = (
-        "HTMLファイルを作業ガイドとして登録します。" + "img要素のsrc属性がローカルの画像を参照している場合（http, https, dataスキーマが付与されていない）、" "画像もアップロードします。"
+        "HTMLファイルを作業ガイドとして登録します。"
+        + "img要素のsrc属性がローカルの画像を参照している場合（http, https, dataスキーマが付与されていない）、"
+        "画像もアップロードします。"
     )
     epilog = "チェッカーまたはオーナロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/job/list_generated_task_history.py
+++ b/annofabcli/job/list_generated_task_history.py
@@ -61,9 +61,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     argument_parser.add_project_id()
 
-    argument_parser.add_format(
-        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV
-    )
+    argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)
     argument_parser.add_output()
     argument_parser.add_csv_format()
 

--- a/annofabcli/job/list_job.py
+++ b/annofabcli/job/list_job.py
@@ -18,9 +18,7 @@ class ListJob(AbstractCommandLineInterface):
     ジョブ一覧を表示する。
     """
 
-    def get_job_list(
-        self, project_id: str, job_type: ProjectJobType, job_query: Optional[Dict[str, Any]] = None
-    ) -> List[ProjectJobInfo]:
+    def get_job_list(self, project_id: str, job_type: ProjectJobType, job_query: Optional[Dict[str, Any]] = None) -> List[ProjectJobInfo]:
         """
         ジョブ一覧を取得する。
         """
@@ -36,9 +34,7 @@ class ListJob(AbstractCommandLineInterface):
         job_list = self.service.wrapper.get_all_project_job(project_id, query_params=query_params)
         return job_list
 
-    def print_job_list(
-        self, project_id: str, job_type: ProjectJobType, job_query: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def print_job_list(self, project_id: str, job_type: ProjectJobType, job_query: Optional[Dict[str, Any]] = None) -> None:
         """
         ジョブ一覧を出力する
 
@@ -75,9 +71,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("--job_type", type=str, choices=job_choices, required=True, help="ジョブタイプを指定します。")
 
-    argument_parser.add_format(
-        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV
-    )
+    argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)
     argument_parser.add_output()
     argument_parser.add_csv_format()
 

--- a/annofabcli/job/list_last_job.py
+++ b/annofabcli/job/list_last_job.py
@@ -61,9 +61,7 @@ class ListLastJob(AbstractCommandLineInterface):
 
         return project_info
 
-    def get_last_job_list(
-        self, project_id_list: List[str], job_type: ProjectJobType, add_details: bool = False
-    ) -> List[ProjectJobInfo]:
+    def get_last_job_list(self, project_id_list: List[str], job_type: ProjectJobType, add_details: bool = False) -> List[ProjectJobInfo]:
         job_list = []
         for project_id in project_id_list:
             project = self.service.wrapper.get_project_or_none(project_id)
@@ -105,9 +103,7 @@ class ListLastJob(AbstractCommandLineInterface):
 
         """
         query_params = {"status": "active", "account_id": self.service.api.account_id}
-        project_list = self.service.wrapper.get_all_projects_of_organization(
-            organization_name, query_params=query_params
-        )
+        project_list = self.service.wrapper.get_all_projects_of_organization(organization_name, query_params=query_params)
         return [e["project_id"] for e in project_list]
 
     def main(self) -> None:
@@ -152,7 +148,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-org",
         "--organization",
         type=str,
-        help="組織配下のすべてのプロジェクトのジョブを出力したい場合は、組織名を指定してください。" "自分が所属している進行中のプロジェクトが対象になります。",
+        help="組織配下のすべてのプロジェクトのジョブを出力したい場合は、組織名を指定してください。"
+        "自分が所属している進行中のプロジェクトが対象になります。",
     )
 
     parser.add_argument(
@@ -161,9 +158,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         help="プロジェクトに関する詳細情報を表示します" "（ ``task_last_updated_datetime, annotation_specs_last_updated_datetime`` ）",
     )
 
-    argument_parser.add_format(
-        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV
-    )
+    argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)
     argument_parser.add_output()
     argument_parser.add_csv_format()
 

--- a/annofabcli/job/subcommand_job.py
+++ b/annofabcli/job/subcommand_job.py
@@ -27,8 +27,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "ジョブ関係のサブコマンド"
     description = "ジョブ関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/job/wait_job.py
+++ b/annofabcli/job/wait_job.py
@@ -25,9 +25,7 @@ class WaitJobMain:
         self.service = service
         self.facade = AnnofabApiFacade(service)
 
-    def wait_job(
-        self, project_id: str, job_type: ProjectJobType, wait_options: WaitOptions, job_id: Optional[str] = None
-    ):
+    def wait_job(self, project_id: str, job_type: ProjectJobType, wait_options: WaitOptions, job_id: Optional[str] = None):
         MAX_WAIT_MINUTE = wait_options.max_tries * wait_options.interval / 60
         logger.info(f"job_type='{job_type.value}', job_id='{job_id}' :: ジョブが完了するまで、最大{MAX_WAIT_MINUTE}分間待ちます。")
         result = self.service.wrapper.wait_until_job_finished(

--- a/annofabcli/organization_member/change_organization_member.py
+++ b/annofabcli/organization_member/change_organization_member.py
@@ -116,8 +116,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     description = "組織メンバの情報（ロールなど）を変更します。"
     epilog = "組織オーナまたは組織管理者ロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, command_help=subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, command_help=subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/organization_member/delete_organization_member.py
+++ b/annofabcli/organization_member/delete_organization_member.py
@@ -52,9 +52,7 @@ class DeleteOrganizationMemberMain(AbstractCommandLineWithConfirmInterface):
             ):
                 continue
 
-            logger.debug(
-                f"user_id='{user_id}'のユーザを組織から脱退させます。 :: username='{member['username']}', role='{member['role']}'"
-            )
+            logger.debug(f"user_id='{user_id}'のユーザを組織から脱退させます。 :: username='{member['username']}', role='{member['role']}'")
             try:
                 self.service.api.delete_organization_member(organization_name, user_id)
                 logger.debug(f"user_id='{user_id}'のユーザを組織'{organization_name}'から脱退させました。")
@@ -103,8 +101,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     description = "組織からユーザを脱退させます。"
     epilog = "組織オーナまたは組織管理者ロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, command_help=subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, command_help=subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/organization_member/invite_organization_member.py
+++ b/annofabcli/organization_member/invite_organization_member.py
@@ -101,8 +101,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     description = "組織にユーザを招待します。"
     epilog = "組織オーナまたは組織管理者ロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, command_help=subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, command_help=subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/organization_member/list_organization_member.py
+++ b/annofabcli/organization_member/list_organization_member.py
@@ -19,7 +19,7 @@ class ListOrganizationMember(AbstractCommandLineInterface):
     組織メンバ一覧を表示する。
     """
 
-    PRIOR_COLUMNS = [
+    PRIOR_COLUMNS = [  # noqa: RUF012
         "organization_id",
         "organization_name",
         "account_id",

--- a/annofabcli/organization_member/subcommand_organization_member.py
+++ b/annofabcli/organization_member/subcommand_organization_member.py
@@ -24,8 +24,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "組織メンバ関係のサブコマンド"
     description = "組織メンバ関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/project/change_project_status.py
+++ b/annofabcli/project/change_project_status.py
@@ -187,7 +187,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--force",
         action="store_true",
-        help=f"`--status {ProjectStatus.SUSPENDED.value}`を指定している状態で、 ``--force`` を指定した場合、作業中タスクが残っていても停止状態に変更します。",
+        help=f"`--status {ProjectStatus.SUSPENDED.value}`を指定している状態で、 ``--force`` を指定した場合、作業中タスクが残っていても停止状態に変更します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/project/change_project_status.py
+++ b/annofabcli/project/change_project_status.py
@@ -122,9 +122,7 @@ class ChanegProjectStatusMain:
         self.service.api.put_project(project_id, request_body=project)
         return True
 
-    def change_status_for_project_list(
-        self, project_id_list: List[str], status: ProjectStatus, force_suspend: bool = False
-    ):
+    def change_status_for_project_list(self, project_id_list: List[str], status: ProjectStatus, force_suspend: bool = False):
         """
         複数のプロジェクトに対して、プロジェクトのステータスを変更する。
 
@@ -159,9 +157,7 @@ class ChangeProjectStatus(AbstractCommandLineInterface):
         args = self.args
         project_id_list = annofabcli.common.cli.get_list_from_args(args.project_id)
         main_obj = ChanegProjectStatusMain(self.service)
-        main_obj.change_status_for_project_list(
-            project_id_list=project_id_list, status=ProjectStatus(args.status), force_suspend=args.force
-        )
+        main_obj.change_status_for_project_list(project_id_list=project_id_list, status=ProjectStatus(args.status), force_suspend=args.force)
 
 
 def main(args: argparse.Namespace) -> None:

--- a/annofabcli/project/copy_project.py
+++ b/annofabcli/project/copy_project.py
@@ -93,9 +93,7 @@ class CopyProject(AbstractCommandLineInterface):
                 key = COPIED_TARGET_AND_KEY_MAP[target]
                 request_body[key] = True
 
-        request_body.update(
-            {"dest_project_id": dest_project_id, "dest_title": dest_title, "dest_overview": dest_overview}
-        )
+        request_body.update({"dest_project_id": dest_project_id, "dest_title": dest_title, "dest_overview": dest_overview})
 
         self.service.api.initiate_project_copy(src_project_id, request_body=request_body)
         logger.info("プロジェクトのコピーを実施しています。")
@@ -161,13 +159,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     argument_parser.add_project_id(help_message="コピー元のプロジェクトのproject_idを指定してください。")
 
-    parser.add_argument("--dest_project_id", type=str, help="新しいプロジェクトのproject_idを指定してください。省略した場合は UUIDv4 フォーマットになります。")
+    parser.add_argument(
+        "--dest_project_id", type=str, help="新しいプロジェクトのproject_idを指定してください。省略した場合は UUIDv4 フォーマットになります。"
+    )
     parser.add_argument("--dest_title", type=str, required=True, help="新しいプロジェクトのタイトルを指定してください。")
     parser.add_argument("--dest_overview", type=str, help="新しいプロジェクトの概要を指定してください。")
 
-    parser.add_argument(
-        "--copied_target", type=str, nargs="+", choices=[e.value for e in CopiedTarget], help="コピー対象を指定してください。"
-    )
+    parser.add_argument("--copied_target", type=str, nargs="+", choices=[e.value for e in CopiedTarget], help="コピー対象を指定してください。")
 
     parser.add_argument("--wait", action="store_true", help="プロジェクトのコピーが完了するまで待ちます。")
 

--- a/annofabcli/project/diff_projects.py
+++ b/annofabcli/project/diff_projects.py
@@ -154,9 +154,7 @@ class DiffProjects(AbstractCommandLineInterface):
 
         return flag, diff_message
 
-    def diff_labels_of_annotation_specs(
-        self, labels1: List[Dict[str, Any]], labels2: List[Dict[str, Any]]
-    ) -> DiffResult:
+    def diff_labels_of_annotation_specs(self, labels1: List[Dict[str, Any]], labels2: List[Dict[str, Any]]) -> DiffResult:
         """
         アノテーションラベル情報の差分を表示する。ラベル名(英語)を基準に差分を表示する。
         以下の項目は無視して比較する。
@@ -185,9 +183,7 @@ class DiffProjects(AbstractCommandLineInterface):
             diff_message += "ラベル名(en)が重複しているので、アノテーションラベル情報の差分は確認しません。\n"
 
         if label_names1 != label_names2:
-            diff_message += (
-                f"### ラベル名(en)のListに差分あり\n" f"label_names1: {label_names1}\n" f"label_names2: {label_names2}\n"
-            )
+            diff_message += f"### ラベル名(en)のListに差分あり\n" f"label_names1: {label_names1}\n" f"label_names2: {label_names2}\n"
 
             # 両方に存在するlabel_nameのみ確認する
             is_different = True
@@ -220,9 +216,7 @@ class DiffProjects(AbstractCommandLineInterface):
         return is_different, diff_message
 
     @staticmethod
-    def diff_inspection_phrases(
-        inspection_phrases1: List[Dict[str, Any]], inspection_phrases2: List[Dict[str, Any]]
-    ) -> DiffResult:
+    def diff_inspection_phrases(inspection_phrases1: List[Dict[str, Any]], inspection_phrases2: List[Dict[str, Any]]) -> DiffResult:
         """
         定型指摘の差分を表示する。定型指摘IDを基準に差分を表示する。
 
@@ -286,9 +280,7 @@ class DiffProjects(AbstractCommandLineInterface):
         annotation_specs2, _ = self.service.api.get_annotation_specs(project_id2, query_params={"v": "2"})
 
         if DiffTarget.INSPECTION_PHRASES in diff_targets:
-            bool_result, message = self.diff_inspection_phrases(
-                annotation_specs1["inspection_phrases"], annotation_specs2["inspection_phrases"]
-            )
+            bool_result, message = self.diff_inspection_phrases(annotation_specs1["inspection_phrases"], annotation_specs2["inspection_phrases"])
             is_different = is_different or bool_result
             diff_message += message
 
@@ -374,10 +366,7 @@ class DiffProjects(AbstractCommandLineInterface):
             diff_message += message
 
         if is_different:
-            diff_message = (
-                f"!!! {self.project_title1}({project_id1}) と "
-                f"{self.project_title2}({project_id2}) に差分あり\n" + diff_message
-            )
+            diff_message = f"!!! {self.project_title1}({project_id1}) と " f"{self.project_title2}({project_id2}) に差分あり\n" + diff_message
         return is_different, diff_message
 
     def main(self) -> None:

--- a/annofabcli/project/list_project.py
+++ b/annofabcli/project/list_project.py
@@ -116,9 +116,7 @@ class ListProjectMain:
 
         return project_query
 
-    def get_project_list_from_organization(
-        self, organization_name: str, project_query: Optional[Dict[str, Any]] = None
-    ) -> List[Project]:
+    def get_project_list_from_organization(self, organization_name: str, project_query: Optional[Dict[str, Any]] = None) -> List[Project]:
         """
         組織名からプロジェクト一覧を取得する。
         """
@@ -127,9 +125,7 @@ class ListProjectMain:
             project_query = self._modify_project_query(organization_name, project_query)
 
         logger.debug(f"project_query: {project_query}")
-        project_list = self.service.wrapper.get_all_projects_of_organization(
-            organization_name, query_params=project_query
-        )
+        project_list = self.service.wrapper.get_all_projects_of_organization(organization_name, query_params=project_query)
 
         for project in project_list:
             project["organization_name"] = organization_name

--- a/annofabcli/project/list_project.py
+++ b/annofabcli/project/list_project.py
@@ -138,7 +138,7 @@ class ListProject(AbstractCommandLineInterface):
     プロジェクト一覧を表示する。
     """
 
-    PRIOR_COLUMNS = [
+    PRIOR_COLUMNS = [  # noqa: RUF012
         "organization_id",
         "organization_name",
         "project_id",

--- a/annofabcli/project/put_project.py
+++ b/annofabcli/project/put_project.py
@@ -74,9 +74,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         f" * {InputDataType.CUSTOM.value} : カスタム（点群など）",
     )
 
-    parser.add_argument(
-        "-p", "--project_id", type=str, required=False, help="作成するプロジェクトのproject_id。未指定の場合はUUIDv4になります。"
-    )
+    parser.add_argument("-p", "--project_id", type=str, required=False, help="作成するプロジェクトのproject_id。未指定の場合はUUIDv4になります。")
     parser.add_argument("--overview", type=str, help="作成するプロジェクトの概要")
     parser.add_argument(
         "--plugin_id", type=str, help="アノテーションエディタプラグインのplugin_id。``--input_data_type custom`` を指定した場合は必須です。"

--- a/annofabcli/project/update_annotation_zip.py
+++ b/annofabcli/project/update_annotation_zip.py
@@ -57,9 +57,7 @@ class SubUpdateAnnotationZip:
         annotation_specs_updated_datetime = annotation_specs_history[-1]["updated_datetime"]
         logger.debug(f"project_id={project_id}: アノテーション仕様の最終更新日時={annotation_specs_updated_datetime}")
 
-        job_list = self.service.api.get_project_job(
-            project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1}
-        )[0]["list"]
+        job_list = self.service.api.get_project_job(project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1})[0]["list"]
 
         if len(job_list) == 0:
             return True
@@ -74,9 +72,7 @@ class SubUpdateAnnotationZip:
             if dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(last_tasks_updated_datetime):
                 return True
 
-            elif dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(
-                annotation_specs_updated_datetime
-            ):
+            elif dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(annotation_specs_updated_datetime):
                 return True
             else:
                 logger.debug(
@@ -104,13 +100,13 @@ class SubUpdateAnnotationZip:
         if result:
             logger.info(f"project_id={project_id}: アノテーションzipの更新が完了しました。")
         else:
-            logger.info(f"project_id={project_id}: アノテーションzipの更新に失敗、または{MAX_WAIT_MINUTU}分待ってもアノテーションzipの更新が終了しませんでした。")
+            logger.info(
+                f"project_id={project_id}: アノテーションzipの更新に失敗、または{MAX_WAIT_MINUTU}分待ってもアノテーションzipの更新が終了しませんでした。"
+            )
         return result
 
     def _update_annotation_zip_for_project(self, project_id: str) -> None:
-        job_list = self.service.api.get_project_job(
-            project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1}
-        )[0]["list"]
+        job_list = self.service.api.get_project_job(project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1})[0]["list"]
         if len(job_list) > 0:
             job = job_list[0]
             if job["job_status"] == JobStatus.PROGRESS.value:
@@ -120,9 +116,7 @@ class SubUpdateAnnotationZip:
         self.service.api.post_annotation_archive_update(project_id)
         logger.info(f"project_id={project_id}: アノテーションzipの更新処理が開始されました。")
 
-    def execute_for_project(
-        self, project_id: str, force: bool = False, wait: bool = False, wait_options: Optional[WaitOptions] = None
-    ) -> None:
+    def execute_for_project(self, project_id: str, force: bool = False, wait: bool = False, wait_options: Optional[WaitOptions] = None) -> None:
         """
         1つのプロジェクトに対して、アノテーションzipを更新して、必要なら更新が完了するまで待ちます。
         """
@@ -132,9 +126,7 @@ class SubUpdateAnnotationZip:
             return
 
         logger.debug(f"project_id={project_id}: project_title='{project['title']}'")
-        if not self.facade.contains_any_project_member_role(
-            project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
-        ):
+        if not self.facade.contains_any_project_member_role(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]):
             logger.warning(f"project_id={project_id}: オーナロールまたはアノテーションユーザロールでないため、アノテーションzipを更新できません。")
             return
 
@@ -208,7 +200,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--force", action="store_true", help="アノテーションzipを常に更新します。指定しない場合は、アノテーションzipを更新する必要がなければ更新しません。"
+        "--force",
+        action="store_true",
+        help="アノテーションzipを常に更新します。指定しない場合は、アノテーションzipを更新する必要がなければ更新しません。",
     )
 
     parser.add_argument("--wait", action="store_true", help="アノテーションzipの更新が完了するまで待ちます。")

--- a/annofabcli/project/update_annotation_zip.py
+++ b/annofabcli/project/update_annotation_zip.py
@@ -101,7 +101,7 @@ class SubUpdateAnnotationZip:
             logger.info(f"project_id={project_id}: アノテーションzipの更新が完了しました。")
         else:
             logger.info(
-                f"project_id={project_id}: アノテーションzipの更新に失敗、または{MAX_WAIT_MINUTU}分待ってもアノテーションzipの更新が終了しませんでした。"
+                f"project_id={project_id}: アノテーションzipの更新に失敗、または{MAX_WAIT_MINUTU}分待ってもアノテーションzipの更新が終了しませんでした。"  # noqa: E501
             )
         return result
 

--- a/annofabcli/project_member/change_project_members.py
+++ b/annofabcli/project_member/change_project_members.py
@@ -193,7 +193,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--member_info",
         type=str,
-        help="プロジェクトメンバに対して設定するメンバ情報を、JSON形式で指定します。 ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。 "
+        help="プロジェクトメンバに対して設定するメンバ情報を、JSON形式で指定します。 ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。 "  # noqa: E501
         "以下のキーが指定可能です。sampling_inspection_rate, sampling_acceptance_rate, "
         "未設定にする場合は、値にnullを指定してください。"
         "詳細は https://annofab.com/docs/api/#operation/putProjectMember を参照ください。 ",

--- a/annofabcli/project_member/change_project_members.py
+++ b/annofabcli/project_member/change_project_members.py
@@ -110,12 +110,8 @@ class ChangeProjectMembers(AbstractCommandLineInterface):
 
             # メンバを登録
             try:
-                self.put_project_member(
-                    project_id, user_id, old_member, member_role=member_role, member_info=member_info
-                )
-                logger.debug(
-                    f"user_id = {user_id} のプロジェクトメンバ情報を変更しました。member_role={member_role}, member_info={member_info}"
-                )
+                self.put_project_member(project_id, user_id, old_member, member_role=member_role, member_info=member_info)
+                logger.debug(f"user_id = {user_id} のプロジェクトメンバ情報を変更しました。member_role={member_role}, member_info={member_info}")
                 count_invite_members += 1
 
             except requests.exceptions.HTTPError as e:
@@ -162,9 +158,7 @@ class ChangeProjectMembers(AbstractCommandLineInterface):
         if not self.validate(args, member_info):
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
-        self.change_project_members(
-            args.project_id, user_id_list=user_id_list, member_role=member_role, member_info=member_info
-        )
+        self.change_project_members(args.project_id, user_id_list=user_id_list, member_role=member_role, member_info=member_info)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -190,7 +184,10 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     user_group.add_argument("--all_user", action="store_true", help="自分以外のすべてのプロジェクトメンバを変更します。")
 
     parser.add_argument(
-        "--role", type=str, choices=role_choices, help="プロジェクトメンバにユーザに割り当てるロールを指定します。指定しない場合は、ロールは変更されません。"
+        "--role",
+        type=str,
+        choices=role_choices,
+        help="プロジェクトメンバにユーザに割り当てるロールを指定します。指定しない場合は、ロールは変更されません。",
     )
 
     parser.add_argument(

--- a/annofabcli/project_member/copy_project_members.py
+++ b/annofabcli/project_member/copy_project_members.py
@@ -82,9 +82,7 @@ class CopyProjectMembers(AbstractCommandLineInterface):
                 "sampling_acceptance_rate": member.get("sampling_acceptance_rate"),
                 "last_updated_datetime": last_updated_datetime,
             }
-            updated_project_member = self.service.api.put_project_member(
-                project_id, member["user_id"], request_body=request_body
-            )[0]
+            updated_project_member = self.service.api.put_project_member(project_id, member["user_id"], request_body=request_body)[0]
             updated_project_members.append(updated_project_member)
 
             command_name = "追加" if last_updated_datetime is None else "更新"
@@ -110,9 +108,7 @@ class CopyProjectMembers(AbstractCommandLineInterface):
         src_project_members = self.service.wrapper.get_all_project_members(src_project_id)
         src_organization_members = self.get_organization_members_from_project_id(src_project_id)
         # 組織外のメンバが含まれている可能性があるので、除去する
-        src_project_members = [
-            e for e in src_project_members if self.find_member(src_organization_members, e["account_id"]) is not None
-        ]
+        src_project_members = [e for e in src_project_members if self.find_member(src_organization_members, e["account_id"]) is not None]
 
         dest_project_members = self.service.wrapper.get_all_project_members(dest_project_id)
         dest_organization_members = self.get_organization_members_from_project_id(dest_project_id)

--- a/annofabcli/project_member/drop_project_members.py
+++ b/annofabcli/project_member/drop_project_members.py
@@ -55,9 +55,7 @@ class DropProjectMembersMain:
                 logger.warning(f"{project_title}({project_id}) のプロジェクトメンバから、{user_id} を脱退させられませんでした。")
 
     def drop_role_with_organization(self, organization_name: str, user_id_list: List[str]):
-        projects = self.service.wrapper.get_all_projects_of_organization(
-            organization_name, query_params={"account_id": self.service.api.account_id}
-        )
+        projects = self.service.wrapper.get_all_projects_of_organization(organization_name, query_params={"account_id": self.service.api.account_id})
 
         project_id_list = [e["project_id"] for e in projects]
         self.drop_role_with_project_id(project_id_list, user_id_list=user_id_list)
@@ -120,7 +118,10 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     drop_group.add_argument(
-        "-org", "--organization", type=str, help="組織名を指定すると、組織配下のすべてのプロジェクト（自分が所属している）から、ユーザを脱退させます。"
+        "-org",
+        "--organization",
+        type=str,
+        help="組織名を指定すると、組織配下のすべてのプロジェクト（自分が所属している）から、ユーザを脱退させます。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/project_member/invite_project_members.py
+++ b/annofabcli/project_member/invite_project_members.py
@@ -61,18 +61,12 @@ class InviteProjectMemberMain:
                     f"{project_title}({project_id}) のプロジェクトメンバに、{user_id} を {member_role.value} ロールで追加できませんでした。"
                 )
 
-    def assign_role_with_organization(
-        self, organization_name: str, user_id_list: List[str], member_role: ProjectMemberRole
-    ):
-        projects = self.service.wrapper.get_all_projects_of_organization(
-            organization_name, query_params={"account_id": self.service.api.account_id}
-        )
+    def assign_role_with_organization(self, organization_name: str, user_id_list: List[str], member_role: ProjectMemberRole):
+        projects = self.service.wrapper.get_all_projects_of_organization(organization_name, query_params={"account_id": self.service.api.account_id})
         project_id_list = [e["project_id"] for e in projects]
         self.assign_role_with_project_id(project_id_list, user_id_list=user_id_list, member_role=member_role)
 
-    def assign_role_with_project_id(
-        self, project_id_list: List[str], user_id_list: List[str], member_role: ProjectMemberRole
-    ):
+    def assign_role_with_project_id(self, project_id_list: List[str], user_id_list: List[str], member_role: ProjectMemberRole):
         for project_id in project_id_list:
             try:
                 if not self.facade.my_role_is_owner(project_id):
@@ -138,7 +132,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         nargs="+",
         help="招待するプロジェクトのproject_idを指定してください。 ``file://`` を先頭に付けると、一覧が記載されたファイルを指定できます。",
     )
-    assign_group.add_argument("-org", "--organization", type=str, help="組織名を指定すると、組織配下のすべてのプロジェクト（自分が所属している）に招待します。")
+    assign_group.add_argument(
+        "-org", "--organization", type=str, help="組織名を指定すると、組織配下のすべてのプロジェクト（自分が所属している）に招待します。"
+    )
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/project_member/list_users.py
+++ b/annofabcli/project_member/list_users.py
@@ -42,9 +42,7 @@ class ListUser(AbstractCommandLineInterface):
         project_members = self.service.wrapper.get_all_project_members(project_id, query_params=query_params)
         return project_members
 
-    def get_project_members_with_project_id(
-        self, project_id_list: List[str], include_inactive: bool = False
-    ) -> List[ProjectMember]:
+    def get_project_members_with_project_id(self, project_id_list: List[str], include_inactive: bool = False) -> List[ProjectMember]:
         all_project_members: List[ProjectMember] = []
 
         for project_id in project_id_list:
@@ -52,7 +50,9 @@ class ListUser(AbstractCommandLineInterface):
                 project, _ = self.service.api.get_project(project_id)
             except requests.exceptions.HTTPError as e:
                 logger.warning(e)
-                logger.warning(f"project_id = {project_id} のプロジェクトにアクセスできなかった（存在しないproject_id、またはプロジェクトメンバでない）")
+                logger.warning(
+                    f"project_id = {project_id} のプロジェクトにアクセスできなかった（存在しないproject_id、またはプロジェクトメンバでない）"
+                )
                 continue
 
             project_title = project["title"]

--- a/annofabcli/project_member/list_users.py
+++ b/annofabcli/project_member/list_users.py
@@ -21,7 +21,7 @@ class ListUser(AbstractCommandLineInterface):
     ユーザを表示する
     """
 
-    PRIOR_COLUMNS = [
+    PRIOR_COLUMNS = [  # noqa: RUF012
         "project_id",
         "project_title",
         "account_id",

--- a/annofabcli/project_member/put_project_members.py
+++ b/annofabcli/project_member/put_project_members.py
@@ -55,9 +55,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
             "sampling_acceptance_rate": member.sampling_acceptance_rate,
             "last_updated_datetime": last_updated_datetime,
         }
-        updated_project_member = self.service.api.put_project_member(
-            project_id, member.user_id, request_body=request_body
-        )[0]
+        updated_project_member = self.service.api.put_project_member(project_id, member.user_id, request_body=request_body)[0]
         return updated_project_member
 
     def delete_project_member(self, project_id: str, deleted_member: Dict[str, Any]):
@@ -66,9 +64,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
             "member_role": deleted_member["member_role"],
             "last_updated_datetime": deleted_member["updated_datetime"],
         }
-        updated_project_member = self.service.api.put_project_member(
-            project_id, deleted_member["user_id"], request_body=request_body
-        )[0]
+        updated_project_member = self.service.api.put_project_member(project_id, deleted_member["user_id"], request_body=request_body)[0]
         return updated_project_member
 
     def put_project_members(self, project_id: str, members: List[Member], delete: bool = False):
@@ -111,16 +107,12 @@ class PutProjectMembers(AbstractCommandLineInterface):
             # メンバを登録
             try:
                 self.invite_project_member(project_id, member, old_project_members)
-                logger.debug(
-                    f"user_id = {member.user_id}, member_role = {member.member_role.value} のユーザをプ" f"ロジェクトメンバに登録しました。"
-                )
+                logger.debug(f"user_id = {member.user_id}, member_role = {member.member_role.value} のユーザをプ" f"ロジェクトメンバに登録しました。")
                 count_invite_members += 1
 
             except requests.exceptions.HTTPError as e:
                 logger.warning(e)
-                logger.warning(
-                    f"プロジェクトメンバの登録に失敗しました。" f"user_id = {member.user_id}, member_role = {member.member_role.value}"
-                )
+                logger.warning(f"プロジェクトメンバの登録に失敗しました。" f"user_id = {member.user_id}, member_role = {member.member_role.value}")
 
         logger.info(f"{project_title} に、{count_invite_members} / {len(members)} 件のプロジェクトメンバを登録しました。")
 
@@ -129,9 +121,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
             user_id_list = [e.user_id for e in members]
             # 自分自身は削除しないようにする
             deleted_members = [
-                e
-                for e in old_project_members
-                if (e["user_id"] not in user_id_list and e["user_id"] != self.service.api.login_user_id)
+                e for e in old_project_members if (e["user_id"] not in user_id_list and e["user_id"] != self.service.api.login_user_id)
             ]
 
             count_delete_members = 0
@@ -203,7 +193,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
 
-    parser.add_argument("--delete", action="store_true", help="CSVファイルに記載されていないプロジェクトメンバを削除します。ただし自分自身は削除しません。")
+    parser.add_argument(
+        "--delete", action="store_true", help="CSVファイルに記載されていないプロジェクトメンバを削除します。ただし自分自身は削除しません。"
+    )
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/project_member/subcommand_project_member.py
+++ b/annofabcli/project_member/subcommand_project_member.py
@@ -28,8 +28,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "プロジェクトメンバ関係のサブコマンド"
     description = "プロジェクトメンバ関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/stat_visualization/mask_visualization_dir.py
+++ b/annofabcli/stat_visualization/mask_visualization_dir.py
@@ -79,9 +79,7 @@ def create_replacement_dict(
     replacement_dict_for_username = dict(zip(df3["username"], replacement_dict_for_user_id.values()))
     replacement_dict_for_account_id = dict(zip(df3["account_id"], replacement_dict_for_user_id.values()))
 
-    replacement_dict_by_biography = create_replacement_dict_by_biography(
-        df_user, not_masked_biography_set=not_masked_biography_set
-    )
+    replacement_dict_by_biography = create_replacement_dict_by_biography(df_user, not_masked_biography_set=not_masked_biography_set)
 
     return ReplacementDict(
         user_id=replacement_dict_for_user_id,
@@ -91,9 +89,7 @@ def create_replacement_dict(
     )
 
 
-def write_line_graph(
-    task: Task, output_project_dir: ProjectDir, user_id_list: Optional[List[str]] = None, minimal_output: bool = False
-):
+def write_line_graph(task: Task, output_project_dir: ProjectDir, user_id_list: Optional[List[str]] = None, minimal_output: bool = False):
     output_project_dir.write_cumulative_line_graph(
         AnnotatorCumulativeProductivity.from_task(task),
         phase=TaskPhase.ANNOTATION,
@@ -122,20 +118,12 @@ def write_line_graph(
     output_project_dir.write_performance_per_started_date_csv(acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE)
 
     if not minimal_output:
-        output_project_dir.write_performance_line_graph_per_date(
-            annotator_per_date_obj, phase=TaskPhase.ANNOTATION, user_id_list=user_id_list
-        )
-        output_project_dir.write_performance_line_graph_per_date(
-            inspector_per_date_obj, phase=TaskPhase.INSPECTION, user_id_list=user_id_list
-        )
-        output_project_dir.write_performance_line_graph_per_date(
-            acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE, user_id_list=user_id_list
-        )
+        output_project_dir.write_performance_line_graph_per_date(annotator_per_date_obj, phase=TaskPhase.ANNOTATION, user_id_list=user_id_list)
+        output_project_dir.write_performance_line_graph_per_date(inspector_per_date_obj, phase=TaskPhase.INSPECTION, user_id_list=user_id_list)
+        output_project_dir.write_performance_line_graph_per_date(acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE, user_id_list=user_id_list)
 
 
-def create_df_user(
-    worktime_per_date_user: WorktimePerDate, task_worktime_by_phase_user: TaskWorktimeByPhaseUser
-) -> pandas.DataFrame:
+def create_df_user(worktime_per_date_user: WorktimePerDate, task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> pandas.DataFrame:
     """
     ユーザー情報が格納されているDataFrameを生成します。
 
@@ -183,9 +171,7 @@ def mask_visualization_dir(
     )
 
     # CSVのユーザ情報をマスクする
-    masked_user_performance = UserPerformance.from_df_wrapper(
-        masked_worktime_per_date, masked_task_worktime_by_phase_user
-    )
+    masked_user_performance = UserPerformance.from_df_wrapper(masked_worktime_per_date, masked_task_worktime_by_phase_user)
     output_project_dir.write_user_performance(masked_user_performance)
 
     # メンバのパフォーマンスを散布図で出力する
@@ -213,12 +199,8 @@ def mask_visualization_dir(
 
 
 def main(args: argparse.Namespace) -> None:
-    not_masked_biography_set = (
-        set(get_list_from_args(args.not_masked_biography)) if args.not_masked_biography is not None else None
-    )
-    not_masked_user_id_set = (
-        set(get_list_from_args(args.not_masked_user_id)) if args.not_masked_user_id is not None else None
-    )
+    not_masked_biography_set = set(get_list_from_args(args.not_masked_biography)) if args.not_masked_biography is not None else None
+    not_masked_user_id_set = set(get_list_from_args(args.not_masked_user_id)) if args.not_masked_user_id is not None else None
 
     mask_visualization_dir(
         project_dir=ProjectDir(args.dir),

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -91,15 +91,9 @@ class WritingVisualizationFile:
         inspector_per_date_obj = InspectorProductivityPerDate.from_df_task(task.df)
         acceptor_per_date_obj = AcceptorProductivityPerDate.from_df_task(task.df)
 
-        self.output_project_dir.write_performance_per_started_date_csv(
-            annotator_per_date_obj, phase=TaskPhase.ANNOTATION
-        )
-        self.output_project_dir.write_performance_per_started_date_csv(
-            inspector_per_date_obj, phase=TaskPhase.INSPECTION
-        )
-        self.output_project_dir.write_performance_per_started_date_csv(
-            acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE
-        )
+        self.output_project_dir.write_performance_per_started_date_csv(annotator_per_date_obj, phase=TaskPhase.ANNOTATION)
+        self.output_project_dir.write_performance_per_started_date_csv(inspector_per_date_obj, phase=TaskPhase.INSPECTION)
+        self.output_project_dir.write_performance_per_started_date_csv(acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE)
 
         # 折れ線グラフを出力
         self.output_project_dir.write_performance_line_graph_per_date(
@@ -203,12 +197,8 @@ def merge_visualization_dir(  # pylint: disable=too-many-statements
     task = merging_obj.merge_task_list()
     worktime_per_date = merging_obj.merge_worktime_per_date()
 
-    user_performance = UserPerformance.from_df_wrapper(
-        task_worktime_by_phase_user=task_worktime_by_phase_user, worktime_per_date=worktime_per_date
-    )
-    whole_performance = WholePerformance.from_df_wrapper(
-        task_worktime_by_phase_user=task_worktime_by_phase_user, worktime_per_date=worktime_per_date
-    )
+    user_performance = UserPerformance.from_df_wrapper(task_worktime_by_phase_user=task_worktime_by_phase_user, worktime_per_date=worktime_per_date)
+    whole_performance = WholePerformance.from_df_wrapper(task_worktime_by_phase_user=task_worktime_by_phase_user, worktime_per_date=worktime_per_date)
     writing_obj = WritingVisualizationFile(output_project_dir, user_id_list=user_id_list, minimal_output=minimal_output)
 
     writing_obj.write_task_list_and_histogram(task)

--- a/annofabcli/stat_visualization/subcommand_stat_visualization.py
+++ b/annofabcli/stat_visualization/subcommand_stat_visualization.py
@@ -24,8 +24,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "`annofabcli statistics visualization` コマンドの出力結果を加工するサブコマンド（アルファ版）"
     description = "`annofabcli statistics visualization` コマンドの出力結果を加工するサブコマンド（アルファ版）"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/stat_visualization/summarize_whole_performance_csv.py
+++ b/annofabcli/stat_visualization/summarize_whole_performance_csv.py
@@ -33,7 +33,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "summarize_whole_performance_csv"
-    subcommand_help = "``annofabcli statistics visualize`` コマンドの出力結果であるプロジェクトディレクトリから、プロジェクトごとの生産性や品質の一覧を出力します。。"
+    subcommand_help = "``annofabcli statistics visualize`` コマンドの出力結果であるプロジェクトディレクトリから、プロジェクトごとの生産性や品質の一覧を出力します。。"  # noqa: E501
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help)
     parse_args(parser)
     return parser

--- a/annofabcli/stat_visualization/write_graph.py
+++ b/annofabcli/stat_visualization/write_graph.py
@@ -90,9 +90,7 @@ class WritingGraph:
             logger.warning("'タスクlist.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
 
         try:
-            self.output_project_dir.write_whole_productivity_line_graph_per_date(
-                self.project_dir.read_whole_productivity_per_date()
-            )
+            self.output_project_dir.write_whole_productivity_line_graph_per_date(self.project_dir.read_whole_productivity_per_date())
         except Exception:
             logger.warning("'日毎の生産量と生産性.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
 

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -146,7 +146,7 @@ class CollectingPerformanceInfo:
         self,
         *,
         productivity_indicator: ProductivityIndicator = ProductivityIndicator.ACTUAL_WORKTIME_HOUR_PER_ANNOTATION_COUNT,
-        quality_indicator: QualityIndicator = QualityIndicator.POINTED_OUT_INSPECTION_COMMENT_COUNT_PER_ANNOTATION_COUNT,  # noqa: E501
+        quality_indicator: QualityIndicator = QualityIndicator.POINTED_OUT_INSPECTION_COMMENT_COUNT_PER_ANNOTATION_COUNT,
         threshold_info: Optional[ThresholdInfo] = None,
         productivity_indicator_by_directory: Optional[ProductivityIndicatorByDirectory] = None,
         quality_indicator_by_directory: Optional[QualityIndicatorByDirectory] = None,
@@ -155,15 +155,9 @@ class CollectingPerformanceInfo:
         self.quality_indicator = quality_indicator
         self.productivity_indicator = productivity_indicator
         self.threshold_info = threshold_info if threshold_info is not None else ThresholdInfo()
-        self.threshold_infos_by_directory = (
-            threshold_infos_by_directory if threshold_infos_by_directory is not None else {}
-        )
-        self.productivity_indicator_by_directory = (
-            productivity_indicator_by_directory if productivity_indicator_by_directory is not None else {}
-        )
-        self.quality_indicator_by_directory = (
-            quality_indicator_by_directory if quality_indicator_by_directory is not None else {}
-        )
+        self.threshold_infos_by_directory = threshold_infos_by_directory if threshold_infos_by_directory is not None else {}
+        self.productivity_indicator_by_directory = productivity_indicator_by_directory if productivity_indicator_by_directory is not None else {}
+        self.quality_indicator_by_directory = quality_indicator_by_directory if quality_indicator_by_directory is not None else {}
 
     def get_threshold_info(self, project_title: str, productivity_type: ProductivityType) -> ThresholdInfo:
         """指定したプロジェクト名に対応する、閾値情報を取得する。"""
@@ -172,16 +166,8 @@ class CollectingPerformanceInfo:
         if local_info is None:
             return global_info
 
-        worktime = (
-            local_info.threshold_worktime
-            if local_info.threshold_worktime is not None
-            else global_info.threshold_worktime
-        )
-        task_count = (
-            local_info.threshold_task_count
-            if local_info.threshold_task_count is not None
-            else global_info.threshold_task_count
-        )
+        worktime = local_info.threshold_worktime if local_info.threshold_worktime is not None else global_info.threshold_worktime
+        task_count = local_info.threshold_task_count if local_info.threshold_task_count is not None else global_info.threshold_task_count
 
         return ThresholdInfo(threshold_worktime=worktime, threshold_task_count=task_count)
 
@@ -198,18 +184,14 @@ class CollectingPerformanceInfo:
 
         threshold_info = self.get_threshold_info(project_title, productivity_type)
         if threshold_info.threshold_worktime is not None:
-            df = df[
-                df[(self.productivity_indicator.worktime_type.value, phase.value)] > threshold_info.threshold_worktime
-            ]
+            df = df[df[(self.productivity_indicator.worktime_type.value, phase.value)] > threshold_info.threshold_worktime]
 
         if threshold_info.threshold_task_count is not None:
             df = df[df[("task_count", phase.value)] > threshold_info.threshold_task_count]
 
         return df
 
-    def join_annotation_productivity(
-        self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str
-    ) -> pandas.DataFrame:
+    def join_annotation_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str) -> pandas.DataFrame:
         """
         引数`df_performance`から教師付生産性を抽出して引数`df`にjoinした結果を返す
 
@@ -224,18 +206,12 @@ class CollectingPerformanceInfo:
 
         df_joined = self.filter_df_with_threshold(df_joined, phase, project_title=project_title)
 
-        productivity_indicator = self.productivity_indicator_by_directory.get(
-            project_title, self.productivity_indicator
-        )
+        productivity_indicator = self.productivity_indicator_by_directory.get(project_title, self.productivity_indicator)
         df_tmp = df_joined[[(productivity_indicator.value, phase.value)]]
-        df_tmp.columns = pandas.MultiIndex.from_tuples(
-            [(project_title, f"{productivity_indicator.value}__{phase.value}")]
-        )
+        df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{productivity_indicator.value}__{phase.value}")])
         return df.join(df_tmp)
 
-    def join_inspection_acceptance_productivity(
-        self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str
-    ) -> pandas.DataFrame:
+    def join_inspection_acceptance_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str) -> pandas.DataFrame:
         """
         引数`df_performance`から検査/受入の生産性を抽出して引数`df`にjoinした結果を返す
 
@@ -245,9 +221,7 @@ class CollectingPerformanceInfo:
             df_performance: 引数`project_title`のユーザーごとの生産性と品質が格納されたDataFrame。
         """
 
-        productivity_indicator = self.productivity_indicator_by_directory.get(
-            project_title, self.productivity_indicator
-        )
+        productivity_indicator = self.productivity_indicator_by_directory.get(project_title, self.productivity_indicator)
 
         def _join_inspection():
             phase = TaskPhase.INSPECTION
@@ -258,9 +232,7 @@ class CollectingPerformanceInfo:
             df_joined = self.filter_df_with_threshold(df_joined, phase, project_title=project_title)
 
             df_tmp = df_joined[[(productivity_indicator.value, phase.value)]]
-            df_tmp.columns = pandas.MultiIndex.from_tuples(
-                [(project_title, f"{productivity_indicator.value}__{phase.value}")]
-            )
+            df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{productivity_indicator.value}__{phase.value}")])
 
             return df.join(df_tmp)
 
@@ -273,9 +245,7 @@ class CollectingPerformanceInfo:
             df_joined = self.filter_df_with_threshold(df_joined, phase, project_title=project_title)
 
             df_tmp = df_joined[[(productivity_indicator.value, phase.value)]]
-            df_tmp.columns = pandas.MultiIndex.from_tuples(
-                [(project_title, f"{productivity_indicator.value}__{phase.value}")]
-            )
+            df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{productivity_indicator.value}__{phase.value}")])
 
             return df.join(df_tmp)
 
@@ -284,9 +254,7 @@ class CollectingPerformanceInfo:
 
         return df
 
-    def join_annotation_quality(
-        self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str
-    ) -> pandas.DataFrame:
+    def join_annotation_quality(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str) -> pandas.DataFrame:
         """
         引数`df_performance`から教師付の品質を抽出して引数`df`にjoinした結果を返す
 
@@ -358,12 +326,8 @@ class CollectingPerformanceInfo:
 
         # プロジェクトの生産性と品質のDataFrameを生成する
         project_performance = ProjectPerformance.from_project_dirs(project_dir_list)
-        project_actual_worktime = ProjectWorktimePerMonth.from_project_dirs(
-            project_dir_list, WorktimeColumn.ACTUAL_WORKTIME_HOUR
-        )
-        project_monitored_worktime = ProjectWorktimePerMonth.from_project_dirs(
-            project_dir_list, WorktimeColumn.MONITORED_WORKTIME_HOUR
-        )
+        project_actual_worktime = ProjectWorktimePerMonth.from_project_dirs(project_dir_list, WorktimeColumn.ACTUAL_WORKTIME_HOUR)
+        project_monitored_worktime = ProjectWorktimePerMonth.from_project_dirs(project_dir_list, WorktimeColumn.MONITORED_WORKTIME_HOUR)
         return ResultDataframe(
             annotation_productivity=df_annotation_productivity.reset_index(),
             inspection_acceptance_productivity=df_inspection_acceptance_productivity.reset_index(),
@@ -398,9 +362,7 @@ def to_rank(series: pandas.Series) -> pandas.Series:
 
 
 def to_deviation(series: pandas.Series, threshold_deviation_user_count: Optional[int] = None) -> pandas.Series:
-    if series.count() == 0 or (
-        threshold_deviation_user_count is not None and series.count() <= threshold_deviation_user_count
-    ):
+    if series.count() == 0 or (threshold_deviation_user_count is not None and series.count() <= threshold_deviation_user_count):
         return pandas.Series([numpy.nan] * len(series))
     else:
         std = series.std(ddof=0)
@@ -495,9 +457,7 @@ def create_user_df(target_dir: Path) -> pandas.DataFrame:
 
 
 class WritingCsv:
-    def __init__(
-        self, threshold_deviation_user_count: Optional[int] = None, user_ids: Optional[Collection[str]] = None
-    ) -> None:
+    def __init__(self, threshold_deviation_user_count: Optional[int] = None, user_ids: Optional[Collection[str]] = None) -> None:
         self.threshold_deviation_user_count = threshold_deviation_user_count
         self.user_ids = user_ids
 
@@ -506,9 +466,7 @@ class WritingCsv:
 
         # 偏差値のCSVを出力
         print_csv(
-            create_deviation_df(
-                df, threshold_deviation_user_count=self.threshold_deviation_user_count, user_ids=self.user_ids
-            ),
+            create_deviation_df(df, threshold_deviation_user_count=self.threshold_deviation_user_count, user_ids=self.user_ids),
             str(output_dir / f"{csv_basename}__deviation.csv"),
         )
 
@@ -582,9 +540,7 @@ class WritePerformanceRatingCsv(AbstractCommandLineWithoutWebapiInterface):
 
         result = CollectingPerformanceInfo(
             productivity_indicator=ProductivityIndicator(args.productivity_indicator),
-            productivity_indicator_by_directory=create_productivity_indicator_by_directory(
-                args.productivity_indicator_by_directory
-            ),
+            productivity_indicator_by_directory=create_productivity_indicator_by_directory(args.productivity_indicator_by_directory),
             quality_indicator=QualityIndicator(args.quality_indicator),
             quality_indicator_by_directory=create_quality_indicator_by_directory(args.quality_indicator_by_directory),
             threshold_info=ThresholdInfo(

--- a/annofabcli/statistics/database.py
+++ b/annofabcli/statistics/database.py
@@ -235,14 +235,14 @@ class Database:
                 elif job_status == JobStatus.SUCCEEDED:
                     if dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(last_tasks_updated_datetime):
                         logger.info(
-                            f"{self.logging_prefix}: タスクの最新更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。"
+                            f"{self.logging_prefix}: タスクの最新更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。"  # noqa: E501
                         )
                         self.annofab_service.api.post_annotation_archive_update(project_id)
                         self.wait_for_completion_updated_annotation(project_id)
 
                     elif dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(annotation_specs_updated_datetime):
                         logger.info(
-                            f"{self.logging_prefix}: アノテーション仕様の更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。"
+                            f"{self.logging_prefix}: アノテーション仕様の更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。"  # noqa: E501
                         )
                         self.annofab_service.api.post_annotation_archive_update(project_id)
                         self.wait_for_completion_updated_annotation(project_id)

--- a/annofabcli/statistics/database.py
+++ b/annofabcli/statistics/database.py
@@ -95,7 +95,7 @@ class Database:
             return True
 
     def get_annotation_count_by_task(self) -> Dict[str, int]:
-        logger.debug(f"{self.logging_prefix}: アノテーションZIPを読み込みます。file='{str(self.annotations_zip_path)}'")
+        logger.debug(f"{self.logging_prefix}: アノテーションZIPを読み込みます。file='{self.annotations_zip_path!s}'")
 
         result: Dict[str, int] = defaultdict(int)
         for index, parser in enumerate(lazy_parse_simple_annotation_zip(self.annotations_zip_path)):
@@ -214,14 +214,12 @@ class Database:
         annotation_specs_updated_datetime = annotation_specs_history[-1]["updated_datetime"]
         logger.debug(f"{self.logging_prefix}: アノテーション仕様の最終更新日時={annotation_specs_updated_datetime}")
 
-        job_list = self.annofab_service.api.get_project_job(
-            project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1}
-        )[0]["list"]
+        job_list = self.annofab_service.api.get_project_job(project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1})[0][
+            "list"
+        ]
         if len(job_list) > 0:
             job = job_list[0]
-            logger.debug(
-                f"{self.logging_prefix}: アノテーションzipの最終更新日時={job['updated_datetime']}, job_status={job['job_status']}"
-            )
+            logger.debug(f"{self.logging_prefix}: アノテーションzipの最終更新日時={job['updated_datetime']}, job_status={job['job_status']}")
 
         if should_update_annotation_zip:
             if len(job_list) == 0:
@@ -235,16 +233,14 @@ class Database:
                     self.wait_for_completion_updated_annotation(project_id)
 
                 elif job_status == JobStatus.SUCCEEDED:
-                    if dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(
-                        last_tasks_updated_datetime
-                    ):
-                        logger.info(f"{self.logging_prefix}: タスクの最新更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。")
+                    if dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(last_tasks_updated_datetime):
+                        logger.info(
+                            f"{self.logging_prefix}: タスクの最新更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。"
+                        )
                         self.annofab_service.api.post_annotation_archive_update(project_id)
                         self.wait_for_completion_updated_annotation(project_id)
 
-                    elif dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(
-                        annotation_specs_updated_datetime
-                    ):
+                    elif dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(annotation_specs_updated_datetime):
                         logger.info(
                             f"{self.logging_prefix}: アノテーション仕様の更新日時よりアノテーションzipの最終更新日時の方が古いので、アノテーションzipを更新します。"
                         )
@@ -268,9 +264,9 @@ class Database:
             should_update_task_json:
         """
 
-        job_list = self.annofab_service.api.get_project_job(
-            project_id, query_params={"type": ProjectJobType.GEN_TASKS_LIST.value, "limit": 1}
-        )[0]["list"]
+        job_list = self.annofab_service.api.get_project_job(project_id, query_params={"type": ProjectJobType.GEN_TASKS_LIST.value, "limit": 1})[0][
+            "list"
+        ]
 
         if len(job_list) == 0:
             if should_update_task_json:
@@ -279,9 +275,7 @@ class Database:
 
         else:
             job = job_list[0]
-            logger.debug(
-                f"{self.logging_prefix}: タスク全件ファイルの最終更新日時={job['updated_datetime']}, job_status={job['job_status']}"
-            )
+            logger.debug(f"{self.logging_prefix}: タスク全件ファイルの最終更新日時={job['updated_datetime']}, job_status={job['job_status']}")
 
             if should_update_task_json:
                 job_status = JobStatus(job["job_status"])
@@ -317,16 +311,14 @@ class Database:
         annotation_specs_updated_datetime = annotation_specs_history[-1]["updated_datetime"]
         logger.debug(f"{self.logging_prefix}: アノテーション仕様の最終更新日時={annotation_specs_updated_datetime}")
 
-        job_list = self.annofab_service.api.get_project_job(
-            self.project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1}
-        )[0]["list"]
+        job_list = self.annofab_service.api.get_project_job(self.project_id, query_params={"type": ProjectJobType.GEN_ANNOTATION.value, "limit": 1})[
+            0
+        ]["list"]
         if len(job_list) == 0:
             logger.debug(f"{self.logging_prefix}: アノテーションzipの最終更新日時は不明です。")
         else:
             job = job_list[0]
-            logger.debug(
-                f"{self.logging_prefix}: アノテーションzipの最終更新日時={job['updated_datetime']}, job_status={job['job_status']}"
-            )
+            logger.debug(f"{self.logging_prefix}: アノテーションzipの最終更新日時={job['updated_datetime']}, job_status={job['job_status']}")
 
     def _download_db_file(self, is_latest: bool, is_get_task_histories_one_of_each: bool):
         """
@@ -341,9 +333,7 @@ class Database:
 
         wait_options = WaitOptions(interval=60, max_tries=360)
 
-        downloading_obj.download_task_json(
-            self.project_id, dest_path=str(self.tasks_json_path), is_latest=is_latest, wait_options=wait_options
-        )
+        downloading_obj.download_task_json(self.project_id, dest_path=str(self.tasks_json_path), is_latest=is_latest, wait_options=wait_options)
         downloading_obj.download_annotation_zip(
             self.project_id,
             dest_path=str(self.annotations_zip_path),
@@ -365,9 +355,7 @@ class Database:
 
         else:
             try:
-                downloading_obj.download_task_history_json(
-                    self.project_id, dest_path=str(self.task_histories_json_path)
-                )
+                downloading_obj.download_task_history_json(self.project_id, dest_path=str(self.task_histories_json_path))
             except DownloadingFileNotFoundError:
                 # プロジェクトを作成した日だと、タスク履歴全県ファイルが作成されていないので、DownloadingFileNotFoundErrorが発生する
                 # その場合でも、処理は継続できるので、タスク履歴APIを１個ずつ実行して、タスク履歴ファイルを作成する
@@ -392,11 +380,7 @@ class Database:
         query = self.query
 
         # 終了日はその日の23:59までを対象とするため、１日加算する
-        dt_end_date = (
-            self._to_datetime_with_tz(query.end_date) + datetime.timedelta(days=1)
-            if query.end_date is not None
-            else None
-        )
+        dt_end_date = self._to_datetime_with_tz(query.end_date) + datetime.timedelta(days=1) if query.end_date is not None else None
 
         def filter_task(arg_task: Dict[str, Any]) -> bool:
             """
@@ -437,9 +421,7 @@ class Database:
         return filtered_task_list
 
     @staticmethod
-    def _filter_task_with_task_history(
-        task_list: List[Task], dict_task_histories: Dict[str, List[TaskHistory]], start_date: str
-    ) -> List[Task]:
+    def _filter_task_with_task_history(task_list: List[Task], dict_task_histories: Dict[str, List[TaskHistory]], start_date: str) -> List[Task]:
         """
         タスク履歴を参照して、タスクを絞り込む。
 
@@ -464,9 +446,7 @@ class Database:
                 return False
 
             # 初回教師付けの開始日時をfirst_started_datetimeとするため「(タスク作成)」の履歴がある場合はスキップする。
-            first_started_datetime = (task_histories[0] if not has_task_creation else task_histories[1])[
-                "started_datetime"
-            ]
+            first_started_datetime = (task_histories[0] if not has_task_creation else task_histories[1])["started_datetime"]
             if first_started_datetime is None:
                 return False
             return dateutil.parser.parse(first_started_datetime) >= dt_start_date

--- a/annofabcli/statistics/histogram.py
+++ b/annofabcli/statistics/histogram.py
@@ -31,9 +31,7 @@ def get_histogram_figure(
     hist, bin_edges = numpy.histogram(ser, bins)
 
     df_histogram = pandas.DataFrame({"frequency": hist, "left": bin_edges[:-1], "right": bin_edges[1:]})
-    df_histogram["interval"] = [
-        f"{left:.1f} to {right:.1f}" for left, right in zip(df_histogram["left"], df_histogram["right"])
-    ]
+    df_histogram["interval"] = [f"{left:.1f} to {right:.1f}" for left, right in zip(df_histogram["left"], df_histogram["right"])]
 
     source = ColumnDataSource(df_histogram)
     fig = figure(

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -132,7 +132,7 @@ class LineGraph:
         y_column: str,
         *,
         legend_label: str,
-        color: Optional[Any] = None,
+        color: Optional[Any] = None,  # noqa: ANN401
         is_secondary_y_axis: bool = False,
         **kwargs,
     ) -> tuple[GlyphRenderer, GlyphRenderer]:
@@ -175,7 +175,7 @@ class LineGraph:
         y_column: str,
         *,
         legend_label: str,
-        color: Optional[Any] = None,
+        color: Optional[Any] = None,  # noqa: ANN401
         is_secondary_y_axis: bool = False,
         **kwargs,
     ) -> tuple[GlyphRenderer, GlyphRenderer]:

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -116,7 +116,7 @@ class LineGraph:
             "right",
         )
         if secondary_y_axis_range is not None:
-            self.figure.extra_y_ranges = {self._SECONDARY_Y_RANGE_NAME: secondary_y_axis_range}  # type: ignore[assignment]  # noqa: E501
+            self.figure.extra_y_ranges = {self._SECONDARY_Y_RANGE_NAME: secondary_y_axis_range}  # type: ignore[assignment]
         else:
             self.figure.extra_y_ranges = {self._SECONDARY_Y_RANGE_NAME: DataRange1d()}  # type: ignore[assignment]
 

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -197,7 +197,7 @@ class ListAnnotationCounterByInputData:
 
         def convert_attribute_value_to_key(value: Union[bool, str, int, float]) -> str:
             if isinstance(value, bool):
-                # bool値をCSVの列名やJSONのキーとして扱う場合、`True/False`だとPythonに依存したように見えてしまうので（本当？）、`true/false`に変換する
+                # bool値をCSVの列名やJSONのキーとして扱う場合、`True/False`だとPythonに依存したように見えてしまうので（本当？）、`true/false`に変換する  # noqa: E501
                 if value:
                     return "true"
                 elif not value:
@@ -413,7 +413,7 @@ class AttributeCountCsv:
     Args:
         selective_attribute_value_max_count: 選択肢系の属性の値の個数の上限。これを超えた場合は、非選択肢系属性（トラッキングIDやアノテーションリンクなど）とみなす
 
-    """
+    """  # noqa: E501
 
     def __init__(self, selective_attribute_value_max_count: int = 20, csv_format: Optional[dict[str, Any]] = None) -> None:
         self.csv_format = csv_format
@@ -727,7 +727,7 @@ class AnnotationSpecs:
         duplicated_attributes = [key for key, value in collections.Counter(target_attribute_value_keys).items() if value > 1]
         if len(duplicated_attributes) > 0:
             logger.warning(
-                f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_attributes}"
+                f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_attributes}"  # noqa: E501
             )
 
         return target_attribute_value_keys
@@ -1149,7 +1149,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--latest",
         action="store_true",
-        help="``--annotation`` を指定しないとき、最新のアノテーションzipを参照します。このオプションを指定すると、アノテーションzipを更新するのに数分待ちます。",
+        help="``--annotation`` を指定しないとき、最新のアノテーションzipを参照します。このオプションを指定すると、アノテーションzipを更新するのに数分待ちます。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -181,9 +181,7 @@ class ListAnnotationCounterByInputData:
         self.target_labels = set(target_labels) if target_labels is not None else None
         self.target_attribute_names = set(target_attribute_names) if target_attribute_names is not None else None
         self.non_target_labels = set(non_target_labels) if non_target_labels is not None else None
-        self.non_target_attribute_names = (
-            set(non_target_attribute_names) if non_target_attribute_names is not None else None
-        )
+        self.non_target_attribute_names = set(non_target_attribute_names) if non_target_attribute_names is not None else None
         self.frame_no_map = frame_no_map
 
     def get_annotation_counter(
@@ -215,11 +213,7 @@ class ListAnnotationCounterByInputData:
             )
         if self.non_target_labels is not None:
             annotation_count_by_label = collections.Counter(
-                {
-                    label: count
-                    for label, count in annotation_count_by_label.items()
-                    if label not in self.non_target_labels
-                }
+                {label: count for label, count in annotation_count_by_label.items() if label not in self.non_target_labels}
             )
 
         attributes_list: list[AttributeValueKey] = []
@@ -421,9 +415,7 @@ class AttributeCountCsv:
 
     """
 
-    def __init__(
-        self, selective_attribute_value_max_count: int = 20, csv_format: Optional[dict[str, Any]] = None
-    ) -> None:
+    def __init__(self, selective_attribute_value_max_count: int = 20, csv_format: Optional[dict[str, Any]] = None) -> None:
         self.csv_format = csv_format
         self.selective_attribute_value_max_count = selective_attribute_value_max_count
 
@@ -438,9 +430,7 @@ class AttributeCountCsv:
             attribute_name_list.append((label, attribute_name))
 
         non_selective_attribute_names = {
-            key
-            for key, value in collections.Counter(attribute_name_list).items()
-            if value > self.selective_attribute_value_max_count
+            key for key, value in collections.Counter(attribute_name_list).items() if value > self.selective_attribute_value_max_count
         }
         if len(non_selective_attribute_names) > 0:
             logger.debug(
@@ -579,9 +569,7 @@ class LabelCountCsv:
     def __init__(self, csv_format: Optional[dict[str, Any]] = None) -> None:
         self.csv_format = csv_format
 
-    def _value_columns(
-        self, counter_list: Collection[AnnotationCounter], prior_label_columns: Optional[list[str]]
-    ) -> list[str]:
+    def _value_columns(self, counter_list: Collection[AnnotationCounter], prior_label_columns: Optional[list[str]]) -> list[str]:
         all_attr_key_set = {attr_key for c in counter_list for attr_key in c.annotation_count_by_label}
         if prior_label_columns is not None:
             remaining_columns = sorted(all_attr_key_set - set(prior_label_columns))
@@ -697,7 +685,9 @@ class AnnotationSpecs:
         result = [to_label_name(label) for label in self._labels_v1]
         duplicated_labels = [key for key, value in collections.Counter(result).items() if value > 1]
         if len(duplicated_labels) > 0:
-            logger.warning(f"アノテーション仕様のラベル英語名が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_labels}")
+            logger.warning(
+                f"アノテーション仕様のラベル英語名が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_labels}"
+            )
         return result
 
     def selective_attribute_value_keys(self) -> list[AttributeValueKey]:
@@ -734,9 +724,7 @@ class AnnotationSpecs:
                 else:
                     continue
 
-        duplicated_attributes = [
-            key for key, value in collections.Counter(target_attribute_value_keys).items() if value > 1
-        ]
+        duplicated_attributes = [key for key, value in collections.Counter(target_attribute_value_keys).items() if value > 1]
         if len(duplicated_attributes) > 0:
             logger.warning(
                 f"アノテーション仕様の属性情報（ラベル英語名、属性英語名、選択肢英語名）が重複しています。アノテーション個数が正しく算出できない可能性があります。:: {duplicated_attributes}"
@@ -852,17 +840,13 @@ class ListAnnotationCountMain:
             if annotation_specs is not None:
                 label_columns = annotation_specs.label_keys()
 
-            LabelCountCsv().print_csv_by_input_data(
-                counter_list_by_input_data, output_file, prior_label_columns=label_columns
-            )
+            LabelCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_label_columns=label_columns)
         elif csv_type == CsvType.ATTRIBUTE:
             attribute_columns: Optional[list[AttributeValueKey]] = None
             if annotation_specs is not None:
                 attribute_columns = annotation_specs.selective_attribute_value_keys()
 
-            AttributeCountCsv().print_csv_by_input_data(
-                counter_list_by_input_data, output_file, prior_attribute_columns=attribute_columns
-            )
+            AttributeCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_attribute_columns=attribute_columns)
 
     def print_annotation_counter_csv_by_task(
         self,
@@ -881,9 +865,7 @@ class ListAnnotationCountMain:
             annotation_specs = AnnotationSpecs(self.service, project_id)
             non_selective_attribute_name_keys = annotation_specs.non_selective_attribute_name_keys()
 
-        counter_list_by_task = ListAnnotationCounterByTask(
-            non_target_attribute_names=non_selective_attribute_name_keys
-        ).get_annotation_counter_list(
+        counter_list_by_task = ListAnnotationCounterByTask(non_target_attribute_names=non_selective_attribute_name_keys).get_annotation_counter_list(
             annotation_path,
             target_task_ids=target_task_ids,
             task_query=task_query,
@@ -903,9 +885,7 @@ class ListAnnotationCountMain:
             if annotation_specs is not None:
                 attribute_columns = annotation_specs.selective_attribute_value_keys()
 
-            AttributeCountCsv().print_csv_by_task(
-                counter_list_by_task, output_file, prior_attribute_columns=attribute_columns
-            )
+            AttributeCountCsv().print_csv_by_task(counter_list_by_task, output_file, prior_attribute_columns=attribute_columns)
 
     def print_annotation_counter_json_by_input_data(
         self,
@@ -1047,7 +1027,7 @@ class ListAnnotationCount(AbstractCommandLineInterface):
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and args.annotation is None:
             print(
-                f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",  # noqa: E501
+                f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
                 file=sys.stderr,
             )
             return False
@@ -1062,18 +1042,12 @@ class ListAnnotationCount(AbstractCommandLineInterface):
 
         project_id: Optional[str] = args.project_id
         if project_id is not None:
-            super().validate_project(
-                project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
-            )
+            super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         annotation_path = Path(args.annotation) if args.annotation is not None else None
 
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
-        task_query = (
-            TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query))
-            if args.task_query is not None
-            else None
-        )
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
         group_by = GroupBy(args.group_by)
         csv_type = CsvType(args.type)
@@ -1125,7 +1099,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser = ArgumentParser(parser)
 
     parser.add_argument(
-        "--annotation", type=str, help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。"
+        "--annotation",
+        type=str,
+        help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。",
     )
 
     parser.add_argument(
@@ -1190,8 +1166,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "各ラベル、各属性値のアノテーション数を出力します。"
     description = "各ラベル、各属性値のアノテーション数を、タスクごと/入力データごとに出力します。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -195,7 +195,7 @@ class ListAnnotationCounterByInputData:
             simple_annotation: JSONファイルの内容
         """
 
-        def convert_attribute_value_to_key(value: Union[bool, str, int, float]) -> str:
+        def convert_attribute_value_to_key(value: Union[bool, str, float]) -> str:
             if isinstance(value, bool):
                 # bool値をCSVの列名やJSONのキーとして扱う場合、`True/False`だとPythonに依存したように見えてしまうので（本当？）、`true/false`に変換する  # noqa: E501
                 if value:

--- a/annofabcli/statistics/list_worktime.py
+++ b/annofabcli/statistics/list_worktime.py
@@ -39,9 +39,7 @@ def _get_worktime_dict_from_event(event: WorktimeFromTaskHistoryEvent) -> Workti
 
         while dt_tmp_start.date() < dt_end.date():
             dt_next_date = dt_tmp_start.date() + datetime.timedelta(days=1)
-            dt_tmp_end = datetime.datetime(
-                year=dt_next_date.year, month=dt_next_date.month, day=dt_next_date.day, tzinfo=jst_tzinfo
-            )
+            dt_tmp_end = datetime.datetime(year=dt_next_date.year, month=dt_next_date.month, day=dt_next_date.day, tzinfo=jst_tzinfo)
             worktime_hour = (dt_tmp_end - dt_tmp_start).total_seconds() / 3600
             dict_result[(str(dt_tmp_start.date()), event.account_id, event.phase)] = worktime_hour
             dt_tmp_start = dt_tmp_end
@@ -62,9 +60,7 @@ def get_worktime_dict_from_event_list(task_history_event_list: list[WorktimeFrom
     return dict_result
 
 
-def get_df_worktime(
-    task_history_event_list: list[WorktimeFromTaskHistoryEvent], member_list: list[dict[str, Any]]
-) -> pandas.DataFrame:
+def get_df_worktime(task_history_event_list: list[WorktimeFromTaskHistoryEvent], member_list: list[dict[str, Any]]) -> pandas.DataFrame:
     dict_worktime = get_worktime_dict_from_event_list(task_history_event_list)
 
     s = pandas.Series(
@@ -88,13 +84,9 @@ def get_df_worktime(
         if column not in df.columns:
             df[column] = 0
 
-    df.fillna(
-        {"annotation_worktime_hour": 0, "inspection_worktime_hour": 0, "acceptance_worktime_hour": 0}, inplace=True
-    )
+    df.fillna({"annotation_worktime_hour": 0, "inspection_worktime_hour": 0, "acceptance_worktime_hour": 0}, inplace=True)
 
-    df["worktime_hour"] = (
-        df["annotation_worktime_hour"] + df["inspection_worktime_hour"] + df["acceptance_worktime_hour"]
-    )
+    df["worktime_hour"] = df["annotation_worktime_hour"] + df["inspection_worktime_hour"] + df["acceptance_worktime_hour"]
 
     df_member = pandas.DataFrame(member_list)[["account_id", "user_id", "username", "biography"]]
 
@@ -127,9 +119,7 @@ class ListWorktimeFromTaskHistoryEvent(AbstractCommandLineInterface):
             project_id,
             task_history_event_json=task_history_event_json,
         )
-        project_member_list = self.service.wrapper.get_all_project_members(
-            project_id, query_params={"include_inactive_member": ""}
-        )
+        project_member_list = self.service.wrapper.get_all_project_members(project_id, query_params={"include_inactive_member": ""})
         df = get_df_worktime(worktime_list, project_member_list)
 
         if len(worktime_list) > 0:

--- a/annofabcli/statistics/subcommand_statistics.py
+++ b/annofabcli/statistics/subcommand_statistics.py
@@ -31,8 +31,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "統計関係のサブコマンド"
     description = "統計関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/statistics/summarize_task_count.py
+++ b/annofabcli/statistics/summarize_task_count.py
@@ -106,9 +106,7 @@ def create_task_count_summary(task_list: List[Task], number_of_inspections: int)
         task["simple_status"] = SimpleTaskStatus.from_task_status(status).value
 
     df = pandas.DataFrame(task_list)
-    df["phase"] = pandas.Categorical(
-        df["phase"], categories=[TaskPhase.ANNOTATION.value, TaskPhase.INSPECTION.value, TaskPhase.ACCEPTANCE.value]
-    )
+    df["phase"] = pandas.Categorical(df["phase"], categories=[TaskPhase.ANNOTATION.value, TaskPhase.INSPECTION.value, TaskPhase.ACCEPTANCE.value])
     df["simple_status"] = pandas.Categorical(
         df["simple_status"],
         categories=[
@@ -119,7 +117,7 @@ def create_task_count_summary(task_list: List[Task], number_of_inspections: int)
     )
 
     # `observed=True`を指定する理由：以下の警告に対応するため
-    # FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas.  # noqa: E501
+    # FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas.
     # Specify observed=False to silence this warning and retain the current behavior
     summary_df = df.pivot_table(
         values="task_id", index=["step", "phase", "phase_stage", "simple_status"], aggfunc="count", observed=False
@@ -141,16 +139,12 @@ class SummarizeTaskCount(AbstractCommandLineInterface):
         project, _ = self.service.api.get_project(project_id)
         return project["configuration"]["number_of_inspections"]
 
-    def summarize_task_count(
-        self, project_id: str, *, task_json_path: Optional[Path], is_latest: bool, is_execute_get_tasks_api: bool
-    ) -> None:
+    def summarize_task_count(self, project_id: str, *, task_json_path: Optional[Path], is_latest: bool, is_execute_get_tasks_api: bool) -> None:
         if is_execute_get_tasks_api:
             super().validate_project(project_id)
         else:
             # タスク全件ファイルをダウンロードするので、オーナロールかアノテーションユーザロールであることを確認する。
-            super().validate_project(
-                project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
-            )
+            super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         if is_execute_get_tasks_api:
             task_list = self.service.wrapper.get_all_tasks(project_id)
@@ -165,9 +159,7 @@ class SummarizeTaskCount(AbstractCommandLineInterface):
         task_count_df = create_task_count_summary(task_list, number_of_inspections=number_of_inspections)
         annofabcli.common.utils.print_csv(task_count_df, output=self.output, to_csv_kwargs=self.csv_format)
 
-    def get_task_list_with_downloading_file(
-        self, project_id: str, task_json_path: Optional[Path], is_latest: bool
-    ) -> List[Task]:
+    def get_task_list_with_downloading_file(self, project_id: str, task_json_path: Optional[Path], is_latest: bool) -> List[Task]:
         if task_json_path is None:
             cache_dir = annofabcli.common.utils.get_cache_dir()
             task_json_path = cache_dir / f"task-{project_id}.json"
@@ -207,7 +199,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--latest", action="store_true", help="最新のタスク一覧ファイルを参照します。このオプションを指定すると、タスク一覧ファイルを更新するのに数分待ちます。"
+        "--latest",
+        action="store_true",
+        help="最新のタスク一覧ファイルを参照します。このオプションを指定すると、タスク一覧ファイルを更新するのに数分待ちます。",
     )
 
     parser.add_argument(
@@ -233,8 +227,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "タスクのフェーズ、ステータス、ステップごとにタスク数を出力します。"
     description = "タスクのフェーズ、ステータス、ステップごとにタスク数を、CSV形式で出力します。"
     epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行できます。ただし``--execute_get_tasks_api``を指定した場合は、どのロールでも実行できます。"
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/statistics/summarize_task_count.py
+++ b/annofabcli/statistics/summarize_task_count.py
@@ -207,7 +207,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--execute_get_tasks_api",
         action="store_true",
-        help="[EXPERIMENTAL] ``getTasks`` APIを実行して、タスク情報を参照します。タスク数が少ないプロジェクトで、最新のタスク情報を参照したいときに利用できます。",
+        help="[EXPERIMENTAL] ``getTasks`` APIを実行して、タスク情報を参照します。タスク数が少ないプロジェクトで、最新のタスク情報を参照したいときに利用できます。",  # noqa: E501
     )
 
     argument_parser.add_csv_format()
@@ -226,7 +226,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_name = "summarize_task_count"
     subcommand_help = "タスクのフェーズ、ステータス、ステップごとにタスク数を出力します。"
     description = "タスクのフェーズ、ステータス、ステップごとにタスク数を、CSV形式で出力します。"
-    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行できます。ただし``--execute_get_tasks_api``を指定した場合は、どのロールでも実行できます。"
+    epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行できます。ただし``--execute_get_tasks_api``を指定した場合は、どのロールでも実行できます。"  # noqa: E501
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/statistics/summarize_task_count_by_task_id_group.py
+++ b/annofabcli/statistics/summarize_task_count_by_task_id_group.py
@@ -122,11 +122,7 @@ def create_task_count_summary_df(
 
     if task_id_groups is not None:
         df_tmp = pandas.DataFrame(
-            [
-                (task_id_group, task_id)
-                for task_id_group, task_id_list in task_id_groups.items()
-                for task_id in task_id_list
-            ],
+            [(task_id_group, task_id) for task_id_group, task_id_list in task_id_groups.items() for task_id in task_id_list],
             columns=("task_id_group", "task_id"),
         )
         df_task = df_task.merge(df_tmp, on="task_id", how="left")
@@ -144,9 +140,7 @@ def create_task_count_summary_df(
         add_columns_if_not_exists(df_summary, status.value)
 
     df_summary["sum"] = (
-        df_task.pivot_table(values="task_id", index=["task_id_group"], aggfunc="count", fill_value=0)
-        .reset_index()
-        .fillna(0)["task_id"]
+        df_task.pivot_table(values="task_id", index=["task_id_group"], aggfunc="count", fill_value=0).reset_index().fillna(0)["task_id"]
     )
 
     return df_summary
@@ -175,16 +169,12 @@ class SummarizeTaskCountByTaskId(AbstractCommandLineInterface):
             task_json_path = cache_dir / f"{project_id}-task.json"
 
             downloading_obj = DownloadingFile(self.service)
-            downloading_obj.download_task_json(
-                project_id, dest_path=str(task_json_path), is_latest=args.latest, wait_options=wait_options
-            )
+            downloading_obj.download_task_json(project_id, dest_path=str(task_json_path), is_latest=args.latest, wait_options=wait_options)
 
         with open(task_json_path, encoding="utf-8") as f:
             task_list = json.load(f)
 
-        df = create_task_count_summary_df(
-            task_list, task_id_delimiter=args.task_id_delimiter, task_id_groups=get_json_from_args(args.task_id_groups)
-        )
+        df = create_task_count_summary_df(task_list, task_id_delimiter=args.task_id_delimiter, task_id_groups=get_json_from_args(args.task_id_groups))
         self.print_summarize_task_count(df)
 
 
@@ -214,7 +204,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--latest", action="store_true", help="最新のタスク一覧ファイルを参照します。このオプションを指定すると、タスク一覧ファイルを更新するのに数分待ちます。"
+        "--latest",
+        action="store_true",
+        help="最新のタスク一覧ファイルを参照します。このオプションを指定すると、タスク一覧ファイルを更新するのに数分待ちます。",
     )
 
     parser.add_argument(

--- a/annofabcli/statistics/summarize_task_count_by_user.py
+++ b/annofabcli/statistics/summarize_task_count_by_user.py
@@ -134,9 +134,7 @@ class SummarizeTaskCountByUser(AbstractCommandLineInterface):
             task_json_path = cache_dir / f"{project_id}-task.json"
 
             downloading_obj = DownloadingFile(self.service)
-            downloading_obj.download_task_json(
-                project_id, dest_path=str(task_json_path), is_latest=args.latest, wait_options=wait_options
-            )
+            downloading_obj.download_task_json(project_id, dest_path=str(task_json_path), is_latest=args.latest, wait_options=wait_options)
 
         with open(task_json_path, encoding="utf-8") as f:
             task_list = json.load(f)
@@ -160,7 +158,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--latest", action="store_true", help="最新のタスク一覧ファイルを参照します。このオプションを指定すると、タスク一覧ファイルを更新するのに数分待ちます。"
+        "--latest",
+        action="store_true",
+        help="最新のタスク一覧ファイルを参照します。このオプションを指定すると、タスク一覧ファイルを更新するのに数分待ちます。",
     )
 
     parser.add_argument(
@@ -190,8 +190,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "ユーザごとに、担当しているタスク数を出力します。"
     description = "ユーザごとに、担当しているタスク数をCSV形式で出力します。"
     epilog = "アノテーションユーザまたはオーナロールを持つユーザで実行してください。"
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/statistics/table.py
+++ b/annofabcli/statistics/table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Any, Dict, List, Optional
 

--- a/annofabcli/statistics/table.py
+++ b/annofabcli/statistics/table.py
@@ -79,9 +79,7 @@ class Table:
         account_id_list = [
             e["account_id"]
             for e in task_history_list
-            if TaskPhase(e["phase"]) == phase
-            and e["account_id"] is not None
-            and isoduration_to_hour(e["accumulated_labor_time_milliseconds"]) > 0
+            if TaskPhase(e["phase"]) == phase and e["account_id"] is not None and isoduration_to_hour(e["accumulated_labor_time_milliseconds"]) > 0
         ]
         return len(set(account_id_list)) >= 2
 
@@ -126,9 +124,7 @@ class Table:
 
     def _get_project_members_dict(self) -> Dict[str, Any]:
         project_members_dict = {}
-        project_members = self.annofab_service.wrapper.get_all_project_members(
-            self.project_id, query_params={"include_inactive_member": True}
-        )
+        project_members = self.annofab_service.wrapper.get_all_project_members(self.project_id, query_params={"include_inactive_member": True})
         for member in project_members:
             project_members_dict[member["account_id"]] = member
         return project_members_dict
@@ -139,10 +135,7 @@ class Table:
         タスク履歴関係の情報を設定する
         """
 
-        task["worktime_hour"] = sum(
-            annofabcli.common.utils.isoduration_to_hour(e["accumulated_labor_time_milliseconds"])
-            for e in task_histories
-        )
+        task["worktime_hour"] = sum(annofabcli.common.utils.isoduration_to_hour(e["accumulated_labor_time_milliseconds"]) for e in task_histories)
 
         return task
 

--- a/annofabcli/statistics/visualization/dataframe/actual_worktime.py
+++ b/annofabcli/statistics/visualization/dataframe/actual_worktime.py
@@ -19,7 +19,7 @@ class ActualWorktime:
     `project_id`,`date`, `account_id`のペアがユニークなキーです。
     """
 
-    columns = ["project_id", "date", "account_id", "actual_worktime_hour"]
+    columns = ["project_id", "date", "account_id", "actual_worktime_hour"]  # noqa: RUF012
 
     @classmethod
     def required_columns_exist(cls, df: pandas.DataFrame) -> bool:

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -52,9 +52,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
 
     def _get_default_user_id_list(self) -> list[str]:
         return (
-            self.df.sort_values(by=f"first_{self.phase.value}_started_datetime", ascending=False)[
-                f"first_{self.phase.value}_user_id"
-            ]
+            self.df.sort_values(by=f"first_{self.phase.value}_started_datetime", ascending=False)[f"first_{self.phase.value}_user_id"]
             .dropna()
             .unique()
             .tolist()
@@ -99,11 +97,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
             """
             xy_columns = set(itertools.chain.from_iterable(columns for columns in columns_list))
             tooltip_columns = set(
-                itertools.chain.from_iterable(
-                    line_graph.tooltip_columns
-                    for line_graph in line_graph_list
-                    if line_graph.tooltip_columns is not None
-                )
+                itertools.chain.from_iterable(line_graph.tooltip_columns for line_graph in line_graph_list if line_graph.tooltip_columns is not None)
             )
             return list(xy_columns | tooltip_columns)
 
@@ -183,9 +177,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         累積情報が格納されたDataFrameを生成する。
         """
         # 教師付の開始時刻でソートして、indexを更新する
-        df = self.df.sort_values(["first_annotation_user_id", "first_annotation_started_datetime"]).reset_index(
-            drop=True
-        )
+        df = self.df.sort_values(["first_annotation_user_id", "first_annotation_started_datetime"]).reset_index(drop=True)
         # タスクの累計数を取得するために設定する
         df["task_count"] = 1
         # 教師付の作業者でgroupby
@@ -428,9 +420,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         Args:
             task_df: タスク一覧のDataFrame. 列が追加される
         """
-        df = self.df.sort_values(["first_inspection_user_id", "first_inspection_started_datetime"]).reset_index(
-            drop=True
-        )
+        df = self.df.sort_values(["first_inspection_user_id", "first_inspection_started_datetime"]).reset_index(drop=True)
 
         # タスクの累計数を取得するために設定する
         df["task_count"] = 1
@@ -625,9 +615,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         """
         最初のアノテーション作業の開始時刻の順にソートして、受入者に関する累計値を算出する
         """
-        df = self.df.sort_values(["first_acceptance_user_id", "first_acceptance_started_datetime"]).reset_index(
-            drop=True
-        )
+        df = self.df.sort_values(["first_acceptance_user_id", "first_acceptance_started_datetime"]).reset_index(drop=True)
         # タスクの累計数を取得するために設定する
         df["task_count"] = 1
 

--- a/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
@@ -138,16 +138,10 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
         for denominator_column in ["input_data_count", "annotation_count"]:
             for phase in ["annotation", "inspection", "acceptance"]:
                 numerator_column = f"{phase}_worktime_hour"
-                sum_df[f"{numerator_column}/{denominator_column}"] = (
-                    sum_df[numerator_column] / sum_df[denominator_column]
-                )
+                sum_df[f"{numerator_column}/{denominator_column}"] = sum_df[numerator_column] / sum_df[denominator_column]
 
-        sum_df["inspection_comment_count/annotation_count"] = (
-            sum_df["inspection_comment_count"] / sum_df["annotation_count"]
-        )
-        sum_df["inspection_comment_count/input_data_count"] = (
-            sum_df["inspection_comment_count"] / sum_df["annotation_count"]
-        )
+        sum_df["inspection_comment_count/annotation_count"] = sum_df["inspection_comment_count"] / sum_df["annotation_count"]
+        sum_df["inspection_comment_count/input_data_count"] = sum_df["inspection_comment_count"] / sum_df["annotation_count"]
 
         return cls(sum_df)
 
@@ -218,12 +212,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
         if target_user_id_list is not None:
             user_id_list = target_user_id_list
         else:
-            user_id_list = (
-                df.sort_values(by="first_annotation_started_date", ascending=False)["first_annotation_user_id"]
-                .dropna()
-                .unique()
-                .tolist()
-            )
+            user_id_list = df.sort_values(by="first_annotation_started_date", ascending=False)["first_annotation_user_id"].dropna().unique().tolist()
 
         user_id_list = get_plotted_user_id_list(user_id_list)
 
@@ -295,17 +284,13 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
                 continue
 
             df_subset = self._get_df_sequential_date(df_subset)
-            df_subset["annotation_worktime_minute/annotation_count"] = (
-                df_subset["annotation_worktime_hour"] * 60 / df_subset["annotation_count"]
-            )
+            df_subset["annotation_worktime_minute/annotation_count"] = df_subset["annotation_worktime_hour"] * 60 / df_subset["annotation_count"]
             df_subset[f"annotation_worktime_minute/annotation_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
-                get_weekly_sum(df_subset["annotation_worktime_hour"])
-                * 60
-                / get_weekly_sum(df_subset["annotation_count"])
+                get_weekly_sum(df_subset["annotation_worktime_hour"]) * 60 / get_weekly_sum(df_subset["annotation_count"])
             )
-            df_subset[
-                f"inspection_comment_count/annotation_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"
-            ] = get_weekly_sum(df_subset["inspection_comment_count"]) / get_weekly_sum(df_subset["annotation_count"])
+            df_subset[f"inspection_comment_count/annotation_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_sum(
+                df_subset["inspection_comment_count"]
+            ) / get_weekly_sum(df_subset["annotation_count"])
 
             source = ColumnDataSource(data=df_subset)
             color = get_color_from_palette(user_index)
@@ -354,12 +339,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
         if target_user_id_list is not None:
             user_id_list = target_user_id_list
         else:
-            user_id_list = (
-                df.sort_values(by="first_annotation_started_date", ascending=False)["first_annotation_user_id"]
-                .dropna()
-                .unique()
-                .tolist()
-            )
+            user_id_list = df.sort_values(by="first_annotation_started_date", ascending=False)["first_annotation_user_id"].dropna().unique().tolist()
 
         user_id_list = get_plotted_user_id_list(user_id_list)
 
@@ -433,18 +413,14 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
                 continue
 
             df_subset = self._get_df_sequential_date(df_subset)
-            df_subset["annotation_worktime_minute/input_data_count"] = (
-                df_subset["annotation_worktime_hour"] * 60 / df_subset["input_data_count"]
-            )
+            df_subset["annotation_worktime_minute/input_data_count"] = df_subset["annotation_worktime_hour"] * 60 / df_subset["input_data_count"]
 
             df_subset[f"annotation_worktime_minute/input_data_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
-                get_weekly_sum(df_subset["annotation_worktime_hour"])
-                * 60
-                / get_weekly_sum(df_subset["input_data_count"])
+                get_weekly_sum(df_subset["annotation_worktime_hour"]) * 60 / get_weekly_sum(df_subset["input_data_count"])
             )
-            df_subset[
-                f"inspection_comment_count/input_data_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"
-            ] = get_weekly_sum(df_subset["inspection_comment_count"]) / get_weekly_sum(df_subset["input_data_count"])
+            df_subset[f"inspection_comment_count/input_data_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_sum(
+                df_subset["inspection_comment_count"]
+            ) / get_weekly_sum(df_subset["input_data_count"])
 
             source = ColumnDataSource(data=df_subset)
             color = get_color_from_palette(user_index)
@@ -500,11 +476,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
             for denominator in ["input_data_count", "annotation_count"]
         ]
 
-        columns = (
-            production_columns
-            + velocity_columns
-            + ["inspection_comment_count/input_data_count", "inspection_comment_count/annotation_count"]
-        )
+        columns = production_columns + velocity_columns + ["inspection_comment_count/input_data_count", "inspection_comment_count/annotation_count"]
 
         print_csv(self.df[columns], output=str(output_file))
 
@@ -548,12 +520,8 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
             ]
         ].sum(numeric_only=True)
 
-        sum_df["inspection_worktime_hour/annotation_count"] = (
-            sum_df["inspection_worktime_hour"] / sum_df["annotation_count"]
-        )
-        sum_df["inspection_worktime_hour/input_data_count"] = (
-            sum_df["inspection_worktime_hour"] / sum_df["input_data_count"]
-        )
+        sum_df["inspection_worktime_hour/annotation_count"] = sum_df["inspection_worktime_hour"] / sum_df["annotation_count"]
+        sum_df["inspection_worktime_hour/input_data_count"] = sum_df["inspection_worktime_hour"] / sum_df["input_data_count"]
 
         return cls(sum_df)
 
@@ -612,12 +580,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
         if target_user_id_list is not None:
             user_id_list = target_user_id_list
         else:
-            user_id_list = (
-                df.sort_values(by="first_inspection_started_date", ascending=False)["first_inspection_user_id"]
-                .dropna()
-                .unique()
-                .tolist()
-            )
+            user_id_list = df.sort_values(by="first_inspection_started_date", ascending=False)["first_inspection_user_id"].dropna().unique().tolist()
 
         user_id_list = get_plotted_user_id_list(user_id_list)
 
@@ -673,13 +636,9 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
                 continue
 
             df_subset = self._get_df_sequential_date(df_subset)
-            df_subset["inspection_worktime_minute/annotation_count"] = (
-                df_subset["inspection_worktime_hour"] * 60 / df_subset["annotation_count"]
-            )
+            df_subset["inspection_worktime_minute/annotation_count"] = df_subset["inspection_worktime_hour"] * 60 / df_subset["annotation_count"]
             df_subset[f"inspection_worktime_minute/annotation_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
-                get_weekly_sum(df_subset["inspection_worktime_hour"])
-                * 60
-                / get_weekly_sum(df_subset["annotation_count"])
+                get_weekly_sum(df_subset["inspection_worktime_hour"]) * 60 / get_weekly_sum(df_subset["annotation_count"])
             )
 
             source = ColumnDataSource(data=df_subset)
@@ -728,12 +687,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
         if target_user_id_list is not None:
             user_id_list = target_user_id_list
         else:
-            user_id_list = (
-                df.sort_values(by="first_inspection_started_date", ascending=False)["first_inspection_user_id"]
-                .dropna()
-                .unique()
-                .tolist()
-            )
+            user_id_list = df.sort_values(by="first_inspection_started_date", ascending=False)["first_inspection_user_id"].dropna().unique().tolist()
 
         user_id_list = get_plotted_user_id_list(user_id_list)
 
@@ -790,13 +744,9 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
                 continue
 
             df_subset = self._get_df_sequential_date(df_subset)
-            df_subset["inspection_worktime_minute/input_data_count"] = (
-                df_subset["inspection_worktime_hour"] * 60 / df_subset["input_data_count"]
-            )
+            df_subset["inspection_worktime_minute/input_data_count"] = df_subset["inspection_worktime_hour"] * 60 / df_subset["input_data_count"]
             df_subset[f"inspection_worktime_minute/input_data_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
-                get_weekly_sum(df_subset["inspection_worktime_hour"])
-                * 60
-                / get_weekly_sum(df_subset["input_data_count"])
+                get_weekly_sum(df_subset["inspection_worktime_hour"]) * 60 / get_weekly_sum(df_subset["input_data_count"])
             )
 
             source = ColumnDataSource(data=df_subset)
@@ -847,9 +797,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
             "inspection_worktime_hour",
         ]
 
-        velocity_columns = [
-            f"inspection_worktime_hour/{denominator}" for denominator in ["input_data_count", "annotation_count"]
-        ]
+        velocity_columns = [f"inspection_worktime_hour/{denominator}" for denominator in ["input_data_count", "annotation_count"]]
 
         columns = production_columns + velocity_columns
 
@@ -895,12 +843,8 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
             ]
         ].sum(numeric_only=True)
 
-        sum_df["acceptance_worktime_hour/annotation_count"] = (
-            sum_df["acceptance_worktime_hour"] / sum_df["annotation_count"]
-        )
-        sum_df["acceptance_worktime_hour/input_data_count"] = (
-            sum_df["acceptance_worktime_hour"] / sum_df["input_data_count"]
-        )
+        sum_df["acceptance_worktime_hour/annotation_count"] = sum_df["acceptance_worktime_hour"] / sum_df["annotation_count"]
+        sum_df["acceptance_worktime_hour/input_data_count"] = sum_df["acceptance_worktime_hour"] / sum_df["input_data_count"]
 
         return AcceptorProductivityPerDate(sum_df)
 
@@ -959,12 +903,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
         if target_user_id_list is not None:
             user_id_list = target_user_id_list
         else:
-            user_id_list = (
-                df.sort_values(by="first_acceptance_started_date", ascending=False)["first_acceptance_user_id"]
-                .dropna()
-                .unique()
-                .tolist()
-            )
+            user_id_list = df.sort_values(by="first_acceptance_started_date", ascending=False)["first_acceptance_user_id"].dropna().unique().tolist()
 
         user_id_list = get_plotted_user_id_list(user_id_list)
 
@@ -1021,14 +960,10 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
                 continue
 
             df_subset = self._get_df_sequential_date(df_subset)
-            df_subset["acceptance_worktime_minute/annotation_count"] = (
-                df_subset["acceptance_worktime_hour"] * 60 / df_subset["annotation_count"]
-            )
+            df_subset["acceptance_worktime_minute/annotation_count"] = df_subset["acceptance_worktime_hour"] * 60 / df_subset["annotation_count"]
 
             df_subset[f"acceptance_worktime_minute/annotation_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
-                get_weekly_sum(df_subset["acceptance_worktime_hour"])
-                * 60
-                / get_weekly_sum(df_subset["annotation_count"])
+                get_weekly_sum(df_subset["acceptance_worktime_hour"]) * 60 / get_weekly_sum(df_subset["annotation_count"])
             )
 
             source = ColumnDataSource(data=df_subset)
@@ -1078,12 +1013,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
         if target_user_id_list is not None:
             user_id_list = target_user_id_list
         else:
-            user_id_list = (
-                df.sort_values(by="first_acceptance_started_date", ascending=False)["first_acceptance_user_id"]
-                .dropna()
-                .unique()
-                .tolist()
-            )
+            user_id_list = df.sort_values(by="first_acceptance_started_date", ascending=False)["first_acceptance_user_id"].dropna().unique().tolist()
 
         user_id_list = get_plotted_user_id_list(user_id_list)
 
@@ -1139,13 +1069,9 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
                 continue
 
             df_subset = self._get_df_sequential_date(df_subset)
-            df_subset["acceptance_worktime_minute/input_data_count"] = (
-                df_subset["acceptance_worktime_hour"] * 60 / df_subset["input_data_count"]
-            )
+            df_subset["acceptance_worktime_minute/input_data_count"] = df_subset["acceptance_worktime_hour"] * 60 / df_subset["input_data_count"]
             df_subset[f"acceptance_worktime_minute/input_data_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
-                get_weekly_sum(df_subset["acceptance_worktime_hour"])
-                * 60
-                / get_weekly_sum(df_subset["input_data_count"])
+                get_weekly_sum(df_subset["acceptance_worktime_hour"]) * 60 / get_weekly_sum(df_subset["input_data_count"])
             )
 
             source = ColumnDataSource(data=df_subset)
@@ -1196,9 +1122,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
             "acceptance_worktime_hour",
         ]
 
-        velocity_columns = [
-            f"acceptance_worktime_hour/{denominator}" for denominator in ["input_data_count", "annotation_count"]
-        ]
+        velocity_columns = [f"acceptance_worktime_hour/{denominator}" for denominator in ["input_data_count", "annotation_count"]]
 
         columns = production_columns + velocity_columns
 

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -57,9 +57,7 @@ class ProjectPerformance:
         else:
             try:
                 project_info = project_dir.read_project_info()
-                return pandas.Series(
-                    [project_info.project_id, project_info.project_title, project_info.input_data_type], index=index
-                )
+                return pandas.Series([project_info.project_id, project_info.project_title, project_info.input_data_type], index=index)
 
             except Exception:
                 logger.warning(f"'{project_dir}'の`project_info.json`の読み込みに失敗しました。", exc_info=True)
@@ -130,9 +128,7 @@ class ProjectWorktimePerMonth:
         df = project_dir.read_worktime_per_date_user().df.copy()
         df["dt_date"] = pandas.to_datetime(df["date"], format="ISO8601")
 
-        series = df.groupby(pandas.Grouper(key="dt_date", freq=get_frequency_of_monthend())).sum(numeric_only=True)[
-            worktime_column.value
-        ]
+        series = df.groupby(pandas.Grouper(key="dt_date", freq=get_frequency_of_monthend())).sum(numeric_only=True)[worktime_column.value]
         # indexを"2022-04"という形式にする
         new_index = [str(dt)[0:7] for dt in series.index]
         result = pandas.Series(series.values, index=new_index)
@@ -140,9 +136,7 @@ class ProjectWorktimePerMonth:
         return result
 
     @classmethod
-    def from_project_dirs(
-        cls, project_dir_list: list[ProjectDir], worktime_column: WorktimeColumn
-    ) -> ProjectWorktimePerMonth:
+    def from_project_dirs(cls, project_dir_list: list[ProjectDir], worktime_column: WorktimeColumn) -> ProjectWorktimePerMonth:
         """
         プロジェクトディレクトリのlistから、インスタンスを生成します。
         Args:

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -85,7 +85,7 @@ class ProjectPerformance:
     def from_project_dirs(cls, project_dir_list: list[ProjectDir]) -> ProjectPerformance:
         row_list: list[pandas.Series] = []
         for project_dir in project_dir_list:
-            row_list.append(cls._get_series_from_project_dir(project_dir))
+            row_list.append(cls._get_series_from_project_dir(project_dir))  # noqa: PERF401
 
         return cls(pandas.DataFrame(row_list))
 

--- a/annofabcli/statistics/visualization/dataframe/task.py
+++ b/annofabcli/statistics/visualization/dataframe/task.py
@@ -153,9 +153,7 @@ class Task:
 
         # 自動検査したタスクを除外して、検査時間をグラフ化する
         df_ignore_inspection_skipped = df.query("inspection_worktime_hour.notnull() and not inspection_is_skipped")
-        sub_title = get_sub_title_from_series(
-            df_ignore_inspection_skipped["inspection_worktime_hour"], decimals=decimals
-        )
+        sub_title = get_sub_title_from_series(df_ignore_inspection_skipped["inspection_worktime_hour"], decimals=decimals)
         figure_list.append(
             get_histogram_figure(
                 df_ignore_inspection_skipped["inspection_worktime_hour"],
@@ -168,9 +166,7 @@ class Task:
         )
 
         df_ignore_acceptance_skipped = df.query("acceptance_worktime_hour.notnull() and not acceptance_is_skipped")
-        sub_title = get_sub_title_from_series(
-            df_ignore_acceptance_skipped["acceptance_worktime_hour"], decimals=decimals
-        )
+        sub_title = get_sub_title_from_series(df_ignore_acceptance_skipped["acceptance_worktime_hour"], decimals=decimals)
         figure_list.append(
             get_histogram_figure(
                 df_ignore_acceptance_skipped["acceptance_worktime_hour"],
@@ -221,16 +217,10 @@ class Task:
         logger.debug(f"{output_file} を出力します。")
         df = self.df.copy()
 
-        df["diff_days_to_first_inspection_started"] = diff_days(
-            df["first_inspection_started_datetime"], df["first_annotation_started_datetime"]
-        )
-        df["diff_days_to_first_acceptance_started"] = diff_days(
-            df["first_acceptance_started_datetime"], df["first_annotation_started_datetime"]
-        )
+        df["diff_days_to_first_inspection_started"] = diff_days(df["first_inspection_started_datetime"], df["first_annotation_started_datetime"])
+        df["diff_days_to_first_acceptance_started"] = diff_days(df["first_acceptance_started_datetime"], df["first_annotation_started_datetime"])
 
-        df["diff_days_to_first_acceptance_completed"] = diff_days(
-            df["first_acceptance_completed_datetime"], df["first_annotation_started_datetime"]
-        )
+        df["diff_days_to_first_acceptance_completed"] = diff_days(df["first_acceptance_completed_datetime"], df["first_annotation_started_datetime"])
 
         histogram_list = [
             {"column": "annotation_count", "x_axis_label": "アノテーション数", "title": "アノテーション数"},
@@ -273,9 +263,7 @@ class Task:
             x_axis_label = hist["x_axis_label"]
             ser = df[column].dropna()
             sub_title = get_sub_title_from_series(ser, decimals=2)
-            fig = get_histogram_figure(
-                ser, x_axis_label=x_axis_label, y_axis_label="タスク数", title=title, sub_title=sub_title, bins=bins
-            )
+            fig = get_histogram_figure(ser, x_axis_label=x_axis_label, y_axis_label="タスク数", title=title, sub_title=sub_title, bins=bins)
             figure_list.append(fig)
 
         bokeh_obj = bokeh.layouts.gridplot(figure_list, ncols=4)  # type: ignore[arg-type]

--- a/annofabcli/statistics/visualization/dataframe/task_history.py
+++ b/annofabcli/statistics/visualization/dataframe/task_history.py
@@ -64,9 +64,7 @@ class TaskHistory:
         for task_history_list in task_histories.values():
             for task_history in task_history_list:
                 new_task_history = copy.deepcopy(task_history)
-                new_task_history["worktime_hour"] = isoduration_to_hour(
-                    task_history["accumulated_labor_time_milliseconds"]
-                )
+                new_task_history["worktime_hour"] = isoduration_to_hour(task_history["accumulated_labor_time_milliseconds"])
                 all_task_history_list.append(new_task_history)
 
         if len(all_task_history_list) > 0:

--- a/annofabcli/statistics/visualization/dataframe/task_history.py
+++ b/annofabcli/statistics/visualization/dataframe/task_history.py
@@ -23,7 +23,7 @@ class TaskHistory:
     * worktime_hour
     """
 
-    columns = ["project_id", "task_id", "phase", "phase_stage", "account_id", "worktime_hour"]
+    columns = ["project_id", "task_id", "phase", "phase_stage", "account_id", "worktime_hour"]  # noqa: RUF012
 
     @classmethod
     def required_columns_exist(cls, df: pandas.DataFrame) -> bool:

--- a/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
+++ b/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
@@ -24,7 +24,7 @@ class TaskWorktimeByPhaseUser:
         * 品質情報（指摘コメント数、差し戻し回数）
     """
 
-    columns = [
+    columns = [  # noqa: RUF012
         "project_id",
         "task_id",
         "status",

--- a/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
+++ b/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
@@ -76,9 +76,7 @@ class TaskWorktimeByPhaseUser:
         return True
 
     @classmethod
-    def from_df_wrapper(
-        cls, task_history: TaskHistory, user: User, task: Task, project_id: str
-    ) -> TaskWorktimeByPhaseUser:
+    def from_df_wrapper(cls, task_history: TaskHistory, user: User, task: Task, project_id: str) -> TaskWorktimeByPhaseUser:
         """
         AnnoWorkの実績時間から、作業者ごとに生産性を算出する。
 
@@ -181,9 +179,7 @@ class TaskWorktimeByPhaseUser:
         return TaskWorktimeByPhaseUser(df)
 
     @staticmethod
-    def _create_annotation_count_ratio_df(
-        task_history_df: pandas.DataFrame, task_df: pandas.DataFrame
-    ) -> pandas.DataFrame:
+    def _create_annotation_count_ratio_df(task_history_df: pandas.DataFrame, task_df: pandas.DataFrame) -> pandas.DataFrame:
         """
         task_id, phase, (phase_index), user_idの作業時間比から、アノテーション数などの生産量を求める
 
@@ -228,9 +224,7 @@ class TaskWorktimeByPhaseUser:
             logger.warning("タスク一覧が0件です。")
             return pandas.DataFrame()
 
-        group_obj = task_history_df.groupby(["task_id", "phase", "phase_stage", "account_id"]).agg(
-            {"worktime_hour": "sum"}
-        )
+        group_obj = task_history_df.groupby(["task_id", "phase", "phase_stage", "account_id"]).agg({"worktime_hour": "sum"})
         # 担当者だけ変更して作業していないケースを除外する
         group_obj = group_obj[group_obj["worktime_hour"] > 0]
 
@@ -256,15 +250,11 @@ class TaskWorktimeByPhaseUser:
         )
         group_obj["annotation_count"] = group_obj.apply(get_annotation_count, axis="columns")
         group_obj["input_data_count"] = group_obj.apply(get_input_data_count, axis="columns")
-        group_obj["pointed_out_inspection_comment_count"] = group_obj.apply(
-            get_inspection_comment_count, axis="columns"
-        )
+        group_obj["pointed_out_inspection_comment_count"] = group_obj.apply(get_inspection_comment_count, axis="columns")
         group_obj["rejected_count"] = group_obj.apply(get_rejected_count, axis="columns")
         new_df = group_obj.reset_index()
-        new_df["pointed_out_inspection_comment_count"] = new_df["pointed_out_inspection_comment_count"] * new_df[
-            "phase"
-        ].apply(lambda e: 1 if e == TaskPhase.ANNOTATION.value else 0)
-        new_df["rejected_count"] = new_df["rejected_count"] * new_df["phase"].apply(
+        new_df["pointed_out_inspection_comment_count"] = new_df["pointed_out_inspection_comment_count"] * new_df["phase"].apply(
             lambda e: 1 if e == TaskPhase.ANNOTATION.value else 0
         )
+        new_df["rejected_count"] = new_df["rejected_count"] * new_df["phase"].apply(lambda e: 1 if e == TaskPhase.ANNOTATION.value else 0)
         return new_df

--- a/annofabcli/statistics/visualization/dataframe/user.py
+++ b/annofabcli/statistics/visualization/dataframe/user.py
@@ -17,7 +17,7 @@ class User:
     * biography
     """
 
-    columns = ["user_id", "account_id", "username", "biography"]
+    columns = ["user_id", "account_id", "username", "biography"]  # noqa: RUF012
 
     @staticmethod
     def _duplicated_keys(df: pandas.DataFrame) -> bool:

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -173,7 +173,7 @@ class UserPerformance:
 
         for phase in TaskPhase:
             if phase.value in tmp_set:
-                phase_list.append(phase.value)
+                phase_list.append(phase.value)  # noqa: PERF401
 
         return phase_list
 

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -121,13 +121,13 @@ class UserPerformance:
                 計測作業時間の合計値が0により、monitored_worktime_ratioはnanになる場合は、教師付の実績作業時間を実績作業時間の合計値になるようなmonitored_worktime_ratioに変更する
                 """
                 if row[("monitored_worktime_hour", "sum")] == 0:
-                    if phase == TaskPhase.ANNOTATION.value:  # noqa: function-uses-loop-variable
+                    if phase == TaskPhase.ANNOTATION.value:  # noqa: function-uses-loop-variable  # noqa: B023
                         return 1
                     else:
                         return 0
                 else:
                     return (
-                        row[("monitored_worktime_hour", phase)]  # noqa: function-uses-loop-variable
+                        row[("monitored_worktime_hour", phase)]  # noqa: function-uses-loop-variable  # noqa: B023
                         / row[("monitored_worktime_hour", "sum")]
                     )
 

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -110,8 +110,7 @@ class UserPerformance:
         # 集計対象タスクから算出した計測作業時間（`monitored_worktime_hour`）に対応する実績作業時間を推定で算出する
         # 具体的には、実際の計測作業時間と十先作業時間の比（`real_monitored_worktime_hour/real_actual_worktime_hour`）になるように按分する
         df[("actual_worktime_hour", "sum")] = (
-            df[("monitored_worktime_hour", "sum")]
-            / df[("real_monitored_worktime_hour/real_actual_worktime_hour", "sum")]
+            df[("monitored_worktime_hour", "sum")] / df[("real_monitored_worktime_hour/real_actual_worktime_hour", "sum")]
         )
 
         for phase in phase_list:
@@ -136,28 +135,16 @@ class UserPerformance:
             df[("monitored_worktime_ratio", phase)] = df.apply(get_monitored_worktime_ratio, axis=1)
 
             # Annofab時間の比率から、Annowork時間を予測する
-            df[("actual_worktime_hour", phase)] = (
-                df[("actual_worktime_hour", "sum")] * df[("monitored_worktime_ratio", phase)]
-            )
+            df[("actual_worktime_hour", phase)] = df[("actual_worktime_hour", "sum")] * df[("monitored_worktime_ratio", phase)]
 
             # 生産性を算出
-            df[("monitored_worktime_hour/input_data_count", phase)] = (
-                df[("monitored_worktime_hour", phase)] / df[("input_data_count", phase)]
-            )
-            df[("actual_worktime_hour/input_data_count", phase)] = (
-                df[("actual_worktime_hour", phase)] / df[("input_data_count", phase)]
-            )
+            df[("monitored_worktime_hour/input_data_count", phase)] = df[("monitored_worktime_hour", phase)] / df[("input_data_count", phase)]
+            df[("actual_worktime_hour/input_data_count", phase)] = df[("actual_worktime_hour", phase)] / df[("input_data_count", phase)]
 
-            df[("monitored_worktime_hour/annotation_count", phase)] = (
-                df[("monitored_worktime_hour", phase)] / df[("annotation_count", phase)]
-            )
-            df[("actual_worktime_hour/annotation_count", phase)] = (
-                df[("actual_worktime_hour", phase)] / df[("annotation_count", phase)]
-            )
+            df[("monitored_worktime_hour/annotation_count", phase)] = df[("monitored_worktime_hour", phase)] / df[("annotation_count", phase)]
+            df[("actual_worktime_hour/annotation_count", phase)] = df[("actual_worktime_hour", phase)] / df[("annotation_count", phase)]
 
-            ratio__actual_vs_monitored_worktime = (
-                df[("actual_worktime_hour", phase)] / df[("monitored_worktime_hour", phase)]
-            )
+            ratio__actual_vs_monitored_worktime = df[("actual_worktime_hour", phase)] / df[("monitored_worktime_hour", phase)]
             df[("stdev__actual_worktime_hour/input_data_count", phase)] = (
                 df[("stdev__monitored_worktime_hour/input_data_count", phase)] * ratio__actual_vs_monitored_worktime
             )
@@ -236,17 +223,13 @@ class UserPerformance:
         単位量あたり作業時間の標準偏差のDataFrameを生成する
         """
         df_worktime_ratio2 = df_worktime_ratio.copy()
-        df_worktime_ratio2["worktime_hour/input_data_count"] = (
-            df_worktime_ratio2["worktime_hour"] / df_worktime_ratio2["input_data_count"]
-        )
-        df_worktime_ratio2["worktime_hour/annotation_count"] = (
-            df_worktime_ratio2["worktime_hour"] / df_worktime_ratio2["annotation_count"]
-        )
+        df_worktime_ratio2["worktime_hour/input_data_count"] = df_worktime_ratio2["worktime_hour"] / df_worktime_ratio2["input_data_count"]
+        df_worktime_ratio2["worktime_hour/annotation_count"] = df_worktime_ratio2["worktime_hour"] / df_worktime_ratio2["annotation_count"]
 
         # 母標準偏差を算出する
-        df_stdev = df_worktime_ratio2.groupby(["account_id", "phase"])[
-            ["worktime_hour/input_data_count", "worktime_hour/annotation_count"]
-        ].std(ddof=0)
+        df_stdev = df_worktime_ratio2.groupby(["account_id", "phase"])[["worktime_hour/input_data_count", "worktime_hour/annotation_count"]].std(
+            ddof=0
+        )
 
         df_stdev2 = pandas.pivot_table(
             df_stdev,
@@ -320,9 +303,7 @@ class UserPerformance:
         phase_list = list(df2["monitored_worktime_hour"].columns)
 
         # 計測作業時間の合計値を算出する
-        df2[("monitored_worktime_hour", "sum")] = df2[[("monitored_worktime_hour", phase) for phase in phase_list]].sum(
-            axis=1
-        )
+        df2[("monitored_worktime_hour", "sum")] = df2[[("monitored_worktime_hour", phase) for phase in phase_list]].sum(axis=1)
 
         return df2
 
@@ -359,9 +340,7 @@ class UserPerformance:
         df2["worktime_hour/annotation_count"] = df2["worktime_hour"] / df2["annotation_count"]
 
         # 母標準偏差(ddof=0)を算出する
-        df_stdev = df2.groupby(["account_id", "phase"])[
-            ["worktime_hour/input_data_count", "worktime_hour/annotation_count"]
-        ].std(ddof=0)
+        df_stdev = df2.groupby(["account_id", "phase"])[["worktime_hour/input_data_count", "worktime_hour/annotation_count"]].std(ddof=0)
 
         df_stdev2 = pandas.pivot_table(
             df_stdev,
@@ -429,8 +408,7 @@ class UserPerformance:
         )
 
         df_agg_worktime[("real_monitored_worktime_hour/real_actual_worktime_hour", "sum")] = (
-            df_agg_worktime[("real_monitored_worktime_hour", "sum")]
-            / df_agg_worktime[("real_actual_worktime_hour", "sum")]
+            df_agg_worktime[("real_monitored_worktime_hour", "sum")] / df_agg_worktime[("real_actual_worktime_hour", "sum")]
         )
 
         return df_agg_worktime
@@ -450,9 +428,7 @@ class UserPerformance:
                     ("working_days", "")
         """
         df = worktime_per_date.df
-        df2 = df[df["monitored_worktime_hour"] > 0].pivot_table(
-            values="date", index="account_id", aggfunc=["min", "max"]
-        )
+        df2 = df[df["monitored_worktime_hour"] > 0].pivot_table(values="date", index="account_id", aggfunc=["min", "max"])
         df2.columns = pandas.MultiIndex.from_tuples([("first_working_date", ""), ("last_working_date", "")])
 
         # 元のDataFrame`df`が`account_id`,`date`のペアでユニークになっていない可能性も考えて、事前に`account_id`と`date`で集計する
@@ -626,9 +602,7 @@ class UserPerformance:
             ("real_actual_worktime_hour", "sum"),
             ("real_monitored_worktime_hour/real_actual_worktime_hour", "sum"),
         ]
-        actual_worktime_columns = [("actual_worktime_hour", "sum")] + [
-            ("actual_worktime_hour", phase) for phase in phase_list
-        ]
+        actual_worktime_columns = [("actual_worktime_hour", "sum")] + [("actual_worktime_hour", phase) for phase in phase_list]
 
         productivity_columns = (
             [("monitored_worktime_hour/input_data_count", phase) for phase in phase_list]
@@ -717,9 +691,7 @@ class UserPerformance:
             fig.add_layout(span_average_line)
 
     @staticmethod
-    def _get_average_value(
-        df: pandas.DataFrame, numerator_column: tuple[str, str], denominator_column: tuple[str, str]
-    ) -> Optional[float]:
+    def _get_average_value(df: pandas.DataFrame, numerator_column: tuple[str, str], denominator_column: tuple[str, str]) -> Optional[float]:
         numerator = df[numerator_column].sum()
         denominator = df[denominator_column].sum()
         if denominator > 0:
@@ -784,9 +756,7 @@ class UserPerformance:
                     )
 
                 # Annofab時間の比率から、Annowork時間を予測する
-                series[("actual_worktime_hour", phase)] = (
-                    series[("actual_worktime_hour", "sum")] * series[("monitored_worktime_ratio", phase)]
-                )
+                series[("actual_worktime_hour", phase)] = series[("actual_worktime_hour", "sum")] * series[("monitored_worktime_ratio", phase)]
 
                 # 生産性を算出
                 series[("monitored_worktime_hour/input_data_count", phase)] = (
@@ -810,13 +780,9 @@ class UserPerformance:
             series[("pointed_out_inspection_comment_count/input_data_count", phase)] = (
                 series[("pointed_out_inspection_comment_count", phase)] / series[("input_data_count", phase)]
             )
-            series[("rejected_count/task_count", phase)] = (
-                series[("rejected_count", phase)] / series[("task_count", phase)]
-            )
+            series[("rejected_count/task_count", phase)] = series[("rejected_count", phase)] / series[("task_count", phase)]
 
-    def plot_productivity(
-        self, output_file: Path, worktime_type: WorktimeType, performance_unit: PerformanceUnit
-    ) -> None:
+    def plot_productivity(self, output_file: Path, worktime_type: WorktimeType, performance_unit: PerformanceUnit) -> None:
         """作業時間と生産性の関係をメンバごとにプロットする。"""
 
         if not self._validate_df_for_output(output_file):
@@ -844,9 +810,7 @@ class UserPerformance:
             TaskPhase.ACCEPTANCE.value: "受入",
         }
         figure_list = [
-            create_figure(
-                f"{DICT_PHASE_NAME[phase]}の{performance_unit_name}あたり作業時間と累計作業時間の関係({worktime_type.worktime_type_name})"
-            )
+            create_figure(f"{DICT_PHASE_NAME[phase]}の{performance_unit_name}あたり作業時間と累計作業時間の関係({worktime_type.worktime_type_name})")
             for phase in self.phase_list
         ]
 
@@ -876,9 +840,7 @@ class UserPerformance:
 
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
             for fig, phase in zip(figure_list, self.phase_list):
-                filtered_df = df[
-                    (df["biography"] == biography) & df[(x_column, phase)].notna() & df[(y_column, phase)].notna()
-                ]
+                filtered_df = df[(df["biography"] == biography) & df[(x_column, phase)].notna() & df[(y_column, phase)].notna()]
                 if len(filtered_df) == 0:
                     continue
                 source = ColumnDataSource(data=filtered_df)
@@ -902,9 +864,7 @@ class UserPerformance:
                 average_minute = average_hour * 60
                 self._plot_average_line(fig, average_minute, dimension="width")
 
-            quartile = self._get_quartile_value(
-                df, (f"{worktime_type.value}_worktime_minute/{performance_unit.value}", phase)
-            )
+            quartile = self._get_quartile_value(df, (f"{worktime_type.value}_worktime_minute/{performance_unit.value}", phase))
             if quartile is not None:
                 self._plot_quartile_line(fig, quartile, dimension="width")
 
@@ -959,7 +919,9 @@ class UserPerformance:
         figure_list = [
             create_figure(title="タスクあたり差し戻し回数とタスク数の関係", x_axis_label="タスク数", y_axis_label="タスクあたり差し戻し回数"),
             create_figure(
-                title="アノテーションあたり検査コメント数とアノテーション数の関係", x_axis_label="アノテーション数", y_axis_label="アノテーションあたり検査コメント数"
+                title="アノテーションあたり検査コメント数とアノテーション数の関係",
+                x_axis_label="アノテーション数",
+                y_axis_label="アノテーションあたり検査コメント数",
             ),
         ]
         column_pair_list = [
@@ -988,9 +950,7 @@ class UserPerformance:
             for column_pair, fig in zip(column_pair_list, figure_list):
                 x_column = column_pair[0]
                 y_column = column_pair[1]
-                filtered_df = df[
-                    (df["biography"] == biography) & df[(x_column, phase)].notna() & df[(y_column, phase)].notna()
-                ]
+                filtered_df = df[(df["biography"] == biography) & df[(x_column, phase)].notna() & df[(y_column, phase)].notna()]
                 if len(filtered_df) == 0:
                     continue
 
@@ -1009,9 +969,7 @@ class UserPerformance:
             [("rejected_count", "task_count"), ("pointed_out_inspection_comment_count", "annotation_count")],
             figure_list,
         ):
-            average_value = self._get_average_value(
-                df, numerator_column=(column_pair[0], phase), denominator_column=(column_pair[1], phase)
-            )
+            average_value = self._get_average_value(df, numerator_column=(column_pair[0], phase), denominator_column=(column_pair[1], phase))
             if average_value is not None:
                 self._plot_average_line(fig, average_value, dimension="width")
 
@@ -1046,9 +1004,7 @@ class UserPerformance:
         div_element = self._create_div_element()
         write_bokeh_graph(bokeh.layouts.column([div_element, *figure_list]), output_file)
 
-    def plot_quality_and_productivity(
-        self, output_file: Path, worktime_type: WorktimeType, performance_unit: PerformanceUnit
-    ):
+    def plot_quality_and_productivity(self, output_file: Path, worktime_type: WorktimeType, performance_unit: PerformanceUnit):
         """
         作業時間を元に算出した生産性と品質の関係を、メンバごとにプロットする
         """
@@ -1085,9 +1041,7 @@ class UserPerformance:
                 if y_average is not None:
                     self._plot_average_line(fig, y_average, dimension="width")
 
-            x_quartile = self._get_quartile_value(
-                df, (f"{worktime_type.value}_worktime_minute/{performance_unit.value}", phase)
-            )
+            x_quartile = self._get_quartile_value(df, (f"{worktime_type.value}_worktime_minute/{performance_unit.value}", phase))
             for column, fig in zip(
                 ["rejected_count/task_count", f"pointed_out_inspection_comment_count/{performance_unit.value}"],
                 figure_list,
@@ -1175,9 +1129,7 @@ class UserPerformance:
         for biography_index, biography in enumerate(sorted(set(df["biography"]))):
             for fig, column_pair in zip(figure_list, column_pair_list):
                 x_column, y_column = column_pair
-                filtered_df = df[
-                    (df["biography"] == biography) & df[(x_column, phase)].notna() & df[(y_column, phase)].notna()
-                ]
+                filtered_df = df[(df["biography"] == biography) & df[(x_column, phase)].notna() & df[(y_column, phase)].notna()]
                 if len(filtered_df) == 0:
                     continue
                 source = ColumnDataSource(data=filtered_df)

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -476,7 +476,7 @@ class UserPerformance:
             task_worktime_by_phase_user: タスク、フェーズ、ユーザーごとの作業時間や生産量が格納されたオブジェクト。生産量やタスクにかかった作業時間の取得に利用します。
 
 
-        """
+        """  # noqa: E501
 
         def drop_unnecessary_columns(df: pandas.DataFrame) -> pandas.DataFrame:
             """
@@ -744,7 +744,7 @@ class UserPerformance:
 
             for phase in phase_list:
                 # Annofab時間の比率を算出
-                # 計測作業時間の合計値が0により、monitored_worktime_ratioはnanになる場合は、教師付の実績作業時間を実績作業時間の合計値になるようなmonitored_worktime_ratioに変更する
+                # 計測作業時間の合計値が0により、monitored_worktime_ratioはnanになる場合は、教師付の実績作業時間を実績作業時間の合計値になるようなmonitored_worktime_ratioに変更する  # noqa: E501
                 if series[("monitored_worktime_hour", "sum")] == 0:
                     if phase == TaskPhase.ANNOTATION.value:
                         series[("monitored_worktime_ratio", phase)] = 1

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -121,13 +121,13 @@ class UserPerformance:
                 計測作業時間の合計値が0により、monitored_worktime_ratioはnanになる場合は、教師付の実績作業時間を実績作業時間の合計値になるようなmonitored_worktime_ratioに変更する
                 """
                 if row[("monitored_worktime_hour", "sum")] == 0:
-                    if phase == TaskPhase.ANNOTATION.value:  # noqa: function-uses-loop-variable  # noqa: B023
+                    if phase == TaskPhase.ANNOTATION.value:  # noqa: B023
                         return 1
                     else:
                         return 0
                 else:
                     return (
-                        row[("monitored_worktime_hour", phase)]  # noqa: function-uses-loop-variable  # noqa: B023
+                        row[("monitored_worktime_hour", phase)]  # noqa: B023
                         / row[("monitored_worktime_hour", "sum")]
                     )
 

--- a/annofabcli/statistics/visualization/dataframe/whole_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_performance.py
@@ -25,7 +25,7 @@ class WholePerformance:
         series: 全体の生産性と品質が格納されたpandas.Series
     """
 
-    STRING_KEYS = {("first_working_date", ""), ("last_working_date", "")}
+    STRING_KEYS = {("first_working_date", ""), ("last_working_date", "")}  # noqa: RUF012
     """文字列が格納されているキー"""
 
     def __init__(self, series: pandas.Series) -> None:

--- a/annofabcli/statistics/visualization/dataframe/whole_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_performance.py
@@ -62,12 +62,8 @@ class WholePerformance:
             df_task_worktime_by_phase_user[column] = "pseudo_value"
 
         unique_keys_for_worktime = ["date"]
-        addable_columns_for_worktime = list(
-            set(df_worktime_per_date.columns) - set(user_info_columns) - set(unique_keys_for_worktime)
-        )
-        df_worktime_per_date = df_worktime_per_date.groupby(unique_keys_for_worktime)[
-            addable_columns_for_worktime
-        ].sum()
+        addable_columns_for_worktime = list(set(df_worktime_per_date.columns) - set(user_info_columns) - set(unique_keys_for_worktime))
+        df_worktime_per_date = df_worktime_per_date.groupby(unique_keys_for_worktime)[addable_columns_for_worktime].sum()
         df_worktime_per_date[user_info_columns] = PSEUDO_VALUE
         df_worktime_per_date = df_worktime_per_date.reset_index()
 
@@ -76,14 +72,9 @@ class WholePerformance:
 
         unique_keys_for_worktime = ["project_id", "task_id", "phase", "phase_stage"]
         addable_columns_for_task = list(
-            set(df_task_worktime_by_phase_user.columns)
-            - set(user_info_columns)
-            - set(unique_keys_for_worktime)
-            - {"status"}
+            set(df_task_worktime_by_phase_user.columns) - set(user_info_columns) - set(unique_keys_for_worktime) - {"status"}
         )
-        df_task_worktime_by_phase_user = df_task_worktime_by_phase_user.groupby(unique_keys_for_worktime)[
-            addable_columns_for_task
-        ].sum()
+        df_task_worktime_by_phase_user = df_task_worktime_by_phase_user.groupby(unique_keys_for_worktime)[addable_columns_for_task].sum()
         df_task_worktime_by_phase_user[user_info_columns] = PSEUDO_VALUE
         df_task_worktime_by_phase_user = df_task_worktime_by_phase_user.reset_index()
         # status情報を結合する
@@ -123,13 +114,9 @@ class WholePerformance:
             ]
         ].sum()
         for phase in TaskPhase:
-            df_all[("working_user_count", phase.value)] = (
-                df_worktime2[f"monitored_{phase.value}_worktime_hour"] > 0
-            ).sum()
+            df_all[("working_user_count", phase.value)] = (df_worktime2[f"monitored_{phase.value}_worktime_hour"] > 0).sum()
 
-        df_all = df_all.drop(
-            [("account_id", ""), ("user_id", ""), ("username", ""), ("biography", "")], axis=1, errors="ignore"
-        )
+        df_all = df_all.drop([("account_id", ""), ("user_id", ""), ("username", ""), ("biography", "")], axis=1, errors="ignore")
         return cls(df_all.iloc[0])
 
     @classmethod
@@ -231,7 +218,7 @@ class WholePerformance:
         series = self.series[indexes]
 
         output_file.parent.mkdir(exist_ok=True, parents=True)
-        logger.debug(f"{str(output_file)} を出力します。")
+        logger.debug(f"{output_file!s} を出力します。")
         series.to_csv(str(output_file), sep=",", encoding="utf_8_sig", header=False)
 
     @staticmethod

--- a/annofabcli/statistics/visualization/dataframe/whole_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_performance.py
@@ -98,7 +98,7 @@ class WholePerformance:
             worktime_per_date: 日ごとの作業時間が記載されたDataFrameを格納したオブジェクト。ユーザー情報の取得や、実際の作業時間（集計タスクに影響しない）の算出に利用します。
             task_worktime_by_phase_user: タスク、フェーズ、ユーザーごとの作業時間や生産量が格納されたオブジェクト。生産量やタスクにかかった作業時間の取得に利用します。
 
-        """
+        """  # noqa: E501
         # 1人が作業した場合のパフォーマンス情報を生成する
         all_user_performance = cls._create_all_user_performance(worktime_per_date, task_worktime_by_phase_user)
 

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -182,19 +182,13 @@ class WholeProductivityPerCompletedDate:
             ).fillna(0)
 
             # 作業したユーザ数を算出
-            df_tmp = (
-                df_worktime[df_worktime["monitored_worktime_hour"] > 0]
-                .pivot_table(values=["user_id"], index="date", aggfunc="count")
-                .fillna(0)
-            )
+            df_tmp = df_worktime[df_worktime["monitored_worktime_hour"] > 0].pivot_table(values=["user_id"], index="date", aggfunc="count").fillna(0)
             if len(df_tmp) > 0:
                 df_agg_labor["working_user_count"] = df_tmp
             else:
                 df_agg_labor["working_user_count"] = 0
 
-            df_agg_labor["unmonitored_worktime_hour"] = (
-                df_agg_labor["actual_worktime_hour"] - df_agg_labor["monitored_worktime_hour"]
-            )
+            df_agg_labor["unmonitored_worktime_hour"] = df_agg_labor["actual_worktime_hour"] - df_agg_labor["monitored_worktime_hour"]
 
         else:
             df_agg_labor = pandas.DataFrame(
@@ -255,9 +249,7 @@ class WholeProductivityPerCompletedDate:
                 add_velocity_column(df, numerator_column=f"{category}_worktime_hour", denominator_column=unit)
 
     @classmethod
-    def merge(
-        cls, obj1: WholeProductivityPerCompletedDate, obj2: WholeProductivityPerCompletedDate
-    ) -> WholeProductivityPerCompletedDate:
+    def merge(cls, obj1: WholeProductivityPerCompletedDate, obj2: WholeProductivityPerCompletedDate) -> WholeProductivityPerCompletedDate:
         """
         日毎の全体の生産量、生産性が格納されたDataFrameを結合する。
 
@@ -271,9 +263,7 @@ class WholeProductivityPerCompletedDate:
         df1 = obj1.df
         df2 = obj2.df
 
-        def merge_row(
-            str_date: str, columns: pandas.Index, row1: Optional[pandas.Series], row2: Optional[pandas.Series]
-        ) -> pandas.Series:
+        def merge_row(str_date: str, columns: pandas.Index, row1: Optional[pandas.Series], row2: Optional[pandas.Series]) -> pandas.Series:
             if row1 is not None and row2 is not None:
                 sum_row = row1.fillna(0) + row2.fillna(0)
             elif row1 is not None and row2 is None:
@@ -347,16 +337,14 @@ class WholeProductivityPerCompletedDate:
                     "monitored_acceptance",
                     "unmonitored",
                 ]:
-                    df[f"{category}_worktime_minute/{denominator}"] = (
-                        df[f"{category}_worktime_hour"] * 60 / df[denominator]
-                    )
+                    df[f"{category}_worktime_minute/{denominator}"] = df[f"{category}_worktime_hour"] * 60 / df[denominator]
                     df[f"{category}_worktime_minute/{denominator}{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = (
                         get_weekly_sum(df[f"{category}_worktime_hour"]) * 60 / get_weekly_sum(df[denominator])
                     )
 
-            df[f"actual_worktime_hour/task_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_sum(
-                df["actual_worktime_hour"]
-            ) / get_weekly_sum(df["task_count"])
+            df[f"actual_worktime_hour/task_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_sum(df["actual_worktime_hour"]) / get_weekly_sum(
+                df["task_count"]
+            )
             df[f"monitored_worktime_hour/task_count{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_sum(
                 df["monitored_worktime_hour"]
             ) / get_weekly_sum(df["task_count"])
@@ -398,8 +386,7 @@ class WholeProductivityPerCompletedDate:
             line_graph.add_secondary_y_axis(
                 "作業時間[hour]",
                 secondary_y_axis_range=DataRange1d(
-                    end=max(df["actual_worktime_hour"].max(), df["monitored_worktime_hour"].max())
-                    * SECONDARY_Y_RANGE_RATIO
+                    end=max(df["actual_worktime_hour"].max(), df["monitored_worktime_hour"].max()) * SECONDARY_Y_RANGE_RATIO
                 ),
                 primary_y_axis_range=DataRange1d(end=df["task_count"].max() * SECONDARY_Y_RANGE_RATIO),
             )
@@ -451,8 +438,7 @@ class WholeProductivityPerCompletedDate:
             line_graph.add_secondary_y_axis(
                 "作業時間[hour]",
                 secondary_y_axis_range=DataRange1d(
-                    end=max(df["actual_worktime_hour"].max(), df["monitored_worktime_hour"].max())
-                    * SECONDARY_Y_RANGE_RATIO
+                    end=max(df["actual_worktime_hour"].max(), df["monitored_worktime_hour"].max()) * SECONDARY_Y_RANGE_RATIO
                 ),
                 primary_y_axis_range=DataRange1d(end=df["input_data_count"].max() * SECONDARY_Y_RANGE_RATIO),
             )
@@ -547,9 +533,7 @@ class WholeProductivityPerCompletedDate:
                         "monitored_acceptance_worktime_minute/input_data_count",
                     ],
                 ),
-                "y_info_list": [
-                    {"column": f"{e[0]}_minute/input_data_count", "legend": f"入力データあたり{e[1]}"} for e in phase_prefix
-                ],
+                "y_info_list": [{"column": f"{e[0]}_minute/input_data_count", "legend": f"入力データあたり{e[1]}"} for e in phase_prefix],
             },
             {
                 "line_graph": create_line_graph(
@@ -570,9 +554,7 @@ class WholeProductivityPerCompletedDate:
                         "monitored_acceptance_worktime_minute/annotation_count",
                     ],
                 ),
-                "y_info_list": [
-                    {"column": f"{e[0]}_minute/annotation_count", "legend": f"アノテーションあたり{e[1]}"} for e in phase_prefix
-                ],
+                "y_info_list": [{"column": f"{e[0]}_minute/annotation_count", "legend": f"アノテーションあたり{e[1]}"} for e in phase_prefix],
             },
         ]
 
@@ -637,8 +619,7 @@ class WholeProductivityPerCompletedDate:
             line_graph.add_secondary_y_axis(
                 "作業時間[hour]",
                 secondary_y_axis_range=DataRange1d(
-                    end=max(df["cumsum_actual_worktime_hour"].max(), df["cumsum_monitored_worktime_hour"].max())
-                    * SECONDARY_Y_RANGE_RATIO
+                    end=max(df["cumsum_actual_worktime_hour"].max(), df["cumsum_monitored_worktime_hour"].max()) * SECONDARY_Y_RANGE_RATIO
                 ),
                 primary_y_axis_range=DataRange1d(end=df["cumsum_task_count"].max() * SECONDARY_Y_RANGE_RATIO),
             )
@@ -693,8 +674,7 @@ class WholeProductivityPerCompletedDate:
             line_graph.add_secondary_y_axis(
                 "作業時間[hour]",
                 secondary_y_axis_range=DataRange1d(
-                    end=max(df["cumsum_actual_worktime_hour"].max(), df["cumsum_monitored_worktime_hour"].max())
-                    * SECONDARY_Y_RANGE_RATIO
+                    end=max(df["cumsum_actual_worktime_hour"].max(), df["cumsum_monitored_worktime_hour"].max()) * SECONDARY_Y_RANGE_RATIO
                 ),
                 primary_y_axis_range=DataRange1d(end=df["cumsum_input_data_count"].max() * SECONDARY_Y_RANGE_RATIO),
             )
@@ -899,9 +879,9 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         def add_velocity_column(df: pandas.DataFrame, numerator_column: str, denominator_column: str):
             df[f"{numerator_column}/{denominator_column}"] = df[numerator_column] / df[denominator_column]
 
-            df[
-                f"{numerator_column}/{denominator_column}{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"
-            ] = get_weekly_moving_average(df[numerator_column]) / get_weekly_moving_average(df[denominator_column])
+            df[f"{numerator_column}/{denominator_column}{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_moving_average(
+                df[numerator_column]
+            ) / get_weekly_moving_average(df[denominator_column])
 
         # annofab 計測時間から算出したvelocityを追加
         add_velocity_column(df, numerator_column="worktime_hour", denominator_column="input_data_count")
@@ -957,10 +937,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         # 日付の一覧を生成
         if len(df_agg_sub_task) > 0:
             df_date_base = pandas.DataFrame(
-                index=[
-                    e.strftime("%Y-%m-%d")
-                    for e in pandas.date_range(start=df_agg_sub_task.index.min(), end=df_agg_sub_task.index.max())
-                ]
+                index=[e.strftime("%Y-%m-%d") for e in pandas.date_range(start=df_agg_sub_task.index.min(), end=df_agg_sub_task.index.max())]
             )
         else:
             df_date_base = pandas.DataFrame()
@@ -1014,9 +991,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
     def merge(
         cls, obj1: WholeProductivityPerFirstAnnotationStartedDate, obj2: WholeProductivityPerFirstAnnotationStartedDate
     ) -> WholeProductivityPerFirstAnnotationStartedDate:
-        def merge_row(
-            str_date: str, columns: pandas.Index, row1: Optional[pandas.Series], row2: Optional[pandas.Series]
-        ) -> pandas.Series:
+        def merge_row(str_date: str, columns: pandas.Index, row1: Optional[pandas.Series], row2: Optional[pandas.Series]) -> pandas.Series:
             if row1 is not None and row2 is not None:
                 sum_row = row1.fillna(0) + row2.fillna(0)
             elif row1 is not None and row2 is None:
@@ -1283,6 +1258,4 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
 
-        write_bokeh_graph(
-            bokeh.layouts.column([create_div_element()] + [e.figure for e in line_graph_list]), output_file
-        )
+        write_bokeh_graph(bokeh.layouts.column([create_div_element()] + [e.figure for e in line_graph_list]), output_file)

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -495,7 +495,7 @@ class WholeProductivityPerCompletedDate:
             ("monitored_acceptance_worktime", "計測作業時間(受入)"),
         ]
         if df["actual_worktime_hour"].sum() > 0:
-            # 条件分岐の理由：実績作業時間がないときは、非計測作業時間がマイナス値になり、分かりづらいグラフになるため。必要なときのみ非計測作業時間をプロットする
+            # 条件分岐の理由：実績作業時間がないときは、非計測作業時間がマイナス値になり、分かりづらいグラフになるため。必要なときのみ非計測作業時間をプロットする  # noqa: E501
             phase_prefix.append(("unmonitored_worktime", "非計測作業時間"))
 
         fig_info_list = [

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -163,9 +163,7 @@ class WorktimePerDate:
                 df[f"monitored_{phase}_worktime_hour"] = 0
 
         df["monitored_worktime_hour"] = (
-            df["monitored_annotation_worktime_hour"]
-            + df["monitored_inspection_worktime_hour"]
-            + df["monitored_acceptance_worktime_hour"]
+            df["monitored_annotation_worktime_hour"] + df["monitored_inspection_worktime_hour"] + df["monitored_acceptance_worktime_hour"]
         )
 
         if not actual_worktime.is_empty():
@@ -208,17 +206,13 @@ class WorktimePerDate:
         Annoworkで作業したメンバが、Annofabのプロジェクトで作業していない場合もあるので、
         できるだけたくさんのメンバを取得できるようにするため、組織メンバを取得しています。
         """
-        project_member_list = service.wrapper.get_all_project_members(
-            project_id, query_params={"include_inactive_member": ""}
-        )
+        project_member_list = service.wrapper.get_all_project_members(project_id, query_params={"include_inactive_member": ""})
         df_project_member = pandas.DataFrame(project_member_list)
         organization, _ = service.api.get_organization_of_project(project_id)
         organization_member_list = service.wrapper.get_all_organization_members(organization["organization_name"])
         df_organization_member = pandas.DataFrame(organization_member_list)
 
-        df_member = pandas.concat([df_project_member, df_organization_member])[
-            ["account_id", "user_id", "username", "biography"]
-        ]
+        df_member = pandas.concat([df_project_member, df_organization_member])[["account_id", "user_id", "username", "biography"]]
         df_member.drop_duplicates(subset=["account_id", "user_id", "username", "biography"], inplace=True)
         return df_member
 
@@ -271,15 +265,9 @@ class WorktimePerDate:
         # 作業時間の累積値
         df_result["cumulative_actual_worktime_hour"] = groupby_obj["actual_worktime_hour"].cumsum()
         df_result["cumulative_monitored_worktime_hour"] = groupby_obj["monitored_worktime_hour"].cumsum()
-        df_result["cumulative_monitored_annotation_worktime_hour"] = groupby_obj[
-            "monitored_annotation_worktime_hour"
-        ].cumsum()
-        df_result["cumulative_monitored_acceptance_worktime_hour"] = groupby_obj[
-            "monitored_acceptance_worktime_hour"
-        ].cumsum()
-        df_result["cumulative_monitored_inspection_worktime_hour"] = groupby_obj[
-            "monitored_inspection_worktime_hour"
-        ].cumsum()
+        df_result["cumulative_monitored_annotation_worktime_hour"] = groupby_obj["monitored_annotation_worktime_hour"].cumsum()
+        df_result["cumulative_monitored_acceptance_worktime_hour"] = groupby_obj["monitored_acceptance_worktime_hour"].cumsum()
+        df_result["cumulative_monitored_inspection_worktime_hour"] = groupby_obj["monitored_inspection_worktime_hour"].cumsum()
 
         return df_result
 
@@ -477,7 +465,7 @@ class WorktimePerDate:
             show_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=False)
             checkbox_group = line_graph.create_checkbox_displaying_markers()
 
-            widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group])  # type: ignore[list-item] # noqa: E501
+            widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group])  # type: ignore[list-item]
             graph_group = bokeh.layouts.row([line_graph.figure, widgets])  # type: ignore[list-item]
             graph_group_list.append(graph_group)
 

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -71,7 +71,7 @@ class WorktimePerDate:
 
         self.df = df
 
-    _df_dtype = {
+    _df_dtype = {  # noqa: RUF012
         "date": "string",
         "account_id": "string",
         "user_id": "string",
@@ -84,7 +84,7 @@ class WorktimePerDate:
         "monitored_acceptance_worktime_hour": "float64",
     }
 
-    columns = [
+    columns = [  # noqa: RUF012
         "date",
         "account_id",
         "user_id",

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -81,7 +81,7 @@ class ProjectDir(DataClassJsonMixin):
         if file.exists():
             return Task.from_csv(file)
         else:
-            logger.warning(f"'{str(file)}'を読み込もうとしましたが、ファイルは存在しません。")
+            logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
             return Task.empty()
 
     def write_task_list(self, obj: Task) -> None:
@@ -94,7 +94,7 @@ class ProjectDir(DataClassJsonMixin):
         if file.exists():
             return TaskWorktimeByPhaseUser.from_csv(file)
         else:
-            logger.warning(f"'{str(file)}'を読み込もうとしましたが、ファイルは存在しません。")
+            logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
             return TaskWorktimeByPhaseUser.empty()
 
     def write_task_worktime_list(self, obj: TaskWorktimeByPhaseUser) -> None:
@@ -131,9 +131,7 @@ class ProjectDir(DataClassJsonMixin):
 
         if not minimal_output:
             # アノテーション単位より大きい単位の折れ線グラフは不要かもしれないので、オプションにした
-            obj.plot_input_data_metrics(
-                output_dir / f"{phase_name}者用/累積折れ線-横軸_入力データ数-{phase_name}者用.html", user_id_list
-            )
+            obj.plot_input_data_metrics(output_dir / f"{phase_name}者用/累積折れ線-横軸_入力データ数-{phase_name}者用.html", user_id_list)
 
             if phase == TaskPhase.ANNOTATION:
                 # 教師付フェーズの場合は、「差し戻し回数」で品質を評価した場合があるので、タスク単位の指標も出力する
@@ -168,7 +166,7 @@ class ProjectDir(DataClassJsonMixin):
         if file.exists():
             return WholePerformance.from_csv(file)
         else:
-            logger.warning(f"'{str(file)}'を読み込もうとしましたが、ファイルは存在しません。")
+            logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
             return WholePerformance.empty()
 
     def write_whole_performance(self, whole_performance: WholePerformance) -> None:
@@ -204,17 +202,13 @@ class ProjectDir(DataClassJsonMixin):
             self.project_dir / self.FILENAME_WHOLE_PRODUCTIVITY_PER_FIRST_ANNOTATION_STARTED_DATE
         )
 
-    def write_whole_productivity_per_first_annotation_started_date(
-        self, obj: WholeProductivityPerFirstAnnotationStartedDate
-    ):
+    def write_whole_productivity_per_first_annotation_started_date(self, obj: WholeProductivityPerFirstAnnotationStartedDate):
         """
         教師付開始日ごとの生産性と品質の情報を書き込みます。
         """
         obj.to_csv(self.project_dir / self.FILENAME_WHOLE_PRODUCTIVITY_PER_FIRST_ANNOTATION_STARTED_DATE)
 
-    def write_whole_productivity_line_graph_per_annotation_started_date(
-        self, obj: WholeProductivityPerFirstAnnotationStartedDate
-    ):
+    def write_whole_productivity_line_graph_per_annotation_started_date(self, obj: WholeProductivityPerFirstAnnotationStartedDate):
         """
         横軸が教師付開始日、縦軸が全体の生産性などをプロットした折れ線グラフを出力します。
         """
@@ -228,7 +222,7 @@ class ProjectDir(DataClassJsonMixin):
         if file.exists():
             return UserPerformance.from_csv(file)
         else:
-            logger.warning(f"'{str(file)}'を読み込もうとしましたが、ファイルは存在しません。")
+            logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
             return UserPerformance.empty()
 
     def write_user_performance(self, user_performance: UserPerformance) -> None:
@@ -300,7 +294,7 @@ class ProjectDir(DataClassJsonMixin):
         if file.exists():
             return WorktimePerDate.from_csv(file)
         else:
-            logger.warning(f"'{str(file)}'を読み込もうとしましたが、ファイルは存在しません。")
+            logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
             return WorktimePerDate.empty()
 
     def write_worktime_per_date_user(self, obj: WorktimePerDate) -> None:
@@ -324,9 +318,7 @@ class ProjectDir(DataClassJsonMixin):
         """
         `project_info.json`を書き込む。
         """
-        print_json(
-            project_info.to_dict(encode_json=True), output=self.project_dir / self.FILENAME_PROJECT_INFO, is_pretty=True
-        )
+        print_json(project_info.to_dict(encode_json=True), output=self.project_dir / self.FILENAME_PROJECT_INFO, is_pretty=True)
 
     def read_merge_info(self) -> MergingInfo:
         """

--- a/annofabcli/statistics/visualize_annotation_count.py
+++ b/annofabcli/statistics/visualize_annotation_count.py
@@ -362,7 +362,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--latest",
         action="store_true",
-        help="``--annotation`` を指定しないとき、最新のアノテーションzipを参照します。このオプションを指定すると、アノテーションzipを更新するのに数分待ちます。",
+        help="``--annotation`` を指定しないとき、最新のアノテーションzipを参照します。このオプションを指定すると、アノテーションzipを更新するのに数分待ちます。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/statistics/visualize_annotation_count.py
+++ b/annofabcli/statistics/visualize_annotation_count.py
@@ -61,9 +61,7 @@ def _only_selective_attribute(columns: list[AttributeValueKey]) -> list[Attribut
         attribute_name_list.append((label, attribute_name))
 
     non_selective_attribute_names = {
-        key
-        for key, value in collections.Counter(attribute_name_list).items()
-        if value > SELECTIVE_ATTRIBUTE_VALUE_MAX_COUNT
+        key for key, value in collections.Counter(attribute_name_list).items() if value > SELECTIVE_ATTRIBUTE_VALUE_MAX_COUNT
     }
 
     if len(non_selective_attribute_names) > 0:
@@ -112,9 +110,7 @@ def plot_label_histogram(
         hist, bin_edges = numpy.histogram(df[col], bins)
 
         df_histogram = pandas.DataFrame({"frequency": hist, "left": bin_edges[:-1], "right": bin_edges[1:]})
-        df_histogram["interval"] = [
-            f"{left:.1f} to {right:.1f}" for left, right in zip(df_histogram["left"], df_histogram["right"])
-        ]
+        df_histogram["interval"] = [f"{left:.1f} to {right:.1f}" for left, right in zip(df_histogram["left"], df_histogram["right"])]
 
         source = ColumnDataSource(df_histogram)
         fig = figure(
@@ -170,9 +166,7 @@ def plot_attribute_histogram(
         hist, bin_edges = numpy.histogram(df[col], bins)
 
         df_histogram = pandas.DataFrame({"frequency": hist, "left": bin_edges[:-1], "right": bin_edges[1:]})
-        df_histogram["interval"] = [
-            f"{left:.1f} to {right:.1f}" for left, right in zip(df_histogram["left"], df_histogram["right"])
-        ]
+        df_histogram["interval"] = [f"{left:.1f} to {right:.1f}" for left, right in zip(df_histogram["left"], df_histogram["right"])]
 
         source = ColumnDataSource(df_histogram)
         fig = figure(
@@ -205,7 +199,7 @@ class VisualizeAnnotationCount(AbstractCommandLineInterface):
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and args.annotation is None:
             print(
-                f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",  # noqa: E501
+                f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
                 file=sys.stderr,
             )
             return False
@@ -261,9 +255,7 @@ class VisualizeAnnotationCount(AbstractCommandLineInterface):
             label_keys = annotation_specs.label_keys()
             attribute_value_keys = annotation_specs.selective_attribute_value_keys()
 
-        plot_label_histogram(
-            counter_list, group_by=group_by, output_file=labels_count_html, bins=bins, prior_keys=label_keys
-        )
+        plot_label_histogram(counter_list, group_by=group_by, output_file=labels_count_html, bins=bins, prior_keys=label_keys)
         plot_attribute_histogram(
             counter_list,
             group_by=group_by,
@@ -280,19 +272,13 @@ class VisualizeAnnotationCount(AbstractCommandLineInterface):
 
         project_id: Optional[str] = args.project_id
         if project_id is not None:
-            super().validate_project(
-                project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
-            )
+            super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         output_dir: Path = args.output_dir
         annotation_path = Path(args.annotation) if args.annotation is not None else None
 
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
-        task_query = (
-            TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query))
-            if args.task_query is not None
-            else None
-        )
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
         group_by = GroupBy(args.group_by)
 
@@ -393,8 +379,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "各ラベル、各属性値のアノテーション数をヒストグラムで可視化します。"
     description = "各ラベル、各属性値のアノテーション数をヒストグラムで可視化したファイルを出力します。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -187,9 +187,7 @@ class WriteCsvGraph:
         self.project_dir.write_worktime_per_date_user(worktime_per_date_obj)
 
         task = Task(self._get_task_df())
-        productivity_per_completed_date_obj = WholeProductivityPerCompletedDate.from_df_wrapper(
-            task, worktime_per_date_obj
-        )
+        productivity_per_completed_date_obj = WholeProductivityPerCompletedDate.from_df_wrapper(task, worktime_per_date_obj)
 
         self.project_dir.write_whole_productivity_per_date(productivity_per_completed_date_obj)
 
@@ -199,9 +197,7 @@ class WriteCsvGraph:
         if not self.output_only_text:
             self.project_dir.write_worktime_line_graph(worktime_per_date_obj, user_id_list=user_id_list)
             self.project_dir.write_whole_productivity_line_graph_per_date(productivity_per_completed_date_obj)
-            self.project_dir.write_whole_productivity_line_graph_per_annotation_started_date(
-                productivity_per_started_date_obj
-            )
+            self.project_dir.write_whole_productivity_line_graph_per_annotation_started_date(productivity_per_started_date_obj)
 
     def write_user_productivity_per_date(self, user_id_list: Optional[List[str]] = None) -> None:
         """ユーザごとの日ごとの生産性情報を出力する。"""
@@ -217,15 +213,9 @@ class WriteCsvGraph:
         self.project_dir.write_performance_per_started_date_csv(acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE)
 
         if not self.output_only_text:
-            self.project_dir.write_performance_line_graph_per_date(
-                annotator_per_date_obj, phase=TaskPhase.ANNOTATION, user_id_list=user_id_list
-            )
-            self.project_dir.write_performance_line_graph_per_date(
-                inspector_per_date_obj, phase=TaskPhase.INSPECTION, user_id_list=user_id_list
-            )
-            self.project_dir.write_performance_line_graph_per_date(
-                acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE, user_id_list=user_id_list
-            )
+            self.project_dir.write_performance_line_graph_per_date(annotator_per_date_obj, phase=TaskPhase.ANNOTATION, user_id_list=user_id_list)
+            self.project_dir.write_performance_line_graph_per_date(inspector_per_date_obj, phase=TaskPhase.INSPECTION, user_id_list=user_id_list)
+            self.project_dir.write_performance_line_graph_per_date(acceptor_per_date_obj, phase=TaskPhase.ACCEPTANCE, user_id_list=user_id_list)
 
 
 class VisualizingStatisticsMain:
@@ -276,9 +266,7 @@ class VisualizingStatisticsMain:
             project_title=project_title,
             input_data_type=project_info["input_data_type"],
             measurement_datetime=annofabapi.utils.str_now(),
-            query=Query(
-                task_query=self.task_query, task_ids=self.task_ids, start_date=self.start_date, end_date=self.end_date
-            ),
+            query=Query(task_query=self.task_query, task_ids=self.task_ids, start_date=self.start_date, end_date=self.end_date),
         )
         project_dir.write_project_info(project_summary)
 
@@ -296,9 +284,7 @@ class VisualizingStatisticsMain:
 
         """
 
-        self.facade.validate_project(
-            project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER]
-        )
+        self.facade.validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         project_dir = ProjectDir(output_project_dir)
         self.write_project_info_json(project_id=project_id, project_dir=project_dir)
@@ -314,9 +300,7 @@ class VisualizingStatisticsMain:
                 end_date=self.end_date,
             ),
         )
-        database.update_db(
-            self.download_latest, is_get_task_histories_one_of_each=self.is_get_task_histories_one_of_each
-        )
+        database.update_db(self.download_latest, is_get_task_histories_one_of_each=self.is_get_task_histories_one_of_each)
 
         table_obj = Table(database)
 
@@ -436,8 +420,7 @@ class VisualizeStatistics(AbstractCommandLineInterface):
             df_actual_worktime = pandas.read_csv(args.labor_csv)
             if not ActualWorktime.required_columns_exist(df_actual_worktime):
                 logger.error(
-                    "引数`--labor_csv`のCSVには以下の列が存在しないので、終了します。\n"
-                    "`project_id`, `date`, `account_id`, `actual_worktime_hour`"
+                    "引数`--labor_csv`のCSVには以下の列が存在しないので、終了します。\n" "`project_id`, `date`, `account_id`, `actual_worktime_hour`"
                 )
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
             actual_worktime = ActualWorktime(df_actual_worktime)
@@ -484,14 +467,10 @@ class VisualizeStatistics(AbstractCommandLineInterface):
                     project_performance = ProjectPerformance.from_project_dirs(project_dir_list)
                     project_performance.to_csv(root_output_dir / "プロジェクトごとの生産性と品質.csv")
 
-                    project_actual_worktime = ProjectWorktimePerMonth.from_project_dirs(
-                        project_dir_list, WorktimeColumn.ACTUAL_WORKTIME_HOUR
-                    )
+                    project_actual_worktime = ProjectWorktimePerMonth.from_project_dirs(project_dir_list, WorktimeColumn.ACTUAL_WORKTIME_HOUR)
                     project_actual_worktime.to_csv(root_output_dir / "プロジェクごとの毎月の実績作業時間.csv")
 
-                    project_monitored_worktime = ProjectWorktimePerMonth.from_project_dirs(
-                        project_dir_list, WorktimeColumn.MONITORED_WORKTIME_HOUR
-                    )
+                    project_monitored_worktime = ProjectWorktimePerMonth.from_project_dirs(project_dir_list, WorktimeColumn.MONITORED_WORKTIME_HOUR)
                     project_monitored_worktime.to_csv(root_output_dir / "プロジェクごとの毎月の計測作業時間.csv")
 
                 else:

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -420,7 +420,7 @@ class VisualizeStatistics(AbstractCommandLineInterface):
             df_actual_worktime = pandas.read_csv(args.labor_csv)
             if not ActualWorktime.required_columns_exist(df_actual_worktime):
                 logger.error(
-                    "引数`--labor_csv`のCSVには以下の列が存在しないので、終了します。\n" "`project_id`, `date`, `account_id`, `actual_worktime_hour`"
+                    "引数`--labor_csv`のCSVには以下の列が存在しないので、終了します。\n`project_id`, `date`, `account_id`, `actual_worktime_hour`"
                 )
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
             actual_worktime = ActualWorktime(df_actual_worktime)

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -533,7 +533,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--latest",
         action="store_true",
         help="統計情報の元になるファイル（アノテーションzipなど）の最新版を参照します。このオプションを指定すると、各ファイルを更新するのに5分以上待ちます。\n"
-        "ただしWebAPIの都合上、'タスク履歴全件ファイル'は最新版を参照できません。タスク履歴の最新版を参照する場合は ``--get_task_histories_one_of_each`` を指定してください。",
+        "ただしWebAPIの都合上、'タスク履歴全件ファイル'は最新版を参照できません。タスク履歴の最新版を参照する場合は ``--get_task_histories_one_of_each`` を指定してください。",  # noqa: E501
     )
 
     parser.add_argument(

--- a/annofabcli/supplementary/delete_supplementary_data.py
+++ b/annofabcli/supplementary/delete_supplementary_data.py
@@ -48,9 +48,7 @@ def get_input_data_supplementary_data_dict_from_csv(csv_path: Path) -> InputData
     return input_data_dict
 
 
-def get_input_data_supplementary_data_dict_from_list(
-    supplementary_data_list: List[Dict[str, Any]]
-) -> InputDataSupplementaryDataDict:
+def get_input_data_supplementary_data_dict_from_list(supplementary_data_list: List[Dict[str, Any]]) -> InputDataSupplementaryDataDict:
     input_data_dict = defaultdict(list)
     for supplementary_data in supplementary_data_list:
         input_data_id = supplementary_data["input_data_id"]
@@ -65,9 +63,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
         self.facade = AnnofabApiFacade(service)
         AbstractCommandLineWithConfirmInterface.__init__(self, all_yes)
 
-    def delete_supplementary_data_list_for_input_data(
-        self, project_id: str, input_data_id: str, supplementary_data_id_list: List[str]
-    ) -> int:
+    def delete_supplementary_data_list_for_input_data(self, project_id: str, input_data_id: str, supplementary_data_id_list: List[str]) -> int:
         """
         入力データ配下の補助情報を削除する。
 
@@ -82,9 +78,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
         """
 
         def _get_supplementary_data_list(supplementary_data_id: str) -> Optional[Dict[str, Any]]:
-            return first_true(
-                supplementary_data_list, pred=lambda e: e["supplementary_data_id"] == supplementary_data_id
-            )
+            return first_true(supplementary_data_list, pred=lambda e: e["supplementary_data_id"] == supplementary_data_id)
 
         input_data = self.service.wrapper.get_input_data_or_none(project_id, input_data_id)
         if input_data is None:
@@ -111,9 +105,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
                 continue
 
             try:
-                self.service.api.delete_supplementary_data(
-                    project_id, input_data_id=input_data_id, supplementary_data_id=supplementary_data_id
-                )
+                self.service.api.delete_supplementary_data(project_id, input_data_id=input_data_id, supplementary_data_id=supplementary_data_id)
                 logger.debug(
                     f"補助情報 supplementary_data_id={supplementary_data_id}, "
                     f"supplementary_data_name={supplementary_data['supplementary_data_name']} を削除しました。"
@@ -135,9 +127,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
         total_count = sum(len(e) for e in input_data_dict.values())
         for input_data_id, supplementary_data_id_list in input_data_dict.items():
             try:
-                deleted_count += self.delete_supplementary_data_list_for_input_data(
-                    project_id, input_data_id, supplementary_data_id_list
-                )
+                deleted_count += self.delete_supplementary_data_list_for_input_data(project_id, input_data_id, supplementary_data_id_list)
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(e)
                 logger.warning(f"入力データ(input_data_id={input_data_id})配下の補助情報の削除に失敗しました。")
@@ -163,9 +153,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
         for supplementary_data in supplementary_data_list:
             supplementary_data_id = supplementary_data["supplementary_data_id"]
             try:
-                self.service.api.delete_supplementary_data(
-                    project_id, input_data_id=input_data_id, supplementary_data_id=supplementary_data_id
-                )
+                self.service.api.delete_supplementary_data(project_id, input_data_id=input_data_id, supplementary_data_id=supplementary_data_id)
                 logger.debug(
                     f"補助情報を削除しました。input_data_id={input_data_id}, supplementary_data_id={supplementary_data_id}, "
                     f"supplementary_data_name={supplementary_data['supplementary_data_name']}"

--- a/annofabcli/supplementary/list_supplementary_data.py
+++ b/annofabcli/supplementary/list_supplementary_data.py
@@ -28,9 +28,7 @@ class ListSupplementaryData(AbstractCommandLineInterface):
             all_input_data_id_list.extend(task["input_data_id_list"])
         return all_input_data_id_list
 
-    def get_all_supplementary_data_list(
-        self, project_id: str, input_data_id_list: List[str]
-    ) -> List[SupplementaryData]:
+    def get_all_supplementary_data_list(self, project_id: str, input_data_id_list: List[str]) -> List[SupplementaryData]:
         """
         補助情報一覧を取得する。
         """
@@ -40,9 +38,7 @@ class ListSupplementaryData(AbstractCommandLineInterface):
             if (index + 1) % 100 == 0:
                 logger.debug(f"{index+1} 件目の入力データを取得します。")
 
-            supplementary_data_list = self.service.wrapper.get_supplementary_data_list_or_none(
-                project_id, input_data_id
-            )
+            supplementary_data_list = self.service.wrapper.get_supplementary_data_list_or_none(project_id, input_data_id)
             if supplementary_data_list is not None:
                 all_supplementary_data_list.extend(supplementary_data_list)
             else:
@@ -50,9 +46,7 @@ class ListSupplementaryData(AbstractCommandLineInterface):
 
         return all_supplementary_data_list
 
-    def print_supplementary_data_list(
-        self, project_id: str, input_data_id_list: Optional[List[str]], task_id_list: Optional[List[str]]
-    ) -> None:
+    def print_supplementary_data_list(self, project_id: str, input_data_id_list: Optional[List[str]], task_id_list: Optional[List[str]]) -> None:
         """
         補助情報一覧を出力する
 
@@ -64,22 +58,16 @@ class ListSupplementaryData(AbstractCommandLineInterface):
                 logger.warning("input_data_id_listとtask_id_listの両方がNoneです。")
                 return
 
-        supplementary_data_list = self.get_all_supplementary_data_list(
-            project_id, input_data_id_list=input_data_id_list
-        )
+        supplementary_data_list = self.get_all_supplementary_data_list(project_id, input_data_id_list=input_data_id_list)
         logger.info(f"補助情報一覧の件数: {len(supplementary_data_list)}")
         self.print_according_to_format(supplementary_data_list)
 
     def main(self) -> None:
         args = self.args
-        input_data_id_list = (
-            annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
-        )
+        input_data_id_list = annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
 
-        self.print_supplementary_data_list(
-            project_id=args.project_id, input_data_id_list=input_data_id_list, task_id_list=task_id_list
-        )
+        self.print_supplementary_data_list(project_id=args.project_id, input_data_id_list=input_data_id_list, task_id_list=task_id_list)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -105,12 +93,11 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--input_data_id",
         type=str,
         nargs="+",
-        help="対象の入力データのinput_data_idを指定します。" + " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
+        help="対象の入力データのinput_data_idを指定します。"
+        + " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
     )
 
-    argument_parser.add_format(
-        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV
-    )
+    argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)
     argument_parser.add_output()
     argument_parser.add_csv_format()
 

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -88,9 +88,7 @@ class SubPutSupplementaryData:
             if supplementary_data.supplementary_data_type is not None:
                 request_body.update({"supplementary_data_type": supplementary_data.supplementary_data_type})
 
-            logger.debug(
-                f"'{file_path}'を補助情報として登録します。supplementary_data_name='{supplementary_data.supplementary_data_name}'"
-            )
+            logger.debug(f"'{file_path}'を補助情報として登録します。supplementary_data_name='{supplementary_data.supplementary_data_name}'")
             self.service.wrapper.put_supplementary_data_from_file(
                 project_id,
                 input_data_id=supplementary_data.input_data_id,
@@ -102,9 +100,7 @@ class SubPutSupplementaryData:
         else:
             supplementary_data_type = supplementary_data.supplementary_data_type
             if supplementary_data_type is None:
-                supplementary_data_type = (
-                    "text" if supplementary_data.supplementary_data_path.endswith(".txt") else "image"
-                )
+                supplementary_data_type = "text" if supplementary_data.supplementary_data_path.endswith(".txt") else "image"
 
             request_body = {
                 "supplementary_data_name": supplementary_data.supplementary_data_name,
@@ -144,12 +140,8 @@ class SubPutSupplementaryData:
 
         return yes
 
-    def confirm_put_supplementary_data(
-        self, csv_supplementary_data: CsvSupplementaryData, already_exists: bool = False
-    ) -> bool:
-        message_for_confirm = (
-            f"supplementary_data_name='{csv_supplementary_data.supplementary_data_name}' の補助情報を登録しますか？"
-        )
+    def confirm_put_supplementary_data(self, csv_supplementary_data: CsvSupplementaryData, already_exists: bool = False) -> bool:
+        message_for_confirm = f"supplementary_data_name='{csv_supplementary_data.supplementary_data_name}' の補助情報を登録しますか？"
         if already_exists:
             message_for_confirm += f"supplementary_data_id={csv_supplementary_data.supplementary_data_id} を上書きします。"
         return self.confirm_processing(message_for_confirm)
@@ -161,21 +153,15 @@ class SubPutSupplementaryData:
             self.supplementary_data_cache[key] = supplementary_data_list if supplementary_data_list is not None else []
         return self.supplementary_data_cache[key]
 
-    def get_supplementary_data_by_id(
-        self, project_id: str, input_data_id: str, supplementary_data_id: str
-    ) -> Optional[SupplementaryData]:
+    def get_supplementary_data_by_id(self, project_id: str, input_data_id: str, supplementary_data_id: str) -> Optional[SupplementaryData]:
         cached_list = self.get_supplementary_data_list_cached(project_id, input_data_id)
         return first_true(cached_list, pred=lambda e: e["supplementary_data_id"] == supplementary_data_id)
 
-    def get_supplementary_data_by_number(
-        self, project_id: str, input_data_id: str, supplementary_data_number: int
-    ) -> Optional[SupplementaryData]:
+    def get_supplementary_data_by_number(self, project_id: str, input_data_id: str, supplementary_data_number: int) -> Optional[SupplementaryData]:
         cached_list = self.get_supplementary_data_list_cached(project_id, input_data_id)
         return first_true(cached_list, pred=lambda e: e["supplementary_data_number"] == supplementary_data_number)
 
-    def put_supplementary_data_main(
-        self, project_id: str, csv_supplementary_data: CsvSupplementaryData, overwrite: bool = False
-    ) -> bool:
+    def put_supplementary_data_main(self, project_id: str, csv_supplementary_data: CsvSupplementaryData, overwrite: bool = False) -> bool:
         last_updated_datetime = None
         input_data_id = csv_supplementary_data.input_data_id
         supplementary_data_id = csv_supplementary_data.supplementary_data_id
@@ -191,17 +177,9 @@ class SubPutSupplementaryData:
             old_supplementary_data = self.get_supplementary_data_by_id(project_id, input_data_id, supplementary_data_id)
         else:
             supplementary_data_number = csv_supplementary_data.supplementary_data_number
-            old_supplementary_data_key = (
-                f"input_data_id={input_data_id}, supplementary_data_number={supplementary_data_number}"
-            )
-            old_supplementary_data = self.get_supplementary_data_by_number(
-                project_id, input_data_id, supplementary_data_number
-            )
-            supplementary_data_id = (
-                old_supplementary_data["supplementary_data_id"]
-                if old_supplementary_data is not None
-                else str(uuid.uuid4())
-            )
+            old_supplementary_data_key = f"input_data_id={input_data_id}, supplementary_data_number={supplementary_data_number}"
+            old_supplementary_data = self.get_supplementary_data_by_number(project_id, input_data_id, supplementary_data_number)
+            supplementary_data_id = old_supplementary_data["supplementary_data_id"] if old_supplementary_data is not None else str(uuid.uuid4())
 
         if old_supplementary_data is not None:
             if overwrite:
@@ -218,9 +196,7 @@ class SubPutSupplementaryData:
                 logger.warning(f"'{supplementary_data_path}' は存在しません。")
                 return False
 
-        if not self.confirm_put_supplementary_data(
-            csv_supplementary_data, already_exists=(last_updated_datetime is not None)
-        ):
+        if not self.confirm_put_supplementary_data(csv_supplementary_data, already_exists=(last_updated_datetime is not None)):
             return False
 
         # 補助情報を登録
@@ -291,18 +267,14 @@ class PutSupplementaryData(AbstractCommandLineInterface):
 
         else:
             for csv_supplementary_data in supplementary_data_list:
-                result = obj.put_supplementary_data_main(
-                    project_id, csv_supplementary_data=csv_supplementary_data, overwrite=overwrite
-                )
+                result = obj.put_supplementary_data_main(project_id, csv_supplementary_data=csv_supplementary_data, overwrite=overwrite)
                 if result:
                     count_put_supplementary_data += 1
 
         logger.info(f"{project_title} に、{count_put_supplementary_data} / {len(supplementary_data_list)} 件の補助情報を登録しました。")
 
     @staticmethod
-    def get_supplementary_data_list_from_dict(
-        supplementary_data_dict_list: List[Dict[str, Any]]
-    ) -> List[CsvSupplementaryData]:
+    def get_supplementary_data_list_from_dict(supplementary_data_dict_list: List[Dict[str, Any]]) -> List[CsvSupplementaryData]:
         return [CsvSupplementaryData.from_dict(e) for e in supplementary_data_dict_list]
 
     @staticmethod

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -196,7 +196,7 @@ class SubPutSupplementaryData:
                 logger.warning(f"'{supplementary_data_path}' は存在しません。")
                 return False
 
-        if not self.confirm_put_supplementary_data(csv_supplementary_data, already_exists=(last_updated_datetime is not None)):
+        if not self.confirm_put_supplementary_data(csv_supplementary_data, already_exists=last_updated_datetime is not None):
             return False
 
         # 補助情報を登録

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -251,7 +251,7 @@ class PutSupplementaryData(AbstractCommandLineInterface):
             overwrite: Trueならば、supplementary_data_id（省略時はsupplementary_data_number）がすでに存在していたら上書きします。Falseならばスキップします。
             parallelism: 並列度
 
-        """
+        """  # noqa: E501
 
         project_title = self.facade.get_project_title(project_id)
         logger.info(f"{project_title} に、{len(supplementary_data_list)} 件の補助情報を登録します。")

--- a/annofabcli/supplementary/subcommand_supplementary.py
+++ b/annofabcli/supplementary/subcommand_supplementary.py
@@ -22,8 +22,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "補助情報関係のサブコマンド"
     description = "補助情報関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/task/cancel_acceptance.py
+++ b/annofabcli/task/cancel_acceptance.py
@@ -73,10 +73,7 @@ class CancelAcceptanceMain(AbstractCommandLineWithConfirmInterface):
                 return False
 
             if task["phase"] != TaskPhase.ACCEPTANCE.value or task["status"] != TaskStatus.COMPLETE.value:
-                logger.warning(
-                    f"{logging_prefix}: task_id = {task_id} は受入完了でありません。"
-                    f"status = {task['status']}, phase={task['phase']}"
-                )
+                logger.warning(f"{logging_prefix}: task_id = {task_id} は受入完了でありません。" f"status = {task['status']}, phase={task['phase']}")
                 return False
 
             actual_acceptor: Optional[User] = None
@@ -86,9 +83,7 @@ class CancelAcceptanceMain(AbstractCommandLineWithConfirmInterface):
                 if acceptor_account_id is not None:
                     member = self.get_project_member_from_account_id(acceptor_account_id)
                     if member is not None:
-                        actual_acceptor = User(
-                            account_id=member["account_id"], user_id=member["user_id"], username=member["username"]
-                        )
+                        actual_acceptor = User(account_id=member["account_id"], user_id=member["user_id"], username=member["username"])
                     else:
                         logger.warning(
                             f"{logging_prefix}: task_id = {task_id} の最後の受入フェーズを担当したユーザ"
@@ -113,9 +108,7 @@ class CancelAcceptanceMain(AbstractCommandLineWithConfirmInterface):
 
             operator_account_id = actual_acceptor.account_id if actual_acceptor is not None else None
             if not dryrun:
-                self.service.wrapper.cancel_completed_task(
-                    self.project_id, task_id, operator_account_id=operator_account_id
-                )
+                self.service.wrapper.cancel_completed_task(self.project_id, task_id, operator_account_id=operator_account_id)
             logger.info(f"{logging_prefix} : task_id = {task_id} の受け入れ取り消しが成功しました。")
             return True
 
@@ -237,9 +230,7 @@ class CancelAcceptance(AbstractCommandLineInterface):
         acceptor: Optional[User] = None  # 受入担当者
         if assigned_acceptor_user_id is not None:
             project_member_list = self.service.wrapper.get_all_project_members(args.project_id)
-            member = more_itertools.first_true(
-                project_member_list, pred=lambda e: e["user_id"] == assigned_acceptor_user_id
-            )
+            member = more_itertools.first_true(project_member_list, pred=lambda e: e["user_id"] == assigned_acceptor_user_id)
             if member is None:
                 print(
                     f"{self.COMMON_MESSAGE} argument --assigned_acceptor_user_id: プロジェクトメンバーに user_id='{assigned_acceptor_user_id}'メンバーは存在しません",  # noqa: E501
@@ -288,7 +279,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     assign_group = parser.add_mutually_exclusive_group()
 
     assign_group.add_argument(
-        "--not_assign", action="store_true", help="受入を取り消した後のタスクの担当者を未割り当てにします。" "指定しない場合は、最後の受入phaseの担当者が割り当てます。"
+        "--not_assign",
+        action="store_true",
+        help="受入を取り消した後のタスクの担当者を未割り当てにします。" "指定しない場合は、最後の受入phaseの担当者が割り当てます。",
     )
 
     assign_group.add_argument(
@@ -300,7 +293,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_query()
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.add_argument("--dryrun", action="store_true", help="取り消しが行われた時の結果を表示しますが、実際は受け入れを取り消しません。")

--- a/annofabcli/task/cancel_acceptance.py
+++ b/annofabcli/task/cancel_acceptance.py
@@ -295,7 +295,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.add_argument("--dryrun", action="store_true", help="取り消しが行われた時の結果を表示しますが、実際は受け入れを取り消しません。")

--- a/annofabcli/task/change_operator.py
+++ b/annofabcli/task/change_operator.py
@@ -90,9 +90,7 @@ class ChangeOperatorMain:
             return False
 
         if not match_task_with_query(task, task_query):
-            logger.debug(
-                f"{logging_prefix} : task_id = {task_id} : `--task_query` の条件にマッチしないため、スキップします。task_query={task_query}"
-            )
+            logger.debug(f"{logging_prefix} : task_id = {task_id} : `--task_query` の条件にマッチしないため、スキップします。task_query={task_query}")
             return False
 
         if not self.confirm_change_operator(task):
@@ -252,7 +250,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_query()
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/change_operator.py
+++ b/annofabcli/task/change_operator.py
@@ -252,7 +252,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/change_status_to_break.py
+++ b/annofabcli/task/change_status_to_break.py
@@ -202,7 +202,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/change_status_to_break.py
+++ b/annofabcli/task/change_status_to_break.py
@@ -50,9 +50,7 @@ class ChangeStatusToBreakMain(AbstractCommandLineWithConfirmInterface):
         task: Task = Task.from_dict(dict_task)
 
         if not match_task_with_query(task, task_query):
-            logger.debug(
-                f"{logging_prefix} : task_id = {task_id} : `--task_query` の条件にマッチしないため、スキップします。task_query={task_query}"
-            )
+            logger.debug(f"{logging_prefix} : task_id = {task_id} : `--task_query` の条件にマッチしないため、スキップします。task_query={task_query}")
             return False
 
         if task.status not in (TaskStatus.WORKING, TaskStatus.ON_HOLD):
@@ -176,9 +174,7 @@ class ChangeStatusToBreak(AbstractCommandLineInterface):
         task_query: Optional[TaskQuery] = TaskQuery.from_dict(dict_task_query) if dict_task_query is not None else None
 
         project_id = args.project_id
-        super().validate_project(
-            project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.ACCEPTER, ProjectMemberRole.WORKER]
-        )
+        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.ACCEPTER, ProjectMemberRole.WORKER])
 
         main_obj = ChangeStatusToBreakMain(self.service, all_yes=self.all_yes)
         main_obj.change_status_to_break(
@@ -204,7 +200,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_query()
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/change_status_to_on_hold.py
+++ b/annofabcli/task/change_status_to_on_hold.py
@@ -126,9 +126,7 @@ class ChangingStatusToOnHoldMain(AbstractCommandLineWithConfirmInterface):
             # 休憩中または未着手状態から保留中状態にするには、一旦作業中状態に変更する必要がある
             # 作業中状態にするには、担当者が自分でないといけないので、担当者も自分自身に変更する
             if task.account_id != self.service.api.account_id:
-                updated_task = self.service.wrapper.change_task_operator(
-                    self.project_id, task.task_id, self.service.api.account_id
-                )
+                updated_task = self.service.wrapper.change_task_operator(self.project_id, task.task_id, self.service.api.account_id)
                 task_last_updated_datetime = updated_task["updated_datetime"]
                 logger.debug(f"{logging_prefix}: task_id='{task_id}' のタスクの担当者を'{task_user_id}'から自分自身に変更しました。")
 
@@ -155,9 +153,7 @@ class ChangingStatusToOnHoldMain(AbstractCommandLineWithConfirmInterface):
 
         try:
             # ステータスを保留中状態に変更する
-            self.service.wrapper.change_task_status_to_on_hold(
-                self.project_id, task_id, last_updated_datetime=task_last_updated_datetime
-            )
+            self.service.wrapper.change_task_status_to_on_hold(self.project_id, task_id, last_updated_datetime=task_last_updated_datetime)
             logger.debug(f"{logging_prefix} : task_id='{task_id}' のタスクのステータスを保留中に変更しました。")
             return True
 
@@ -266,9 +262,7 @@ class ChangingStatusToOnHold(AbstractCommandLineInterface):
         task_query: Optional[TaskQuery] = TaskQuery.from_dict(dict_task_query) if dict_task_query is not None else None
 
         project_id = args.project_id
-        super().validate_project(
-            project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.ACCEPTER, ProjectMemberRole.WORKER]
-        )
+        super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.ACCEPTER, ProjectMemberRole.WORKER])
 
         main_obj = ChangingStatusToOnHoldMain(self.service, project_id=project_id, all_yes=self.all_yes)
         main_obj.change_status_to_on_hold(
@@ -296,7 +290,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--comment", type=str, help="保留コメントを指定してください。保留コメントは先頭の入力データに付与します。")
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/complete_tasks.py
+++ b/annofabcli/task/complete_tasks.py
@@ -99,9 +99,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
 
         request_body = [to_req_inspection(e) for e in unanswered_comment_list]
 
-        return self.service.api.batch_update_comments(
-            task.project_id, task.task_id, input_data_id, request_body=request_body
-        )[0]
+        return self.service.api.batch_update_comments(task.project_id, task.task_id, input_data_id, request_body=request_body)[0]
 
     def update_status_of_inspections(
         self,
@@ -153,9 +151,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
         Returns:
 
         """
-        comment_list, _ = self.service.api.get_comments(
-            task.project_id, task.task_id, input_data_id, query_params={"v": "2"}
-        )
+        comment_list, _ = self.service.api.get_comments(task.project_id, task.task_id, input_data_id, query_params={"v": "2"})
         return [
             e
             for e in comment_list
@@ -227,21 +223,15 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
             )
             return answered_comment is not None
 
-        comment_list, _ = self.service.api.get_comments(
-            task.project_id, task.task_id, input_data_id, query_params={"v": "2"}
-        )
+        comment_list, _ = self.service.api.get_comments(task.project_id, task.task_id, input_data_id, query_params={"v": "2"})
         # 未処置の検査コメント
         unprocessed_inspection_list = [
             e
             for e in comment_list
-            if e["comment_type"] == "inspection"
-            and e["comment_node"]["_type"] == "Root"
-            and e["comment_node"]["status"] == "open"
+            if e["comment_type"] == "inspection" and e["comment_node"]["_type"] == "Root" and e["comment_node"]["status"] == "open"
         ]
 
-        unanswered_comment_list = [
-            e for e in unprocessed_inspection_list if not exists_answered_comment(e["comment_id"])
-        ]
+        unanswered_comment_list = [e for e in unprocessed_inspection_list if not exists_answered_comment(e["comment_id"])]
         return unanswered_comment_list
 
     def complete_task_for_annotation_phase(
@@ -271,7 +261,9 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
         logger.debug(f"{task.task_id}: 未回答の検査コメントが {unanswered_comment_count_for_task} 件あります。")
         if unanswered_comment_count_for_task > 0:
             if reply_comment is None:
-                logger.warning(f"{task.task_id}: 未回答の検査コメントに対する返信コメント（'--reply_comment'）が指定されていないので、スキップします。")
+                logger.warning(
+                    f"{task.task_id}: 未回答の検査コメントに対する返信コメント（'--reply_comment'）が指定されていないので、スキップします。"
+                )
                 return False
 
         if not self.confirm_processing(f"タスク'{task.task_id}'の教師付フェーズを次のフェーズに進めますか？"):
@@ -310,7 +302,9 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
         logger.debug(f"{task.task_id}: 未処置の検査コメントが {unprocessed_inspection_count} 件あります。")
         if unprocessed_inspection_count > 0:
             if inspection_status is None:
-                logger.warning(f"{task.task_id}: 未処置の検査コメントに対する対応方法（'--inspection_status'）が指定されていないので、スキップします。")
+                logger.warning(
+                    f"{task.task_id}: 未処置の検査コメントに対する対応方法（'--inspection_status'）が指定されていないので、スキップします。"
+                )
                 return False
 
         if not self.confirm_processing(f"タスク'{task.task_id}'の検査/受入フェーズを次のフェーズに進めますか？"):
@@ -320,9 +314,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
 
         if unprocessed_inspection_count > 0:
             assert inspection_status is not None
-            logger.debug(
-                f"{task.task_id}: 未処置の検査コメント {unprocessed_inspection_count} 件を、{inspection_status.value} 状態にします。"
-            )
+            logger.debug(f"{task.task_id}: 未処置の検査コメント {unprocessed_inspection_count} 件を、{inspection_status.value} 状態にします。")
             for input_data_id, unprocessed_inspection_list in unprocessed_inspection_list_dict.items():
                 if len(unprocessed_inspection_list) == 0:
                     continue
@@ -339,9 +331,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
         return True
 
     @staticmethod
-    def _validate_task(
-        task: Task, target_phase: TaskPhase, target_phase_stage: int, task_query: Optional[TaskQuery]
-    ) -> bool:
+    def _validate_task(task: Task, target_phase: TaskPhase, target_phase_stage: int, task_query: Optional[TaskQuery]) -> bool:
         if not (task.phase == target_phase and task.phase_stage == target_phase_stage):
             logger.warning(f"{task.task_id} は操作対象のフェーズ、フェーズステージではないため、スキップします。")
             return False
@@ -378,9 +368,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
             f"{logging_prefix} : タスク情報 task_id={task_id}, "
             f"phase={task.phase.value}, phase_stage={task.phase_stage}, status={task.status.value}"
         )
-        if not self._validate_task(
-            task, target_phase=target_phase, target_phase_stage=target_phase_stage, task_query=task_query
-        ):
+        if not self._validate_task(task, target_phase=target_phase, target_phase_stage=target_phase_stage, task_query=task_query):
             return False
 
         try:
@@ -590,7 +578,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_query()
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/complete_tasks.py
+++ b/annofabcli/task/complete_tasks.py
@@ -580,7 +580,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/copy_tasks.py
+++ b/annofabcli/task/copy_tasks.py
@@ -144,9 +144,7 @@ class CopyTasksMain(AbstractCommandLineWithConfirmInterface):
                     if result:
                         success_count += 1
                 except Exception:  # pylint: disable=broad-except
-                    logger.warning(
-                        f"タスク'{copy_target.src_task_id}'を'{copy_target.dest_task_id}'にコピーする際に失敗しました。", exc_info=True
-                    )
+                    logger.warning(f"タスク'{copy_target.src_task_id}'を'{copy_target.dest_task_id}'にコピーする際に失敗しました。", exc_info=True)
                     continue
 
         logger.info(f"{success_count} / {len(copy_target_list)} 件 タスクをコピーしました。")
@@ -204,13 +202,16 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         nargs="+",
         required=True,
-        help="コピー元のtask_idとコピー先のtask_idを ``:`` で区切って指定してください。\n" "``file://`` を先頭に付けると、コピー元とコピー先が記載されているファイルを指定できます。",
+        help="コピー元のtask_idとコピー先のtask_idを ``:`` で区切って指定してください。\n"
+        "``file://`` を先頭に付けると、コピー元とコピー先が記載されているファイルを指定できます。",
     )
 
     parser.add_argument("--copy_metadata", action="store_true", help="指定した場合、タスクのメタデータもコピーします。")
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/copy_tasks.py
+++ b/annofabcli/task/copy_tasks.py
@@ -211,7 +211,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -46,9 +46,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
         if len(supplementary_data_list) == 0:
             return 0
 
-        logger.debug(
-            f"task_id='{task_id}', input_data_id='{input_data_id}' :: 補助情報 {len(supplementary_data_list)} 件を削除します。"
-        )
+        logger.debug(f"task_id='{task_id}', input_data_id='{input_data_id}' :: 補助情報 {len(supplementary_data_list)} 件を削除します。")
 
         deleted_count = 0
         for supplementary_data in supplementary_data_list:
@@ -157,9 +155,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
 
         return True
 
-    def delete_task(
-        self, task_id: str, task_query: Optional[TaskQuery] = None, task_index: Optional[int] = None
-    ) -> bool:
+    def delete_task(self, task_id: str, task_query: Optional[TaskQuery] = None, task_index: Optional[int] = None) -> bool:
         """
         タスクを削除します。
 
@@ -186,10 +182,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{log_prefix} :: タスクは存在しません。")
             return False
 
-        logger.debug(
-            f"{log_prefix} :: status={task['status']}, "
-            f"phase={task['phase']}, updated_datetime={task['updated_datetime']}"
-        )
+        logger.debug(f"{log_prefix} :: status={task['status']}, " f"phase={task['phase']}, updated_datetime={task['updated_datetime']}")
 
         if not self._should_delete_task(task, log_prefix, task_query=task_query):
             return False
@@ -206,9 +199,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
                     if result:
                         deleted_input_data_count += 1
                 except Exception:  # pylint: disable=broad-except
-                    logger.warning(
-                        f"{log_prefix} :: 入力データの削除に失敗しました。 :: input_data_id='{input_data_id}'", exc_info=True
-                    )
+                    logger.warning(f"{log_prefix} :: 入力データの削除に失敗しました。 :: input_data_id='{input_data_id}'", exc_info=True)
                 continue
             if deleted_input_data_count > 0:
                 logger.debug(f"{log_prefix} :: {deleted_input_data_count} 件の入力データを削除しました。")
@@ -306,7 +297,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "delete"
     subcommand_help = "タスクを削除します。"
-    description = "タスクを削除します。ただし、作業中/完了状態のタスクは削除できません。デフォルトは、アノテーションが付与されているタスクは削除できません。"
+    description = (
+        "タスクを削除します。ただし、作業中/完了状態のタスクは削除できません。デフォルトは、アノテーションが付与されているタスクは削除できません。"
+    )
     epilog = "オーナロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/task/list_all_tasks.py
+++ b/annofabcli/task/list_all_tasks.py
@@ -68,9 +68,7 @@ class ListTasksWithJsonMain:
 
         logger.debug("出力対象のタスクを抽出しています。")
         task_id_set = set(task_id_list) if task_id_list is not None else None
-        filtered_task_list = [
-            e for e in task_list if self.match_task_with_conditions(e, task_query=task_query, task_id_set=task_id_set)
-        ]
+        filtered_task_list = [e for e in task_list if self.match_task_with_conditions(e, task_query=task_query, task_id_set=task_id_set)]
 
         visualize_obj = AddProps(self.service, project_id)
         return [visualize_obj.add_properties_to_task(e) for e in filtered_task_list]
@@ -81,11 +79,7 @@ class ListTasksWithJson(AbstractCommandLineInterface):
         args = self.args
 
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
-        task_query = (
-            TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query))
-            if args.task_query is not None
-            else None
-        )
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
         project_id = args.project_id
         super().validate_project(project_id, project_member_roles=None)

--- a/annofabcli/task/list_all_tasks.py
+++ b/annofabcli/task/list_all_tasks.py
@@ -148,7 +148,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "list_all"
     subcommand_help = "すべてのタスクの一覧を出力します。"
-    description = "すべてのタスクの一覧を出力します。\n出力されるタスクは、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力したい場合は、 ``--latest`` を指定してください。"
+    description = "すべてのタスクの一覧を出力します。\n出力されるタスクは、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力したい場合は、 ``--latest`` を指定してください。"  # noqa: E501
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
     parse_args(parser)
     return parser

--- a/annofabcli/task/list_all_tasks_added_task_history.py
+++ b/annofabcli/task/list_all_tasks_added_task_history.py
@@ -110,9 +110,7 @@ class ListAllTasksAddedTaskHistoryMain:
 
         task_id_set = set(task_id_list) if task_id_list is not None else None
         logger.debug("出力対象のタスクを抽出しています。")
-        filtered_task_list = [
-            e for e in task_list if self.match_task_with_conditions(e, task_query=task_query, task_id_set=task_id_set)
-        ]
+        filtered_task_list = [e for e in task_list if self.match_task_with_conditions(e, task_query=task_query, task_id_set=task_id_set)]
         return filtered_task_list
 
     def get_task_list_added_task_history(
@@ -143,9 +141,7 @@ class ListAllTasksAddedTaskHistory(AbstractCommandLineInterface):
     @staticmethod
     def validate(args: argparse.Namespace) -> bool:
         COMMON_MESSAGE = "annofabcli task list_merged_task_history: error:"
-        if (args.task_json is None and args.task_history_json is not None) or (
-            args.task_json is not None and args.task_history_json is None
-        ):
+        if (args.task_json is None and args.task_history_json is not None) or (args.task_json is not None and args.task_history_json is None):
             print(
                 f"{COMMON_MESSAGE} '--task_json'と'--task_history_json'の両方を指定する必要があります。",
                 file=sys.stderr,
@@ -162,11 +158,7 @@ class ListAllTasksAddedTaskHistory(AbstractCommandLineInterface):
         project_id = args.project_id
 
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
-        task_query = (
-            TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query))
-            if args.task_query is not None
-            else None
-        )
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
         self.validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
@@ -178,9 +170,7 @@ class ListAllTasksAddedTaskHistory(AbstractCommandLineInterface):
         )
 
         logger.info(f"タスク一覧の件数: {len(task_list)}")
-        TasksAddedTaskHistoryOutput(task_list).output(
-            output_path=args.output, output_format=FormatArgument(args.format)
-        )
+        TasksAddedTaskHistoryOutput(task_list).output(output_path=args.output, output_format=FormatArgument(args.format))
 
 
 def main(args: argparse.Namespace) -> None:

--- a/annofabcli/task/list_tasks.py
+++ b/annofabcli/task/list_tasks.py
@@ -153,7 +153,7 @@ class ListTasks(AbstractCommandLineInterface):
         super().__init__(service, facade, args)
         self.visualize = AddProps(self.service, args.project_id)
 
-    PRIOR_COLUMNS = [
+    PRIOR_COLUMNS = [  # noqa: RUF012
         "project_id",
         "task_id",
         "phase",

--- a/annofabcli/task/list_tasks_added_task_history.py
+++ b/annofabcli/task/list_tasks_added_task_history.py
@@ -157,10 +157,7 @@ class AddingAdditionalInfoToTask:
         # スキップされた履歴より後に検査フェーズがなければ、検査がスキップされたタスクとみなす
         last_task_history_index = task_history_index_list[-1]
         return (
-            more_itertools.first_true(
-                task_histories[last_task_history_index + 1 :], pred=lambda e: e["phase"] == TaskPhase.INSPECTION.value
-            )
-            is None
+            more_itertools.first_true(task_histories[last_task_history_index + 1 :], pred=lambda e: e["phase"] == TaskPhase.INSPECTION.value) is None
         )
 
     def _add_task_history_info(self, task: Task, task_history: Optional[TaskHistory], column_prefix: str) -> Task:
@@ -190,9 +187,7 @@ class AddingAdditionalInfoToTask:
         task.update(
             {
                 f"{column_prefix}_started_datetime": task_history["started_datetime"],
-                f"{column_prefix}_worktime_hour": annofabcli.common.utils.isoduration_to_hour(
-                    task_history["accumulated_labor_time_milliseconds"]
-                ),
+                f"{column_prefix}_worktime_hour": annofabcli.common.utils.isoduration_to_hour(task_history["accumulated_labor_time_milliseconds"]),
             }
         )
 
@@ -209,9 +204,7 @@ class AddingAdditionalInfoToTask:
 
         return task
 
-    def _add_task_history_info_by_phase(
-        self, task: dict[str, Any], task_histories: list[TaskHistory], phase: TaskPhase
-    ) -> Task:
+    def _add_task_history_info_by_phase(self, task: dict[str, Any], task_histories: list[TaskHistory], phase: TaskPhase) -> Task:
         if task_histories is not None:
             task_history_by_phase = [
                 e
@@ -229,8 +222,7 @@ class AddingAdditionalInfoToTask:
 
         # 作業時間に関する情報を設定
         task[f"{phase.value}_worktime_hour"] = sum(
-            annofabcli.common.utils.isoduration_to_hour(e["accumulated_labor_time_milliseconds"])
-            for e in task_history_by_phase
+            annofabcli.common.utils.isoduration_to_hour(e["accumulated_labor_time_milliseconds"]) for e in task_history_by_phase
         )
 
         return task

--- a/annofabcli/task/list_tasks_added_task_history.py
+++ b/annofabcli/task/list_tasks_added_task_history.py
@@ -130,7 +130,7 @@ class AddingAdditionalInfoToTask:
             return False
 
         # スキップされた履歴より後に受入フェーズがなければ、受入がスキップされたタスクとみなす
-        # ただし、スキップされた履歴より後で、「アノテーション一覧で修正された」受入フェーズがある場合（account_id is None）は、スキップされた受入とみなす。
+        # ただし、スキップされた履歴より後で、「アノテーション一覧で修正された」受入フェーズがある場合（account_id is None）は、スキップされた受入とみなす。  # noqa: E501
         last_task_history_index = task_history_index_list[-1]
         return (
             more_itertools.first_true(

--- a/annofabcli/task/put_tasks.py
+++ b/annofabcli/task/put_tasks.py
@@ -143,9 +143,7 @@ class PuttingTaskMain:
         logger.debug("'initiate_tasks_generation' WebAPIを用いてタスクを生成します。")
         content = self.service.wrapper.initiate_tasks_generation_by_csv(self.project_id, csvfile_path=str(csv_file))
         job = content["job"]
-        logger.info(
-            f"Annofab上でタスク作成処理が開始されました。 :: csv_file='{csv_file}', job_type='{job['job_type']}', job_id='{job['job_id']}'"
-        )
+        logger.info(f"Annofab上でタスク作成処理が開始されました。 :: csv_file='{csv_file}', job_type='{job['job_type']}', job_id='{job['job_id']}'")
         if self.should_wait:
             self.wait_for_completion(job["job_id"])
         else:

--- a/annofabcli/task/put_tasks.py
+++ b/annofabcli/task/put_tasks.py
@@ -144,7 +144,7 @@ class PuttingTaskMain:
         content = self.service.wrapper.initiate_tasks_generation_by_csv(self.project_id, csvfile_path=str(csv_file))
         job = content["job"]
         logger.info(
-            f"Annofab上でタスク作成処理が開始されました。 :: csv_file='{csv_file}', job_type='{job['job_type']}', job_id='{job['job_id']}'"  # noqa: E501
+            f"Annofab上でタスク作成処理が開始されました。 :: csv_file='{csv_file}', job_type='{job['job_type']}', job_id='{job['job_id']}'"
         )
         if self.should_wait:
             self.wait_for_completion(job["job_id"])
@@ -293,7 +293,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--wait", action="store_true", help="タスク登録ジョブが終了するまで待ちます。``initiate_tasks_generation`` WebAPIを使うときのみ有効なオプションです。"
+        "--wait",
+        action="store_true",
+        help="タスク登録ジョブが終了するまで待ちます。``initiate_tasks_generation`` WebAPIを使うときのみ有効なオプションです。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/put_tasks.py
+++ b/annofabcli/task/put_tasks.py
@@ -68,7 +68,7 @@ def create_task_relation_csv(task_relation_dict: TaskInputRelation, csv_file: Pa
     tmp_list = []
     for task_id, input_data_id_list in task_relation_dict.items():
         for input_data_id in input_data_id_list:
-            tmp_list.append({"task_id": task_id, "input_data_id": input_data_id})
+            tmp_list.append({"task_id": task_id, "input_data_id": input_data_id})  # noqa: PERF401
     df = pandas.DataFrame(tmp_list)
 
     # webapiの都合上、2列目は空文字でないといけない

--- a/annofabcli/task/put_tasks_by_count.py
+++ b/annofabcli/task/put_tasks_by_count.py
@@ -57,9 +57,7 @@ class PuttingTaskByCountMain:
         }
         content, _ = self.service.api.initiate_tasks_generation(self.project_id, request_body=request_body)
         job = content["job"]
-        logger.info(
-            f"Annofab上でタスク作成処理が開始されました。 :: task_id_prefix='{task_id_prefix}', input_data_count='input_data_count'"
-        )
+        logger.info(f"Annofab上でタスク作成処理が開始されました。 :: task_id_prefix='{task_id_prefix}', input_data_count='input_data_count'")
         if should_wait:
             self.wait_for_completion(job["job_id"])
         else:
@@ -126,7 +124,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("--task_id_prefix", type=str, required=True, help="生成するタスクIDのプレフィックス")
 
-    parser.add_argument("--input_data_count", type=int, required=True, help="タスクに割り当てる入力データの個数。動画プロジェクトの場合は1を指定してください。")
+    parser.add_argument(
+        "--input_data_count", type=int, required=True, help="タスクに割り当てる入力データの個数。動画プロジェクトの場合は1を指定してください。"
+    )
 
     parser.add_argument(
         "--allow_duplicate_input_data", action="store_true", help="指定すると、既にタスクに使われている入力データを使ってタスクを作成します。"

--- a/annofabcli/task/reject_tasks.py
+++ b/annofabcli/task/reject_tasks.py
@@ -32,9 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
-    def __init__(
-        self, service: annofabapi.Resource, *, comment_data: Optional[dict[str, Any]], all_yes: bool = False
-    ) -> None:
+    def __init__(self, service: annofabapi.Resource, *, comment_data: Optional[dict[str, Any]], all_yes: bool = False) -> None:
         self.service = service
         self.facade = AnnofabApiFacade(service)
         self.comment_data = comment_data
@@ -73,13 +71,9 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
             }
         ]
 
-        return self.service.api.batch_update_comments(
-            project_id, task["task_id"], first_input_data_id, request_body=req_inspection
-        )[0]
+        return self.service.api.batch_update_comments(project_id, task["task_id"], first_input_data_id, request_body=req_inspection)[0]
 
-    def confirm_reject_task(
-        self, task_id: str, assign_last_annotator: bool, assigned_annotator_user_id: Optional[str]
-    ) -> bool:
+    def confirm_reject_task(self, task_id: str, assign_last_annotator: bool, assigned_annotator_user_id: Optional[str]) -> bool:
         confirm_message = f"task_id = {task_id} のタスクを差し戻しますか？"
         if assign_last_annotator:
             confirm_message += "最後のannotation phaseの担当者を割り当てます。"
@@ -115,9 +109,7 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
                 last_updated_datetime = _task["updated_datetime"]
                 logger.debug(f"{task_id}: 担当者を自分自身に変更しました。")
 
-            changed_task = self.service.wrapper.change_task_status_to_working(
-                project_id, task_id, last_updated_datetime=last_updated_datetime
-            )
+            changed_task = self.service.wrapper.change_task_status_to_working(project_id, task_id, last_updated_datetime=last_updated_datetime)
             return changed_task
 
         except requests.HTTPError:
@@ -152,9 +144,7 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
             logger.debug(f"task_id = {task_id} : `--task_query`の条件にマッチしないため、スキップします。task_query={task_query}")
             return False
 
-        if not self.confirm_reject_task(
-            task_id, assign_last_annotator=assign_last_annotator, assigned_annotator_user_id=assigned_annotator_user_id
-        ):
+        if not self.confirm_reject_task(task_id, assign_last_annotator=assign_last_annotator, assigned_annotator_user_id=assigned_annotator_user_id):
             return False
 
         return True
@@ -203,17 +193,13 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
                 try:
                     self.add_inspection_comment(project_id, task, inspection_comment)
                     # 作業時間が増えすぎないようにするため、すぐに休憩中状態にする
-                    task = self.service.wrapper.change_task_status_to_break(
-                        project_id, task_id, last_updated_datetime=task["updated_datetime"]
-                    )
+                    task = self.service.wrapper.change_task_status_to_break(project_id, task_id, last_updated_datetime=task["updated_datetime"])
                     logger.debug(f"{logging_prefix} : task_id = {task_id}, 検査コメントを付与しました。")
                     return task
                 except requests.exceptions.HTTPError:
                     logger.warning(f"{logging_prefix} : task_id = {task_id} 検査コメントの付与に失敗しました。", exc_info=True)
                     # 作業時間が増えすぎないようにするため、すぐに休憩中状態にする
-                    self.service.wrapper.change_task_status_to_break(
-                        project_id, task_id, last_updated_datetime=task["updated_datetime"]
-                    )
+                    self.service.wrapper.change_task_status_to_break(project_id, task_id, last_updated_datetime=task["updated_datetime"])
                     raise
             else:
                 task, _ = self.service.api.get_task(project_id, task_id)
@@ -227,11 +213,7 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{logging_prefix} : task_id='{task_id}'のタスクをは存在しないので、スキップします。")
             return False
 
-        logger.debug(
-            f"{logging_prefix} : task_id = {task['task_id']}, "
-            f"status = {task['status']}, "
-            f"phase = {task['phase']}, "
-        )
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
 
         if not self._can_reject_task(
             task=task,
@@ -251,9 +233,7 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
             if not dryrun:
                 # タスクを差し戻す
                 # 担当者やステータスに関係なく差し戻すため、`force=True`を指定する
-                self.service.wrapper.reject_task(
-                    project_id, task_id, force=True, last_updated_datetime=task["updated_datetime"]
-                )
+                self.service.wrapper.reject_task(project_id, task_id, force=True, last_updated_datetime=task["updated_datetime"])
 
             if assign_last_annotator:
                 logger.info(f"{logging_prefix} : task_id = {task_id} のタスクを差し戻しました。タスクの担当者は直前の教師付フェーズの担当者です。")
@@ -267,13 +247,9 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
                 )
 
                 if not dryrun:
-                    self.service.wrapper.change_task_operator(
-                        project_id, task_id, operator_account_id=assigned_annotator_account_id
-                    )
+                    self.service.wrapper.change_task_operator(project_id, task_id, operator_account_id=assigned_annotator_account_id)
 
-                logger.info(
-                    f"{logging_prefix} : task_id = {task_id} のタスクを差し戻しました。タスクの担当者: {assigned_annotator_user_id}"
-                )
+                logger.info(f"{logging_prefix} : task_id = {task_id} のタスクを差し戻しました。タスクの担当者: {assigned_annotator_user_id}")
                 return True
 
         except requests.exceptions.HTTPError:
@@ -395,9 +371,7 @@ class RejectTasks(AbstractCommandLineInterface):
         task_query: Optional[TaskQuery] = TaskQuery.from_dict(dict_task_query) if dict_task_query is not None else None
 
         comment_data = annofabcli.common.cli.get_json_from_args(args.comment_data)
-        custom_project_type = (
-            CustomProjectType(args.custom_project_type) if args.custom_project_type is not None else None
-        )
+        custom_project_type = CustomProjectType(args.custom_project_type) if args.custom_project_type is not None else None
 
         project, _ = self.service.api.get_project(args.project_id)
         if args.comment is not None and comment_data is None:
@@ -408,10 +382,7 @@ class RejectTasks(AbstractCommandLineInterface):
                 comment_data = {"start": 0, "end": 100, "_type": "Time"}
             elif project["input_data_type"] == InputDataType.CUSTOM.value:
                 editor_plugin_id = project["configuration"]["plugin_id"]
-                if (
-                    editor_plugin_id == EditorPluginId.THREE_DIMENSION.value
-                    or custom_project_type == CustomProjectType.THREE_DIMENSION_POINT_CLOUD
-                ):
+                if editor_plugin_id == EditorPluginId.THREE_DIMENSION.value or custom_project_type == CustomProjectType.THREE_DIMENSION_POINT_CLOUD:
                     comment_data = {
                         "data": '{"kind": "CUBOID", "shape": {"dimensions": {"width": 1.0, "height": 1.0, "depth": 1.0}, "location": {"x": 0.0, "y": 0.0, "z": 0.0}, "rotation": {"x": 0.0, "y": 0.0, "z": 0.0}, "direction": {"front": {"x": 1.0, "y": 0.0, "z": 0.0}, "up": {"x": 0.0, "y": 0.0, "z": 1.0}}}, "version": "2"}',  # noqa: E501
                         "_type": "Custom",
@@ -481,7 +452,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     assign_group = parser.add_mutually_exclusive_group()
 
     assign_group.add_argument(
-        "--not_assign", action="store_true", help="差し戻したタスクに担当者を割り当てません。" "指定しない場合は、最後のannotation phaseの担当者が割り当てられます。"
+        "--not_assign",
+        action="store_true",
+        help="差し戻したタスクに担当者を割り当てません。" "指定しない場合は、最後のannotation phaseの担当者が割り当てられます。",
     )
 
     assign_group.add_argument(
@@ -495,7 +468,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_query()
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
     parser.add_argument("--dryrun", action="store_true", help="差し戻しが行われた時の結果を表示しますが、実際はタスクを差し戻しません。")
 

--- a/annofabcli/task/reject_tasks.py
+++ b/annofabcli/task/reject_tasks.py
@@ -424,7 +424,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-c",
         "--comment",
         type=str,
-        help="差し戻すときに付与する検査コメントを指定します。検査コメントはタスク内の先頭画像に付与します。付与する位置は ``--comment_data`` で指定できます。\n"
+        help="差し戻すときに付与する検査コメントを指定します。検査コメントはタスク内の先頭画像に付与します。付与する位置は ``--comment_data`` で指定できます。\n"  # noqa: E501
         "未指定の場合は、検査コメントを付与せずに差し戻します。",
     )
 
@@ -445,7 +445,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--custom_project_type",
         type=str,
         choices=[e.value for e in CustomProjectType],
-        help="[BETA] カスタムプロジェクトの種類を指定します。ビルトインのエディタプラグインを使用していないカスタムプロジェクトに対して、検査コメントの位置を指定しない場合は必須です。\n",
+        help="[BETA] カスタムプロジェクトの種類を指定します。ビルトインのエディタプラグインを使用していないカスタムプロジェクトに対して、検査コメントの位置を指定しない場合は必須です。\n",  # noqa: E501
     )
 
     # 差し戻したタスクの担当者の割当に関して
@@ -470,7 +470,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
     parser.add_argument("--dryrun", action="store_true", help="差し戻しが行われた時の結果を表示しますが、実際はタスクを差し戻しません。")
 

--- a/annofabcli/task/subcommand_task.py
+++ b/annofabcli/task/subcommand_task.py
@@ -48,8 +48,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "タスク関係のサブコマンド"
     description = "タスク関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -219,13 +219,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="指定した場合、メタデータを上書きして更新します（すでに設定されているメタデータは削除されます）。指定しない場合、 ``--metadata`` に指定されたキーのみ更新されます。",
+        help="指定した場合、メタデータを上書きして更新します（すでに設定されているメタデータは削除されます）。指定しない場合、 ``--metadata`` に指定されたキーのみ更新されます。",  # noqa: E501
     )
 
     parser.add_argument(
         "--parallelism",
         type=int,
-        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",  # noqa: E501
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -130,17 +130,13 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
 
             logger.info(f"{success_count} / {len(task_ids)} 件のタスクのmetadataを変更しました。")
 
-    def update_metadata_with_patch_tasks_metadata_api_wrapper(
-        self, tpl: tuple[int, int, list[str]], project_id: str, metadata: Metadata
-    ):
+    def update_metadata_with_patch_tasks_metadata_api_wrapper(self, tpl: tuple[int, int, list[str]], project_id: str, metadata: Metadata):
         global_start_position, global_stop_position, task_id_list = tpl
         logger.debug(f"{global_start_position+1} 〜 {global_stop_position} 件目のタスクのmetadataを更新します。")
         request_body = {task_id: metadata for task_id in task_id_list}
         self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
 
-    def update_metadata_with_patch_tasks_metadata_api(
-        self, project_id: str, task_ids: Collection[str], metadata: Metadata
-    ):
+    def update_metadata_with_patch_tasks_metadata_api(self, project_id: str, task_ids: Collection[str], metadata: Metadata):
         """patch_tasks_metadata webapiを呼び出して、タスクのメタデータを更新します。
         注意：メタデータは上書きされます。
         """
@@ -152,9 +148,7 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
 
         if self.parallelism is None:
             while first_index < len(task_id_list):
-                logger.info(
-                    f"{first_index+1} 〜 {min(first_index+BATCH_SIZE, len(task_id_list))} 件目のタスクのmetadataを更新します。"
-                )
+                logger.info(f"{first_index+1} 〜 {min(first_index+BATCH_SIZE, len(task_id_list))} 件目のタスクのmetadataを更新します。")
                 request_body = {task_id: metadata for task_id in task_id_list[first_index : first_index + BATCH_SIZE]}
                 self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
                 first_index += BATCH_SIZE
@@ -199,9 +193,7 @@ class UpdateMetadataOfTask(AbstractCommandLineInterface):
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id)
         metadata = annofabcli.common.cli.get_json_from_args(args.metadata)
         super().validate_project(args.project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
-        main_obj = UpdateMetadataOfTaskMain(
-            self.service, is_overwrite_metadata=args.overwrite, parallelism=args.parallelism, all_yes=args.yes
-        )
+        main_obj = UpdateMetadataOfTaskMain(self.service, is_overwrite_metadata=args.overwrite, parallelism=args.parallelism, all_yes=args.yes)
         main_obj.update_metadata_of_task(args.project_id, task_ids=task_id_list, metadata=metadata)
 
 
@@ -231,7 +223,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--parallelism", type=int, help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。"
+        "--parallelism",
+        type=int,
+        help="使用するプロセス数（並列度）を指定してください。指定する場合は必ず ``--yes`` を指定してください。指定しない場合は、逐次的に処理します。",
     )
 
     parser.set_defaults(subcommand_func=main)
@@ -242,8 +236,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "タスクのメタデータを更新します。"
     description = "タスクのメタデータを上書きして更新します。"
     epilog = "オーナまたはアノテーションユーザロールを持つユーザで実行してください。"
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/task_history/download_task_history_json.py
+++ b/annofabcli/task_history/download_task_history_json.py
@@ -55,8 +55,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "タスク履歴全件ファイルをダウンロードします。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/task_history/list_all_task_history.py
+++ b/annofabcli/task_history/list_all_task_history.py
@@ -27,9 +27,7 @@ class ListTaskHistoryWithJsonMain:
         self.facade = AnnofabApiFacade(service)
 
     @staticmethod
-    def filter_task_history_dict(
-        task_history_dict: TaskHistoryDict, task_id_list: Optional[List[str]] = None
-    ) -> TaskHistoryDict:
+    def filter_task_history_dict(task_history_dict: TaskHistoryDict, task_id_list: Optional[List[str]] = None) -> TaskHistoryDict:
         if task_id_list is None:
             return task_history_dict
 
@@ -100,9 +98,7 @@ class ListTaskHistoryWithJson(AbstractCommandLineInterface):
         super().validate_project(project_id, project_member_roles=None)
 
         main_obj = ListTaskHistoryWithJsonMain(self.service)
-        task_history_dict = main_obj.get_task_history_dict(
-            project_id, task_history_json=task_history_json, task_id_list=task_id_list
-        )
+        task_history_dict = main_obj.get_task_history_dict(project_id, task_history_json=task_history_json, task_id_list=task_id_list)
         logger.debug(f"{len(task_history_dict)} 件のタスクの履歴情報を出力します。")
         if arg_format == FormatArgument.CSV:
             all_task_history_list = main_obj.to_all_task_history_list_from_dict(task_history_dict)

--- a/annofabcli/task_history/list_all_task_history.py
+++ b/annofabcli/task_history/list_all_task_history.py
@@ -159,7 +159,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "すべてのタスク履歴の一覧を出力します。"
     description = (
         "すべてのタスク履歴の一覧を出力します。\n"
-        "出力されるタスク履歴は、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力したい場合は、 ``annofabcli task_history list`` コマンドを実行してください。"
+        "出力されるタスク履歴は、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力したい場合は、 ``annofabcli task_history list`` コマンドを実行してください。"  # noqa: E501
     )
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)

--- a/annofabcli/task_history/list_task_history.py
+++ b/annofabcli/task_history/list_task_history.py
@@ -53,9 +53,7 @@ class ListTaskHistoryMain:
         all_task_list = self.service.wrapper.get_all_tasks(project_id)
         return [e["task_id"] for e in all_task_list]
 
-    def get_task_history_dict_for_output(
-        self, project_id: str, task_id_list: Optional[List[str]] = None
-    ) -> TaskHistoryDict:
+    def get_task_history_dict_for_output(self, project_id: str, task_id_list: Optional[List[str]] = None) -> TaskHistoryDict:
         """出力対象のタスク履歴情報を取得する"""
         if task_id_list is None:
             task_id_list = self.get_all_task_id_list(project_id)

--- a/annofabcli/task_history/subcommand_task_history.py
+++ b/annofabcli/task_history/subcommand_task_history.py
@@ -22,8 +22,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "タスク履歴関係のサブコマンド"
     description = "タスク履歴関係のサブコマンド"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description, is_subcommand=False
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, is_subcommand=False)
     parse_args(parser)
     return parser

--- a/annofabcli/task_history_event/download_task_history_event_json.py
+++ b/annofabcli/task_history_event/download_task_history_event_json.py
@@ -55,8 +55,6 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "タスク履歴イベント全件ファイルをダウンロードします。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
 
-    parser = annofabcli.common.cli.add_parser(
-        subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog
-    )
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog)
     parse_args(parser)
     return parser

--- a/annofabcli/task_history_event/list_all_task_history_event.py
+++ b/annofabcli/task_history_event/list_all_task_history_event.py
@@ -112,9 +112,7 @@ class ListTaskHistoryEventWithJson(AbstractCommandLineInterface):
         )
 
     @staticmethod
-    def to_all_task_history_event_list_from_dict(
-        task_history_event_dict: dict[str, list[dict[str, Any]]]
-    ) -> List[dict[str, Any]]:
+    def to_all_task_history_event_list_from_dict(task_history_event_dict: dict[str, list[dict[str, Any]]]) -> List[dict[str, Any]]:
         all_task_history_event_list = []
         for task_history_event_list in task_history_event_dict.values():
             all_task_history_event_list.extend(task_history_event_list)

--- a/annofabcli/task_history_event/list_all_task_history_event.py
+++ b/annofabcli/task_history_event/list_all_task_history_event.py
@@ -158,7 +158,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "list_all"
     subcommand_help = "すべてのタスク履歴イベントの一覧を出力します。"
-    description = "すべてのタスク履歴イベントの一覧を出力します。\n出力されるタスク履歴イベントは、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力する方法はありません。"
+    description = "すべてのタスク履歴イベントの一覧を出力します。\n出力されるタスク履歴イベントは、コマンドを実行した日の02:00(JST)頃の状態です。最新の情報を出力する方法はありません。"  # noqa: E501
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
     parse_args(parser)

--- a/annofabcli/task_history_event/list_all_task_history_event.py
+++ b/annofabcli/task_history_event/list_all_task_history_event.py
@@ -39,7 +39,7 @@ class ListTaskHistoryEventWithJsonMain:
             task_id_set = set(task_id_list)
             for event in task_history_event_list:
                 if event["task_id"] in task_id_set:
-                    result.append(event)
+                    result.append(event)  # noqa: PERF401
 
             return result
 

--- a/annofabcli/task_history_event/list_worktime.py
+++ b/annofabcli/task_history_event/list_worktime.py
@@ -163,7 +163,7 @@ class ListWorktimeFromTaskHistoryEventMain:
         while i < len(task_history_event_list):
             event = task_history_event_list[i]
             # account_idを判定している理由：
-            # 受入完了状態のタスクで作成されたアノテーションを、アノテーション一覧画面からオーナーが一括編集すると、account_idがnullのタスク履歴イベントが生成されるため
+            # 受入完了状態のタスクで作成されたアノテーションを、アノテーション一覧画面からオーナーが一括編集すると、account_idがnullのタスク履歴イベントが生成されるため  # noqa: E501
             if event["status"] != TaskStatus.WORKING.value or event["account_id"] is None:
                 i += 1
                 continue

--- a/annofabcli/task_history_event/list_worktime.py
+++ b/annofabcli/task_history_event/list_worktime.py
@@ -64,7 +64,7 @@ class ListWorktimeFromTaskHistoryEventMain:
             task_id_set = set(task_id_list)
             for event in task_history_event_list:
                 if event["task_id"] in task_id_set:
-                    result.append(event)
+                    result.append(event)  # noqa: PERF401
 
             return result
 

--- a/annofabcli/task_history_event/list_worktime.py
+++ b/annofabcli/task_history_event/list_worktime.py
@@ -70,9 +70,7 @@ class ListWorktimeFromTaskHistoryEventMain:
 
         return task_history_event_list
 
-    def get_task_history_event_list(
-        self, project_id: str, task_history_event_json: Optional[Path] = None
-    ) -> list[dict[str, Any]]:
+    def get_task_history_event_list(self, project_id: str, task_history_event_json: Optional[Path] = None) -> list[dict[str, Any]]:
         if task_history_event_json is None:
             downloading_obj = DownloadingFile(self.service)
             cache_dir = annofabcli.common.utils.get_cache_dir()
@@ -114,9 +112,7 @@ class ListWorktimeFromTaskHistoryEventMain:
 
         return result
 
-    def _create_worktime(
-        self, start_event: TaskHistoryEvent, end_event: TaskHistoryEvent
-    ) -> WorktimeFromTaskHistoryEvent:
+    def _create_worktime(self, start_event: TaskHistoryEvent, end_event: TaskHistoryEvent) -> WorktimeFromTaskHistoryEvent:
         diff = parse(end_event["created_datetime"]) - parse(start_event["created_datetime"])
         worktime_hour = diff.total_seconds() / 3600
         assert worktime_hour >= 0, (
@@ -155,9 +151,7 @@ class ListWorktimeFromTaskHistoryEventMain:
             ),
         )
 
-    def _create_worktime_list(
-        self, task_history_event_list: list[TaskHistoryEvent]
-    ) -> list[WorktimeFromTaskHistoryEvent]:
+    def _create_worktime_list(self, task_history_event_list: list[TaskHistoryEvent]) -> list[WorktimeFromTaskHistoryEvent]:
         """タスク履歴イベントから、作業時間のリストを生成する。
 
         Args:
@@ -187,7 +181,8 @@ class ListWorktimeFromTaskHistoryEventMain:
                 TaskStatus.COMPLETE.value,
             }:
                 logger.warning(
-                    "作業中状態のタスク履歴イベントに対応するタスク履歴イベントが存在しませんでした。" f":: start_event={start_event}, next_event={next_event}"
+                    "作業中状態のタスク履歴イベントに対応するタスク履歴イベントが存在しませんでした。"
+                    f":: start_event={start_event}, next_event={next_event}"
                 )
                 i += 1
                 continue
@@ -200,9 +195,7 @@ class ListWorktimeFromTaskHistoryEventMain:
         return result
 
     def get_account_ids_from_user_ids(self, project_id: str, user_ids: set[str]) -> set[str]:
-        project_member_list = self.service.wrapper.get_all_project_members(
-            project_id, query_params={"include_inactive_member": True}
-        )
+        project_member_list = self.service.wrapper.get_all_project_members(project_id, query_params={"include_inactive_member": True})
         return {e["account_id"] for e in project_member_list if e["user_id"] in user_ids}
 
     def get_worktime_list(
@@ -212,18 +205,12 @@ class ListWorktimeFromTaskHistoryEventMain:
         task_id_list: Optional[List[str]] = None,
         user_id_list: Optional[List[str]] = None,
     ) -> list[WorktimeFromTaskHistoryEvent]:
-        all_task_history_event_list = self.get_task_history_event_list(
-            project_id, task_history_event_json=task_history_event_json
-        )
+        all_task_history_event_list = self.get_task_history_event_list(project_id, task_history_event_json=task_history_event_json)
 
         task_id_set = set(task_id_list) if task_id_list is not None else None
-        account_id_set = (
-            self.get_account_ids_from_user_ids(project_id, set(user_id_list)) if user_id_list is not None else None
-        )
+        account_id_set = self.get_account_ids_from_user_ids(project_id, set(user_id_list)) if user_id_list is not None else None
 
-        task_history_event_dict = self._create_task_history_event_dict(
-            all_task_history_event_list, task_ids=task_id_set, account_ids=account_id_set
-        )
+        task_history_event_dict = self._create_task_history_event_dict(all_task_history_event_list, task_ids=task_id_set, account_ids=account_id_set)
 
         worktime_list = []
         for subset_event_list in task_history_event_dict.values():
@@ -279,9 +266,7 @@ class ListWorktimeFromTaskHistoryEvent(AbstractCommandLineInterface):
         )
 
     @staticmethod
-    def to_all_task_history_event_list_from_dict(
-        task_history_event_dict: dict[str, list[dict[str, Any]]]
-    ) -> List[dict[str, Any]]:
+    def to_all_task_history_event_list_from_dict(task_history_event_dict: dict[str, list[dict[str, Any]]]) -> List[dict[str, Any]]:
         all_task_history_event_list = []
         for task_history_event_list in task_history_event_dict.values():
             all_task_history_event_list.extend(task_history_event_list)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc", "edit-this-page", "last-updated"],
     
     # icon_links`を指定しないと、pydata-sphinx-theme v0.13.0で
-    # Handler <function update_config at 0x7f0333cb1430> for event 'builder-inited' threw an exception (exception: 'icon_links') というエラーが発生する
+    # Handler <function update_config at 0x7f0333cb1430> for event 'builder-inited' threw an exception (exception: 'icon_links') というエラーが発生する  # noqa: E501
     # https://github.com/pydata/pydata-sphinx-theme/issues/1220
     "icon_links": [],
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,21 +70,13 @@ files = [
 
 [[package]]
 name = "astroid"
-version = "2.15.8"
+version = "3.0.3"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
-python-versions = ">=3.7.2"
+python-versions = ">=3.8.0"
 files = [
-    {file = "astroid-2.15.8-py3-none-any.whl", hash = "sha256:1aa149fc5c6589e3d0ece885b4491acd80af4f087baafa3fb5203b113e68cd3c"},
-    {file = "astroid-2.15.8.tar.gz", hash = "sha256:6c107453dffee9055899705de3c9ead36e74119cee151e5a9aaf7f0b0e020a6a"},
-]
-
-[package.dependencies]
-lazy-object-proxy = ">=1.4.0"
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
-wrapt = [
-    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
+    {file = "astroid-3.0.3-py3-none-any.whl", hash = "sha256:92fcf218b89f449cdf9f7b39a269f8d5d617b27be68434912e11e79203963a17"},
+    {file = "astroid-3.0.3.tar.gz", hash = "sha256:4148645659b08b70d72460ed1921158027a9e53ae8b7234149b1400eddacbb93"},
 ]
 
 [[package]]
@@ -161,52 +153,6 @@ chardet = ["chardet"]
 charset-normalizer = ["charset-normalizer"]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
-
-[[package]]
-name = "black"
-version = "23.12.1"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"},
-    {file = "black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba"},
-    {file = "black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0"},
-    {file = "black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3"},
-    {file = "black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba"},
-    {file = "black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b"},
-    {file = "black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59"},
-    {file = "black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50"},
-    {file = "black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e"},
-    {file = "black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec"},
-    {file = "black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e"},
-    {file = "black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9"},
-    {file = "black-23.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f"},
-    {file = "black-23.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d"},
-    {file = "black-23.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a"},
-    {file = "black-23.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e"},
-    {file = "black-23.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055"},
-    {file = "black-23.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54"},
-    {file = "black-23.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea"},
-    {file = "black-23.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2"},
-    {file = "black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e"},
-    {file = "black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bokeh"
@@ -341,20 +287,6 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -441,63 +373,63 @@ test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
 
 [[package]]
 name = "coverage"
-version = "7.4.1"
+version = "7.4.2"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:077d366e724f24fc02dbfe9d946534357fda71af9764ff99d73c3c596001bbd7"},
-    {file = "coverage-7.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0193657651f5399d433c92f8ae264aff31fc1d066deee4b831549526433f3f61"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d17bbc946f52ca67adf72a5ee783cd7cd3477f8f8796f59b4974a9b59cacc9ee"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3277f5fa7483c927fe3a7b017b39351610265308f5267ac6d4c2b64cc1d8d25"},
-    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dceb61d40cbfcf45f51e59933c784a50846dc03211054bd76b421a713dcdf19"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6008adeca04a445ea6ef31b2cbaf1d01d02986047606f7da266629afee982630"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c61f66d93d712f6e03369b6a7769233bfda880b12f417eefdd4f16d1deb2fc4c"},
-    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9bb62fac84d5f2ff523304e59e5c439955fb3b7f44e3d7b2085184db74d733b"},
-    {file = "coverage-7.4.1-cp310-cp310-win32.whl", hash = "sha256:f86f368e1c7ce897bf2457b9eb61169a44e2ef797099fb5728482b8d69f3f016"},
-    {file = "coverage-7.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:869b5046d41abfea3e381dd143407b0d29b8282a904a19cb908fa24d090cc018"},
-    {file = "coverage-7.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ffb498a83d7e0305968289441914154fb0ef5d8b3157df02a90c6695978295"},
-    {file = "coverage-7.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cacfaefe6089d477264001f90f55b7881ba615953414999c46cc9713ff93c8c"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d6850e6e36e332d5511a48a251790ddc545e16e8beaf046c03985c69ccb2676"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18e961aa13b6d47f758cc5879383d27b5b3f3dcd9ce8cdbfdc2571fe86feb4dd"},
-    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfd1e1b9f0898817babf840b77ce9fe655ecbe8b1b327983df485b30df8cc011"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6b00e21f86598b6330f0019b40fb397e705135040dbedc2ca9a93c7441178e74"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:536d609c6963c50055bab766d9951b6c394759190d03311f3e9fcf194ca909e1"},
-    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7ac8f8eb153724f84885a1374999b7e45734bf93a87d8df1e7ce2146860edef6"},
-    {file = "coverage-7.4.1-cp311-cp311-win32.whl", hash = "sha256:f3771b23bb3675a06f5d885c3630b1d01ea6cac9e84a01aaf5508706dba546c5"},
-    {file = "coverage-7.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:9d2f9d4cc2a53b38cabc2d6d80f7f9b7e3da26b2f53d48f05876fef7956b6968"},
-    {file = "coverage-7.4.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f68ef3660677e6624c8cace943e4765545f8191313a07288a53d3da188bd8581"},
-    {file = "coverage-7.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23b27b8a698e749b61809fb637eb98ebf0e505710ec46a8aa6f1be7dc0dc43a6"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e3424c554391dc9ef4a92ad28665756566a28fecf47308f91841f6c49288e66"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0860a348bf7004c812c8368d1fc7f77fe8e4c095d661a579196a9533778e156"},
-    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe558371c1bdf3b8fa03e097c523fb9645b8730399c14fe7721ee9c9e2a545d3"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3468cc8720402af37b6c6e7e2a9cdb9f6c16c728638a2ebc768ba1ef6f26c3a1"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:02f2edb575d62172aa28fe00efe821ae31f25dc3d589055b3fb64d51e52e4ab1"},
-    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ca6e61dc52f601d1d224526360cdeab0d0712ec104a2ce6cc5ccef6ed9a233bc"},
-    {file = "coverage-7.4.1-cp312-cp312-win32.whl", hash = "sha256:ca7b26a5e456a843b9b6683eada193fc1f65c761b3a473941efe5a291f604c74"},
-    {file = "coverage-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:85ccc5fa54c2ed64bd91ed3b4a627b9cce04646a659512a051fa82a92c04a448"},
-    {file = "coverage-7.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8bdb0285a0202888d19ec6b6d23d5990410decb932b709f2b0dfe216d031d218"},
-    {file = "coverage-7.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:918440dea04521f499721c039863ef95433314b1db00ff826a02580c1f503e45"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:379d4c7abad5afbe9d88cc31ea8ca262296480a86af945b08214eb1a556a3e4d"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b094116f0b6155e36a304ff912f89bbb5067157aff5f94060ff20bbabdc8da06"},
-    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2f5968608b1fe2a1d00d01ad1017ee27efd99b3437e08b83ded9b7af3f6f766"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:10e88e7f41e6197ea0429ae18f21ff521d4f4490aa33048f6c6f94c6045a6a75"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a4a3907011d39dbc3e37bdc5df0a8c93853c369039b59efa33a7b6669de04c60"},
-    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6d224f0c4c9c98290a6990259073f496fcec1b5cc613eecbd22786d398ded3ad"},
-    {file = "coverage-7.4.1-cp38-cp38-win32.whl", hash = "sha256:23f5881362dcb0e1a92b84b3c2809bdc90db892332daab81ad8f642d8ed55042"},
-    {file = "coverage-7.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:a07f61fc452c43cd5328b392e52555f7d1952400a1ad09086c4a8addccbd138d"},
-    {file = "coverage-7.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8e738a492b6221f8dcf281b67129510835461132b03024830ac0e554311a5c54"},
-    {file = "coverage-7.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46342fed0fff72efcda77040b14728049200cbba1279e0bf1188f1f2078c1d70"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9641e21670c68c7e57d2053ddf6c443e4f0a6e18e547e86af3fad0795414a628"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aeb2c2688ed93b027eb0d26aa188ada34acb22dceea256d76390eea135083950"},
-    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d12c923757de24e4e2110cf8832d83a886a4cf215c6e61ed506006872b43a6d1"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0491275c3b9971cdbd28a4595c2cb5838f08036bca31765bad5e17edf900b2c7"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8dfc5e195bbef80aabd81596ef52a1277ee7143fe419efc3c4d8ba2754671756"},
-    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1a78b656a4d12b0490ca72651fe4d9f5e07e3c6461063a9b6265ee45eb2bdd35"},
-    {file = "coverage-7.4.1-cp39-cp39-win32.whl", hash = "sha256:f90515974b39f4dea2f27c0959688621b46d96d5a626cf9c53dbc653a895c05c"},
-    {file = "coverage-7.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:64e723ca82a84053dd7bfcc986bdb34af8d9da83c521c19d6b472bc6880e191a"},
-    {file = "coverage-7.4.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:32a8d985462e37cfdab611a6f95b09d7c091d07668fdc26e47a725ee575fe166"},
-    {file = "coverage-7.4.1.tar.gz", hash = "sha256:1ed4b95480952b1a26d863e546fa5094564aa0065e1e5f0d4d0041f293251d04"},
+    {file = "coverage-7.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf54c3e089179d9d23900e3efc86d46e4431188d9a657f345410eecdd0151f50"},
+    {file = "coverage-7.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fe6e43c8b510719b48af7db9631b5fbac910ade4bd90e6378c85ac5ac706382c"},
+    {file = "coverage-7.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b98c89db1b150d851a7840142d60d01d07677a18f0f46836e691c38134ed18b"},
+    {file = "coverage-7.4.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5f9683be6a5b19cd776ee4e2f2ffb411424819c69afab6b2db3a0a364ec6642"},
+    {file = "coverage-7.4.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78cdcbf7b9cb83fe047ee09298e25b1cd1636824067166dc97ad0543b079d22f"},
+    {file = "coverage-7.4.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2599972b21911111114100d362aea9e70a88b258400672626efa2b9e2179609c"},
+    {file = "coverage-7.4.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ef00d31b7569ed3cb2036f26565f1984b9fc08541731ce01012b02a4c238bf03"},
+    {file = "coverage-7.4.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:20a875bfd8c282985c4720c32aa05056f77a68e6d8bbc5fe8632c5860ee0b49b"},
+    {file = "coverage-7.4.2-cp310-cp310-win32.whl", hash = "sha256:b3f2b1eb229f23c82898eedfc3296137cf1f16bb145ceab3edfd17cbde273fb7"},
+    {file = "coverage-7.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:7df95fdd1432a5d2675ce630fef5f239939e2b3610fe2f2b5bf21fa505256fa3"},
+    {file = "coverage-7.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a8ddbd158e069dded57738ea69b9744525181e99974c899b39f75b2b29a624e2"},
+    {file = "coverage-7.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81a5fb41b0d24447a47543b749adc34d45a2cf77b48ca74e5bf3de60a7bd9edc"},
+    {file = "coverage-7.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2412e98e70f16243be41d20836abd5f3f32edef07cbf8f407f1b6e1ceae783ac"},
+    {file = "coverage-7.4.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ddb79414c15c6f03f56cc68fa06994f047cf20207c31b5dad3f6bab54a0f66ef"},
+    {file = "coverage-7.4.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf89ab85027427d351f1de918aff4b43f4eb5f33aff6835ed30322a86ac29c9e"},
+    {file = "coverage-7.4.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a178b7b1ac0f1530bb28d2e51f88c0bab3e5949835851a60dda80bff6052510c"},
+    {file = "coverage-7.4.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:06fe398145a2e91edaf1ab4eee66149c6776c6b25b136f4a86fcbbb09512fd10"},
+    {file = "coverage-7.4.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:18cac867950943fe93d6cd56a67eb7dcd2d4a781a40f4c1e25d6f1ed98721a55"},
+    {file = "coverage-7.4.2-cp311-cp311-win32.whl", hash = "sha256:f72cdd2586f9a769570d4b5714a3837b3a59a53b096bb954f1811f6a0afad305"},
+    {file = "coverage-7.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:d779a48fac416387dd5673fc5b2d6bd903ed903faaa3247dc1865c65eaa5a93e"},
+    {file = "coverage-7.4.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:adbdfcda2469d188d79771d5696dc54fab98a16d2ef7e0875013b5f56a251047"},
+    {file = "coverage-7.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ac4bab32f396b03ebecfcf2971668da9275b3bb5f81b3b6ba96622f4ef3f6e17"},
+    {file = "coverage-7.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:006d220ba2e1a45f1de083d5022d4955abb0aedd78904cd5a779b955b019ec73"},
+    {file = "coverage-7.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3733545eb294e5ad274abe131d1e7e7de4ba17a144505c12feca48803fea5f64"},
+    {file = "coverage-7.4.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42a9e754aa250fe61f0f99986399cec086d7e7a01dd82fd863a20af34cbce962"},
+    {file = "coverage-7.4.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2ed37e16cf35c8d6e0b430254574b8edd242a367a1b1531bd1adc99c6a5e00fe"},
+    {file = "coverage-7.4.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b953275d4edfab6cc0ed7139fa773dfb89e81fee1569a932f6020ce7c6da0e8f"},
+    {file = "coverage-7.4.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32b4ab7e6c924f945cbae5392832e93e4ceb81483fd6dc4aa8fb1a97b9d3e0e1"},
+    {file = "coverage-7.4.2-cp312-cp312-win32.whl", hash = "sha256:f5df76c58977bc35a49515b2fbba84a1d952ff0ec784a4070334dfbec28a2def"},
+    {file = "coverage-7.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:34423abbaad70fea9d0164add189eabaea679068ebdf693baa5c02d03e7db244"},
+    {file = "coverage-7.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b11f9c6587668e495cc7365f85c93bed34c3a81f9f08b0920b87a89acc13469"},
+    {file = "coverage-7.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:51593a1f05c39332f623d64d910445fdec3d2ac2d96b37ce7f331882d5678ddf"},
+    {file = "coverage-7.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69f1665165ba2fe7614e2f0c1aed71e14d83510bf67e2ee13df467d1c08bf1e8"},
+    {file = "coverage-7.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3c8bbb95a699c80a167478478efe5e09ad31680931ec280bf2087905e3b95ec"},
+    {file = "coverage-7.4.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:175f56572f25e1e1201d2b3e07b71ca4d201bf0b9cb8fad3f1dfae6a4188de86"},
+    {file = "coverage-7.4.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8562ca91e8c40864942615b1d0b12289d3e745e6b2da901d133f52f2d510a1e3"},
+    {file = "coverage-7.4.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d9a1ef0f173e1a19738f154fb3644f90d0ada56fe6c9b422f992b04266c55d5a"},
+    {file = "coverage-7.4.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f40ac873045db4fd98a6f40387d242bde2708a3f8167bd967ccd43ad46394ba2"},
+    {file = "coverage-7.4.2-cp38-cp38-win32.whl", hash = "sha256:d1b750a8409bec61caa7824bfd64a8074b6d2d420433f64c161a8335796c7c6b"},
+    {file = "coverage-7.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:b4ae777bebaed89e3a7e80c4a03fac434a98a8abb5251b2a957d38fe3fd30088"},
+    {file = "coverage-7.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ff7f92ae5a456101ca8f48387fd3c56eb96353588e686286f50633a611afc95"},
+    {file = "coverage-7.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:861d75402269ffda0b33af94694b8e0703563116b04c681b1832903fac8fd647"},
+    {file = "coverage-7.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3507427d83fa961cbd73f11140f4a5ce84208d31756f7238d6257b2d3d868405"},
+    {file = "coverage-7.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf711d517e21fb5bc429f5c4308fbc430a8585ff2a43e88540264ae87871e36a"},
+    {file = "coverage-7.4.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c00e54f0bd258ab25e7f731ca1d5144b0bf7bec0051abccd2bdcff65fa3262c9"},
+    {file = "coverage-7.4.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f8e845d894e39fb53834da826078f6dc1a933b32b1478cf437007367efaf6f6a"},
+    {file = "coverage-7.4.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:840456cb1067dc350af9080298c7c2cfdddcedc1cb1e0b30dceecdaf7be1a2d3"},
+    {file = "coverage-7.4.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c11ca2df2206a4e3e4c4567f52594637392ed05d7c7fb73b4ea1c658ba560265"},
+    {file = "coverage-7.4.2-cp39-cp39-win32.whl", hash = "sha256:3ff5bdb08d8938d336ce4088ca1a1e4b6c8cd3bef8bb3a4c0eb2f37406e49643"},
+    {file = "coverage-7.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:ac9e95cefcf044c98d4e2c829cd0669918585755dd9a92e28a1a7012322d0a95"},
+    {file = "coverage-7.4.2-pp38.pp39.pp310-none-any.whl", hash = "sha256:f593a4a90118d99014517c2679e04a4ef5aee2d81aa05c26c734d271065efcb6"},
+    {file = "coverage-7.4.2.tar.gz", hash = "sha256:1a5ee18e3a8d766075ce9314ed1cb695414bae67df6a4b0805f5137d93d6f1cb"},
 ]
 
 [package.dependencies]
@@ -795,52 +727,6 @@ files = [
 ]
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.10.0"
-description = "A fast and thorough lazy object proxy."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "lazy-object-proxy-1.10.0.tar.gz", hash = "sha256:78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:855e068b0358ab916454464a884779c7ffa312b8925c6f7401e952dcf3b89977"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab7004cf2e59f7c2e4345604a3e6ea0d92ac44e1c2375527d56492014e690c3"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc0d2fc424e54c70c4bc06787e4072c4f3b1aa2f897dfdc34ce1013cf3ceef05"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e2adb09778797da09d2b5ebdbceebf7dd32e2c96f79da9052b2e87b6ea495895"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1f711e2c6dcd4edd372cf5dec5c5a30d23bba06ee012093267b3376c079ec83"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-win32.whl", hash = "sha256:76a095cfe6045c7d0ca77db9934e8f7b71b14645f0094ffcd842349ada5c5fb9"},
-    {file = "lazy_object_proxy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:b4f87d4ed9064b2628da63830986c3d2dca7501e6018347798313fcf028e2fd4"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fec03caabbc6b59ea4a638bee5fce7117be8e99a4103d9d5ad77f15d6f81020c"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c83f957782cbbe8136bee26416686a6ae998c7b6191711a04da776dc9e47d4"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:009e6bb1f1935a62889ddc8541514b6a9e1fcf302667dcb049a0be5c8f613e56"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:75fc59fc450050b1b3c203c35020bc41bd2695ed692a392924c6ce180c6f1dc9"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:782e2c9b2aab1708ffb07d4bf377d12901d7a1d99e5e410d648d892f8967ab1f"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-win32.whl", hash = "sha256:edb45bb8278574710e68a6b021599a10ce730d156e5b254941754a9cc0b17d03"},
-    {file = "lazy_object_proxy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:e271058822765ad5e3bca7f05f2ace0de58a3f4e62045a8c90a0dfd2f8ad8cc6"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e98c8af98d5707dcdecc9ab0863c0ea6e88545d42ca7c3feffb6b4d1e370c7ba"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:952c81d415b9b80ea261d2372d2a4a2332a3890c2b83e0535f263ddfe43f0d43"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80b39d3a151309efc8cc48675918891b865bdf742a8616a337cb0090791a0de9"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e221060b701e2aa2ea991542900dd13907a5c90fa80e199dbf5a03359019e7a3"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:92f09ff65ecff3108e56526f9e2481b8116c0b9e1425325e13245abfd79bdb1b"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-win32.whl", hash = "sha256:3ad54b9ddbe20ae9f7c1b29e52f123120772b06dbb18ec6be9101369d63a4074"},
-    {file = "lazy_object_proxy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:127a789c75151db6af398b8972178afe6bda7d6f68730c057fbbc2e96b08d282"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4ed0518a14dd26092614412936920ad081a424bdcb54cc13349a8e2c6d106a"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ad9e6ed739285919aa9661a5bbed0aaf410aa60231373c5579c6b4801bd883c"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc0a92c02fa1ca1e84fc60fa258458e5bf89d90a1ddaeb8ed9cc3147f417255"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0aefc7591920bbd360d57ea03c995cebc204b424524a5bd78406f6e1b8b2a5d8"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5faf03a7d8942bb4476e3b62fd0f4cf94eaf4618e304a19865abf89a35c0bbee"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-win32.whl", hash = "sha256:e333e2324307a7b5d86adfa835bb500ee70bfcd1447384a822e96495796b0ca4"},
-    {file = "lazy_object_proxy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:cb73507defd385b7705c599a94474b1d5222a508e502553ef94114a143ec6696"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:366c32fe5355ef5fc8a232c5436f4cc66e9d3e8967c01fb2e6302fd6627e3d94"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18dd842b49456aaa9a7cf535b04ca4571a302ff72ed8740d06b5adcd41fe0757"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9a3a87cf1e133e5b1994144c12ca4aa3d9698517fe1e2ca82977781b16955658"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-win32.whl", hash = "sha256:30b339b2a743c5288405aa79a69e706a06e02958eab31859f7f3c04980853b70"},
-    {file = "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd"},
-    {file = "lazy_object_proxy-1.10.0-pp310.pp311.pp312.pp38.pp39-none-any.whl", hash = "sha256:80fa48bd89c8f2f456fc0765c11c23bf5af827febacd2f523ca5bc1893fcc09d"},
-]
-
-[[package]]
 name = "lxml"
 version = "5.1.0"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
@@ -1110,7 +996,6 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -1337,17 +1222,6 @@ files = [
 [package.extras]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
 
 [[package]]
 name = "pefile"
@@ -1632,28 +1506,26 @@ setuptools = ">=42.0.0"
 
 [[package]]
 name = "pylint"
-version = "2.17.7"
+version = "3.0.3"
 description = "python code static checker"
 optional = false
-python-versions = ">=3.7.2"
+python-versions = ">=3.8.0"
 files = [
-    {file = "pylint-2.17.7-py3-none-any.whl", hash = "sha256:27a8d4c7ddc8c2f8c18aa0050148f89ffc09838142193fdbe98f172781a3ff87"},
-    {file = "pylint-2.17.7.tar.gz", hash = "sha256:f4fcac7ae74cfe36bc8451e931d8438e4a476c20314b1101c458ad0f05191fad"},
+    {file = "pylint-3.0.3-py3-none-any.whl", hash = "sha256:7a1585285aefc5165db81083c3e06363a27448f6b467b3b0f30dbd0ac1f73810"},
+    {file = "pylint-3.0.3.tar.gz", hash = "sha256:58c2398b0301e049609a8429789ec6edf3aabe9b6c5fec916acd18639c16de8b"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.8,<=2.17.0-dev0"
+astroid = ">=3.0.1,<=3.1.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
 ]
-isort = ">=4.2.5,<6"
+isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
@@ -1870,28 +1742,28 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruff"
-version = "0.0.259"
-description = "An extremely fast Python linter, written in Rust."
+version = "0.2.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.259-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:f3938dc45e2a3f818e9cbd53007265c22246fbfded8837b2c563bf0ebde1a226"},
-    {file = "ruff-0.0.259-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:22e1e35bf5f12072cd644d22afd9203641ccf258bc14ff91aa1c43dc14f6047d"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2fb20e89e85d147c85caa807707a1488bccc1f3854dc3d53533e89b52a0c5ff"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49e903bcda19f6bb0725a962c058eb5d61f40d84ef52ed53b61939b69402ab4e"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:71f0ef1985e9a6696fa97da8459917fa34bdaa2c16bd33bd5edead585b7d44f7"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7cfef26619cba184d59aa7fa17b48af5891d51fc0b755a9bc533478a10d4d066"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79b02fa17ec1fd8d306ae302cb47fb614b71e1f539997858243769bcbe78c6d9"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:428507fb321b386dda70d66cd1a8aa0abf51d7c197983d83bb9e4fa5ee60300b"},
-    {file = "ruff-0.0.259-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5fbaea9167f1852757f02133e5daacdb8c75b3431343205395da5b10499927a"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:40ae87f2638484b7e8a7567b04a7af719f1c484c5bf132038b702bb32e1f6577"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:29e2b77b7d5da6a7dd5cf9b738b511355c5734ece56f78e500d4b5bffd58c1a0"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b3c1beacf6037e7f0781d4699d9a2dd4ba2462f475be5b1f45cf84c4ba3c69d"},
-    {file = "ruff-0.0.259-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:daaea322e7e85f4c13d82be9536309e1c4b8b9851bb0cbc7eeb15d490fd46bf9"},
-    {file = "ruff-0.0.259-py3-none-win32.whl", hash = "sha256:38704f151323aa5858370a2f792e122cc25e5d1aabe7d42ceeab83da18f0b456"},
-    {file = "ruff-0.0.259-py3-none-win_amd64.whl", hash = "sha256:aa9449b898287e621942cc71b9327eceb8f0c357e4065fecefb707ef2d978df8"},
-    {file = "ruff-0.0.259-py3-none-win_arm64.whl", hash = "sha256:e4f39e18702de69faaaee3969934b92d7467285627f99a5b6ecd55a7d9f5d086"},
-    {file = "ruff-0.0.259.tar.gz", hash = "sha256:8b56496063ab3bfdf72339a5fbebb8bd46e5c5fee25ef11a9f03b208fa0562ec"},
+    {file = "ruff-0.2.2-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0a9efb032855ffb3c21f6405751d5e147b0c6b631e3ca3f6b20f917572b97eb6"},
+    {file = "ruff-0.2.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d450b7fbff85913f866a5384d8912710936e2b96da74541c82c1b458472ddb39"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecd46e3106850a5c26aee114e562c329f9a1fbe9e4821b008c4404f64ff9ce73"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e22676a5b875bd72acd3d11d5fa9075d3a5f53b877fe7b4793e4673499318ba"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1695700d1e25a99d28f7a1636d85bafcc5030bba9d0578c0781ba1790dbcf51c"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b0c232af3d0bd8f521806223723456ffebf8e323bd1e4e82b0befb20ba18388e"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f63d96494eeec2fc70d909393bcd76c69f35334cdbd9e20d089fb3f0640216ca"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a61ea0ff048e06de273b2e45bd72629f470f5da8f71daf09fe481278b175001"},
+    {file = "ruff-0.2.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e1439c8f407e4f356470e54cdecdca1bd5439a0673792dbe34a2b0a551a2fe3"},
+    {file = "ruff-0.2.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:940de32dc8853eba0f67f7198b3e79bc6ba95c2edbfdfac2144c8235114d6726"},
+    {file = "ruff-0.2.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0c126da55c38dd917621552ab430213bdb3273bb10ddb67bc4b761989210eb6e"},
+    {file = "ruff-0.2.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3b65494f7e4bed2e74110dac1f0d17dc8e1f42faaa784e7c58a98e335ec83d7e"},
+    {file = "ruff-0.2.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1ec49be4fe6ddac0503833f3ed8930528e26d1e60ad35c2446da372d16651ce9"},
+    {file = "ruff-0.2.2-py3-none-win32.whl", hash = "sha256:d920499b576f6c68295bc04e7b17b6544d9d05f196bb3aac4358792ef6f34325"},
+    {file = "ruff-0.2.2-py3-none-win_amd64.whl", hash = "sha256:cc9a91ae137d687f43a44c900e5d95e9617cb37d4c989e462980ba27039d239d"},
+    {file = "ruff-0.2.2-py3-none-win_arm64.whl", hash = "sha256:c9d15fc41e6054bfc7200478720570078f0b41c9ae4f010bcc16bd6f4d1aacdd"},
+    {file = "ruff-0.2.2.tar.gz", hash = "sha256:e62ed7f36b3068a30ba39193a14274cd706bc486fad521276458022f7bccb31d"},
 ]
 
 [[package]]
@@ -2213,13 +2085,13 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.31.0.20240125"
+version = "2.31.0.20240218"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-requests-2.31.0.20240125.tar.gz", hash = "sha256:03a28ce1d7cd54199148e043b2079cdded22d6795d19a2c2a6791a4b2b5e2eb5"},
-    {file = "types_requests-2.31.0.20240125-py3-none-any.whl", hash = "sha256:9592a9a4cb92d6d75d9b491a41477272b710e021011a2a3061157e2fb1f1a5d1"},
+    {file = "types-requests-2.31.0.20240218.tar.gz", hash = "sha256:f1721dba8385958f504a5386240b92de4734e047a08a40751c1654d1ac3349c5"},
+    {file = "types_requests-2.31.0.20240218-py3-none-any.whl", hash = "sha256:a82807ec6ddce8f00fe0e949da6d6bc1fbf1715420218a9640d695f70a9e5a9b"},
 ]
 
 [package.dependencies]
@@ -2264,13 +2136,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.0"
+version = "2.2.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.0-py3-none-any.whl", hash = "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"},
-    {file = "urllib3-2.2.0.tar.gz", hash = "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"},
+    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
+    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
 ]
 
 [package.extras]
@@ -2288,85 +2160,6 @@ python-versions = "*"
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
-]
-
-[[package]]
-name = "wrapt"
-version = "1.16.0"
-description = "Module for decorators, wrappers and monkey patching."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"},
-    {file = "wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"},
-    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440"},
-    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487"},
-    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf"},
-    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72"},
-    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0"},
-    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136"},
-    {file = "wrapt-1.16.0-cp310-cp310-win32.whl", hash = "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d"},
-    {file = "wrapt-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2"},
-    {file = "wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09"},
-    {file = "wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d"},
-    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389"},
-    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060"},
-    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1"},
-    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3"},
-    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956"},
-    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d"},
-    {file = "wrapt-1.16.0-cp311-cp311-win32.whl", hash = "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362"},
-    {file = "wrapt-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89"},
-    {file = "wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b"},
-    {file = "wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36"},
-    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73"},
-    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809"},
-    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b"},
-    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81"},
-    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9"},
-    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c"},
-    {file = "wrapt-1.16.0-cp312-cp312-win32.whl", hash = "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc"},
-    {file = "wrapt-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8"},
-    {file = "wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8"},
-    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39"},
-    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c"},
-    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40"},
-    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc"},
-    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e"},
-    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465"},
-    {file = "wrapt-1.16.0-cp36-cp36m-win32.whl", hash = "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e"},
-    {file = "wrapt-1.16.0-cp36-cp36m-win_amd64.whl", hash = "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966"},
-    {file = "wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593"},
-    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292"},
-    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5"},
-    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"},
-    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228"},
-    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f"},
-    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c"},
-    {file = "wrapt-1.16.0-cp37-cp37m-win32.whl", hash = "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c"},
-    {file = "wrapt-1.16.0-cp37-cp37m-win_amd64.whl", hash = "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00"},
-    {file = "wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0"},
-    {file = "wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202"},
-    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0"},
-    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e"},
-    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f"},
-    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267"},
-    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca"},
-    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6"},
-    {file = "wrapt-1.16.0-cp38-cp38-win32.whl", hash = "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b"},
-    {file = "wrapt-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41"},
-    {file = "wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2"},
-    {file = "wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb"},
-    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8"},
-    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c"},
-    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a"},
-    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664"},
-    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f"},
-    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537"},
-    {file = "wrapt-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3"},
-    {file = "wrapt-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"},
-    {file = "wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"},
-    {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
 ]
 
 [[package]]
@@ -2398,4 +2191,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "1bd52744464b98f6664934bcbc4025f910bc23da8b30c16c61578d5f0a6d824c"
+content-hash = "4940c3d048b43e9d6193bf1cc95002066f1e56ce79b3c86acae603c2626bf16c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ pytest-xdist = "*"
 pytest-cov = "*"
 
 [tool.poetry.group.formatter.dependencies]
-black = "^23.3"
 
 [tool.poetry.group.linter.dependencies]
 # ruffのバージョンの上限を指定する理由:
@@ -68,9 +67,9 @@ black = "^23.3"
 # black 23.3(通常版)は"line-width"を"character count"で計算している。
 # ruffとblackで"line-with"の計算が異なってしまうので、ruffのバージョンの上限を指定した。
 # https://qiita.com/yuji38kwmt/items/04208d2d2cafe1218287
-ruff = "<0.0.260"
-mypy = "^1"
-pylint = "^2"
+ruff = {version="^0.2", python=">=3.11"}
+mypy = {version="^1", python=">=3.11"}
+pylint = {version="^3", python=">=3.11"}
 
 types-pytz = "*"
 types-requests = "*"
@@ -107,14 +106,6 @@ pyinstaller = { version = "^5.9", python = "<3.12" }
 [tool.poetry.scripts]
 annofabcli = "annofabcli.__main__:main"
 
-[tool.isort]
-profile = "black"
-line_length = 120
-
-
-[tool.black]
-line-length = 120
-
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -123,7 +114,10 @@ check_untyped_defs = true
 
 [tool.ruff]
 target-version = "py38"
+line-length = 150
 
+
+[tool.ruff.lint]
 ignore = [
     "G004", # `logging-f-string` : loggingでf-stringを使いたいので無視する
     "PD901", #すでに`df`という変数をいろんなところで使っているため
@@ -138,6 +132,7 @@ ignore = [
     "ANN002", # missing-type-args
     "ANN003", # missing-type-kwargs
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
+    "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。
 
     # いずれ無視しないようにする
     "ANN201", # missing-return-type-public-function:
@@ -167,20 +162,19 @@ ignore = [
     "PT", # flake8-pytest-style
 ]
 
-line-length = 120
 select = [
     "ALL"
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.pyupgrade]
+[tool.ruff.lint.pyupgrade]
 # Python3.8をサポートしているため、`typing.List`などの型ヒントは警告しないようにする
 # https://beta.ruff.rs/docs/settings/#keep-runtime-typing
 keep-runtime-typing = true
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 10
 
 [tool.poetry-dynamic-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,9 @@ ignore = [
     "ANN002", # missing-type-args
     "ANN003", # missing-type-kwargs
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
-    "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。
+    "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。またPython3.11以降ｈ
+    "FIX", # TODOやFIXMEを使うため無視する
+    "TD", # TODOコメントの書き方に気にしていないので無視する
 
     # いずれ無視しないようにする
     "ANN201", # missing-return-type-public-function:

--- a/scripts/mask_user_info_for_all_visualization_dir.py
+++ b/scripts/mask_user_info_for_all_visualization_dir.py
@@ -24,9 +24,7 @@ def execute_mask_user_info_command(project_dir: Path, output_project_dir: Path, 
     subprocess.run(command, check=True)
 
 
-def mask_user_info_for_all_project_dir(
-    project_root_dir: Path, output_dir: Path, remainder_options: Optional[list[str]]
-) -> None:
+def mask_user_info_for_all_project_dir(project_root_dir: Path, output_dir: Path, remainder_options: Optional[list[str]]) -> None:
     for project_dir in project_root_dir.iterdir():
         if not project_dir.is_dir():
             continue

--- a/tests/annotation/test_annotation_query.py
+++ b/tests/annotation/test_annotation_query.py
@@ -5,7 +5,7 @@ from annofabcli.annotation.annotation_query import AnnotationQueryForCLI
 
 
 class TestAnnotationQueryForCLI:
-    ANNOTATION_SPECS = {
+    ANNOTATION_SPECS = {  # noqa: RUF012
         "labels": [
             {
                 "label_id": "9d6cca8d-3f5a-4808-a6c9-0ae18a478176",

--- a/tests/annotation/test_annotation_query.py
+++ b/tests/annotation/test_annotation_query.py
@@ -104,9 +104,7 @@ class TestAnnotationQueryForCLI:
     }
 
     def test_normal(self):
-        query = AnnotationQueryForCLI(
-            label="car", attributes={"car_kind": "emergency_vehicle", "traffic_lane": 1, "tracking_id": "foo"}
-        )
+        query = AnnotationQueryForCLI(label="car", attributes={"car_kind": "emergency_vehicle", "traffic_lane": 1, "tracking_id": "foo"})
         actual = query.to_query_for_api(self.ANNOTATION_SPECS)
         assert actual.label_id == "9d6cca8d-3f5a-4808-a6c9-0ae18a478176"
 

--- a/tests/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
+++ b/tests/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
@@ -4,7 +4,7 @@ from annofabcli.annotation_specs.get_annotation_specs_with_choice_id_replaced im
 
 
 class TestReplacingChoiceId:
-    attribute_list = [
+    attribute_list = [  # noqa: RUF012
         {
             "additional_data_definition_id": "f98a9545-5864-4e5b-a945-d327001a0179",
             "name": {

--- a/tests/annotation_specs/test_get_annotation_specs_with_attribute_id_replaced.py
+++ b/tests/annotation_specs/test_get_annotation_specs_with_attribute_id_replaced.py
@@ -76,6 +76,6 @@ class TestReplacingAttributeId:
             "restrictions": copy.deepcopy(self.restriction_list),
         }
         ReplacingAttributeId(all_yes=True).main(annotation_specs)
-        assert annotation_specs["additionals"][0]["additional_data_definition_id"] == "new_attr1"  # type: ignore[index] # noqa: E501
-        assert annotation_specs["labels"][0]["additional_data_definitions"] == ["new_attr1", "attr2"]  # type: ignore[index] # noqa: E501
-        assert annotation_specs["restrictions"][0]["additional_data_definition_id"] == "new_attr1"  # type: ignore[index] # noqa: E501
+        assert annotation_specs["additionals"][0]["additional_data_definition_id"] == "new_attr1"  # type: ignore[index]
+        assert annotation_specs["labels"][0]["additional_data_definitions"] == ["new_attr1", "attr2"]  # type: ignore[index]
+        assert annotation_specs["restrictions"][0]["additional_data_definition_id"] == "new_attr1"  # type: ignore[index]

--- a/tests/annotation_specs/test_get_annotation_specs_with_attribute_id_replaced.py
+++ b/tests/annotation_specs/test_get_annotation_specs_with_attribute_id_replaced.py
@@ -4,7 +4,7 @@ from annofabcli.annotation_specs.get_annotation_specs_with_attribute_id_replaced
 
 
 class TestReplacingAttributeId:
-    attribute_list = [
+    attribute_list = [  # noqa: RUF012
         {
             "additional_data_definition_id": "attr1",
             "name": {
@@ -31,7 +31,7 @@ class TestReplacingAttributeId:
             ],
         }
     ]
-    label_list = [
+    label_list = [  # noqa: RUF012
         {
             "label_id": "id1",
             "label_name": {
@@ -41,7 +41,7 @@ class TestReplacingAttributeId:
             "additional_data_definitions": ["attr1", "attr2"],
         }
     ]
-    restriction_list = [
+    restriction_list = [  # noqa: RUF012
         {
             "additional_data_definition_id": "attr1",
             "condition": {

--- a/tests/annotation_specs/test_get_annotation_specs_with_label_id_replaced.py
+++ b/tests/annotation_specs/test_get_annotation_specs_with_label_id_replaced.py
@@ -6,7 +6,7 @@ from annofabcli.annotation_specs.get_annotation_specs_with_label_id_replaced imp
 
 
 class TestReplacingLabelId:
-    label_list = [
+    label_list = [  # noqa: RUF012
         {
             "label_id": "id1",
             "label_name": {
@@ -15,7 +15,7 @@ class TestReplacingLabelId:
             },
         }
     ]
-    restriction_list = [
+    restriction_list = [  # noqa: RUF012
         {
             "additional_data_definition_id": "attr1",
             "condition": {

--- a/tests/annotation_specs/test_get_annotation_specs_with_label_id_replaced.py
+++ b/tests/annotation_specs/test_get_annotation_specs_with_label_id_replaced.py
@@ -42,4 +42,4 @@ class TestReplacingLabelId:
         }
         ReplacingLabelId(all_yes=True).main(annotation_specs)
         assert annotation_specs["labels"][0]["label_id"] == "name_en1"
-        assert annotation_specs["restrictions"][0]["condition"]["condition"]["labels"][0] == "name_en1"  # type: ignore[index] # noqa: E501
+        assert annotation_specs["restrictions"][0]["condition"]["condition"]["labels"][0] == "name_en1"  # type: ignore[index]

--- a/tests/annotation_specs/test_list_attribute_restriction.py
+++ b/tests/annotation_specs/test_list_attribute_restriction.py
@@ -93,9 +93,7 @@ class TestListAttributeRestrictionMain:
         assert actual == "'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS ''"
 
     def test_get_restriction_text_list(self):
-        actual1 = self.obj.get_restriction_text_list(
-            self.annotation_specs["restrictions"], target_attribute_names=["link"]
-        )
+        actual1 = self.obj.get_restriction_text_list(self.annotation_specs["restrictions"], target_attribute_names=["link"])
         assert len(actual1) == 1
 
         actual2 = self.obj.get_restriction_text_list(self.annotation_specs["restrictions"], target_label_names=["car"])

--- a/tests/annotation_specs/test_list_attribute_restriction.py
+++ b/tests/annotation_specs/test_list_attribute_restriction.py
@@ -58,7 +58,7 @@ class TestListAttributeRestrictionMain:
         actual = self.obj.get_restriction_text(attribute_id, condition)
         assert (
             actual
-            == "'link' (id='15235360-4f46-42ac-927d-0e046bf52ddd', type='link') HAS LABEL 'bike' (id='40f7796b-3722-4eed-9c0c-04a27f9165d2'), 'bus' (id='22b5189b-af7b-4d9c-83a5-b92f122170ec')"
+            == "'link' (id='15235360-4f46-42ac-927d-0e046bf52ddd', type='link') HAS LABEL 'bike' (id='40f7796b-3722-4eed-9c0c-04a27f9165d2'), 'bus' (id='22b5189b-af7b-4d9c-83a5-b92f122170ec')"  # noqa: E501
         )
 
     def test_get_restriction_text__imply(self):

--- a/tests/filesystem/test_mask_user_info.py
+++ b/tests/filesystem/test_mask_user_info.py
@@ -60,9 +60,7 @@ class TestMaskUserInfo:
 
     def test_create_masked_user_info_df__not_masked_user_id_setとnot_masked_biography_set引数を指定する(self):
         df_original = read_multiheader_csv(str(data_dir / "user2.csv"), header_row_count=2)
-        df_masked = create_masked_user_info_df(
-            df_original, not_masked_biography_set={"China"}, not_masked_user_id_set={"bob"}
-        )
+        df_masked = create_masked_user_info_df(df_original, not_masked_biography_set={"China"}, not_masked_user_id_set={"bob"})
 
         # user_idが"bob", biographyが"China"の行はマスクされていないこと、それ以外はマスクされていることの確認
         not_masked_row_indexes = [1, 2]

--- a/tests/project_member/test_change_project_members.py
+++ b/tests/project_member/test_change_project_members.py
@@ -3,12 +3,7 @@ from annofabcli.project_member.change_project_members import ChangeProjectMember
 
 class TestChangeProjectMembers:
     def test_validate_member_info(self):
-        assert (
-            ChangeProjectMembers.validate_member_info(
-                {"sampling_inspection_rate": 10, "sampling_acceptance_rate": 20, "foo": "bar"}
-            )
-            is True
-        )
+        assert ChangeProjectMembers.validate_member_info({"sampling_inspection_rate": 10, "sampling_acceptance_rate": 20, "foo": "bar"}) is True
 
         assert ChangeProjectMembers.validate_member_info({"sampling_inspection_rate": 10}) is True
 

--- a/tests/statistics/test_list_annotation_count.py
+++ b/tests/statistics/test_list_annotation_count.py
@@ -54,9 +54,9 @@ class TestListAnnotationCounterByInputData:
             }
         )
 
-        counter2 = ListAnnotationCounterByInputData(
-            target_labels=["climatic"], target_attribute_names=[("bird", "occluded")]
-        ).get_annotation_counter(annotation)
+        counter2 = ListAnnotationCounterByInputData(target_labels=["climatic"], target_attribute_names=[("bird", "occluded")]).get_annotation_counter(
+            annotation
+        )
         assert counter2.annotation_count_by_label == collections.Counter({"climatic": 1})
         assert counter2.annotation_count_by_attribute == collections.Counter(
             {
@@ -65,9 +65,7 @@ class TestListAnnotationCounterByInputData:
         )
 
     def test_get_annotation_counter_list(self):
-        counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(
-            data_dir / "simple-annotations.zip"
-        )
+        counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")
         assert len(counter_list) == 4
 
 
@@ -79,9 +77,7 @@ class TestListAnnotationCounterByTask:
 
 class TestLabelCountCsv:
     def test_print_csv_by_input_data(self):
-        counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(
-            data_dir / "simple-annotations.zip"
-        )
+        counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")
         LabelCountCsv().print_csv_by_input_data(
             counter_list,
             output_file=output_dir / "labels_count_by_input_data.csv",
@@ -100,9 +96,7 @@ class TestLabelCountCsv:
 
 class TestAttributeCountCsv:
     def test_print_csv_by_input_data(self):
-        counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(
-            data_dir / "simple-annotations.zip"
-        )
+        counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")
         AttributeCountCsv().print_csv_by_input_data(
             counter_list,
             output_file=output_dir / "list_annotation_count/attributes_count_by_input_data.csv",

--- a/tests/statistics/test_list_worktime.py
+++ b/tests/statistics/test_list_worktime.py
@@ -16,12 +16,8 @@ class TestListWorktime:
                 user_id="alice",
                 username="Alice",
                 worktime_hour=3.0,
-                start_event=SimpleTaskHistoryEvent(
-                    task_history_id="unknown", created_datetime="2019-01-01T23:00:00.000+09:00", status="working"
-                ),
-                end_event=SimpleTaskHistoryEvent(
-                    task_history_id="unknown", created_datetime="2019-01-02T02:00:00.000+09:00", status="on_holding"
-                ),
+                start_event=SimpleTaskHistoryEvent(task_history_id="unknown", created_datetime="2019-01-01T23:00:00.000+09:00", status="working"),
+                end_event=SimpleTaskHistoryEvent(task_history_id="unknown", created_datetime="2019-01-02T02:00:00.000+09:00", status="on_holding"),
             ),
             WorktimeFromTaskHistoryEvent(
                 project_id="prj1",
@@ -32,12 +28,8 @@ class TestListWorktime:
                 user_id="bob",
                 username="Bob",
                 worktime_hour=1.0,
-                start_event=SimpleTaskHistoryEvent(
-                    task_history_id="unknown", created_datetime="2019-01-03T22:00:00.000+09:00", status="working"
-                ),
-                end_event=SimpleTaskHistoryEvent(
-                    task_history_id="unknown", created_datetime="2019-01-03T23:00:00.000+09:00", status="on_holding"
-                ),
+                start_event=SimpleTaskHistoryEvent(task_history_id="unknown", created_datetime="2019-01-03T22:00:00.000+09:00", status="working"),
+                end_event=SimpleTaskHistoryEvent(task_history_id="unknown", created_datetime="2019-01-03T23:00:00.000+09:00", status="on_holding"),
             ),
         ]
 

--- a/tests/statistics/visualization/dataframe/test_task_worktime_by_phase_user.py
+++ b/tests/statistics/visualization/dataframe/test_task_worktime_by_phase_user.py
@@ -17,14 +17,10 @@ class TestTaskWorktimeByPhaseUser:
         task_history = TaskHistory(pandas.read_csv(str(data_dir / "task-history-df.csv")))
         user = User(pandas.read_csv(str(data_dir / "user.csv")))
         task = Task.from_csv(data_dir / "task.csv")
-        actual = TaskWorktimeByPhaseUser.from_df_wrapper(
-            task_history=task_history, user=user, task=task, project_id="prj1"
-        )
+        actual = TaskWorktimeByPhaseUser.from_df_wrapper(task_history=task_history, user=user, task=task, project_id="prj1")
 
         assert len(actual.df) == 10
-        target_row = actual.df[
-            (actual.df["task_id"] == "task1") & (actual.df["phase"] == "annotation") & (actual.df["user_id"] == "alice")
-        ].iloc[0]
+        target_row = actual.df[(actual.df["task_id"] == "task1") & (actual.df["phase"] == "annotation") & (actual.df["user_id"] == "alice")].iloc[0]
         assert target_row["worktime_hour"] == 2
         assert target_row["task_count"] == 1
 
@@ -33,9 +29,7 @@ class TestTaskWorktimeByPhaseUser:
     def test__from_csv__and__to_csv(self):
         actual = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
         assert len(actual.df) == 5
-        target_row = actual.df[
-            (actual.df["task_id"] == "task1") & (actual.df["phase"] == "annotation") & (actual.df["user_id"] == "alice")
-        ].iloc[0]
+        target_row = actual.df[(actual.df["task_id"] == "task1") & (actual.df["phase"] == "annotation") & (actual.df["user_id"] == "alice")].iloc[0]
         assert target_row["worktime_hour"] == 2
         assert target_row["task_count"] == 1
         actual.to_csv(output_dir / "test__from_csv__and__to_csv")
@@ -71,9 +65,7 @@ class TestTaskWorktimeByPhaseUser:
     def test___create_annotation_count_ratio_df(self):
         df_task_history = pandas.read_csv(str(data_dir / "task-history-df.csv"))
         df_task = pandas.read_csv(str(data_dir / "task.csv"))
-        actual = TaskWorktimeByPhaseUser._create_annotation_count_ratio_df(
-            task_df=df_task, task_history_df=df_task_history
-        )
+        actual = TaskWorktimeByPhaseUser._create_annotation_count_ratio_df(task_df=df_task, task_history_df=df_task_history)
         assert len(actual) == 10
 
         actual2 = actual.set_index(["task_id", "phase", "phase_stage", "account_id"])

--- a/tests/statistics/visualization/dataframe/test_whole_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_whole_productivity_per_date.py
@@ -60,9 +60,7 @@ class TestWholeProductivityPerCompletedDate:
     def test_merge(self):
         df1 = pandas.read_csv(str(data_dir / "productivity-per-date.csv"))
         df2 = pandas.read_csv(str(data_dir / "productivity-per-date2.csv"))
-        sum_obj = WholeProductivityPerCompletedDate.merge(
-            WholeProductivityPerCompletedDate(df1), WholeProductivityPerCompletedDate(df2)
-        )
+        sum_obj = WholeProductivityPerCompletedDate.merge(WholeProductivityPerCompletedDate(df1), WholeProductivityPerCompletedDate(df2))
         sum_obj.to_csv(self.output_dir / "merge-productivity-per-date.csv")
 
 

--- a/tests/statistics/visualization/test_write_performance_rating_csv.py
+++ b/tests/statistics/visualization/test_write_performance_rating_csv.py
@@ -20,9 +20,7 @@ data_dir = Path("tests/data/stat_visualization")
 
 
 def test__create_threshold_infos_per_project():
-    actual = create_threshold_infos_per_project(
-        '{"dirname": {"annotation": {"threshold_worktime": 11, "threshold_task_count": 21}}}'
-    )
+    actual = create_threshold_infos_per_project('{"dirname": {"annotation": {"threshold_worktime": 11, "threshold_task_count": 21}}}')
     assert actual == {("dirname", ProductivityType.ANNOTATION): ThresholdInfo(11, 21)}
 
 
@@ -68,78 +66,48 @@ class TestCollectingPerformanceInfo:
 
     def test__join_annotation_productivity(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_annotation_productivity(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual = obj.join_annotation_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual.columns[3] == ("project1", "actual_worktime_hour/annotation_count__annotation")
-        assert df_actual.iloc[0][("project1", "actual_worktime_hour/annotation_count__annotation")] == approx(
-            0.00070, rel=1e-2
-        )
+        assert df_actual.iloc[0][("project1", "actual_worktime_hour/annotation_count__annotation")] == approx(0.00070, rel=1e-2)
 
-        obj2 = CollectingPerformanceInfo(
-            productivity_indicator=ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT
-        )
-        df_actual2 = obj2.join_annotation_productivity(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        obj2 = CollectingPerformanceInfo(productivity_indicator=ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT)
+        df_actual2 = obj2.join_annotation_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual2.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__annotation")
 
         # productivity_indicator_by_directoryが優先されることを確認
         obj3 = CollectingPerformanceInfo(
             productivity_indicator=ProductivityIndicator.ACTUAL_WORKTIME_HOUR_PER_ANNOTATION_COUNT,
-            productivity_indicator_by_directory={
-                "project1": ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT
-            },
+            productivity_indicator_by_directory={"project1": ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT},
         )
-        df_actual3 = obj3.join_annotation_productivity(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual3 = obj3.join_annotation_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual3.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__annotation")
 
     def test__join_inspection_acceptance_productivity(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_inspection_acceptance_productivity(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual = obj.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual.columns[3] == ("project1", "actual_worktime_hour/annotation_count__acceptance")
-        assert df_actual.iloc[1][("project1", "actual_worktime_hour/annotation_count__acceptance")] == approx(
-            0.000145, rel=1e-2
-        )
+        assert df_actual.iloc[1][("project1", "actual_worktime_hour/annotation_count__acceptance")] == approx(0.000145, rel=1e-2)
 
-        obj2 = CollectingPerformanceInfo(
-            productivity_indicator=ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT
-        )
-        df_actual2 = obj2.join_inspection_acceptance_productivity(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        obj2 = CollectingPerformanceInfo(productivity_indicator=ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT)
+        df_actual2 = obj2.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual2.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__acceptance")
 
         # productivity_indicator_by_directoryが優先されることを確認
         obj3 = CollectingPerformanceInfo(
             productivity_indicator=ProductivityIndicator.ACTUAL_WORKTIME_HOUR_PER_ANNOTATION_COUNT,
-            productivity_indicator_by_directory={
-                "project1": ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT
-            },
+            productivity_indicator_by_directory={"project1": ProductivityIndicator.MONITORED_WORKTIME_HOUR_PER_ANNOTATION_COUNT},
         )
-        df_actual3 = obj3.join_inspection_acceptance_productivity(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual3 = obj3.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual3.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__acceptance")
 
     def test__join_annotation_quality(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_annotation_quality(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual = obj.join_annotation_quality(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual.columns[3] == ("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")
-        assert df_actual.iloc[0][
-            ("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")
-        ] == approx(0.000854, rel=1e-2)
+        assert df_actual.iloc[0][("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")] == approx(0.000854, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(quality_indicator=QualityIndicator.REJECTED_COUNT_PER_TASK_COUNT)
-        df_actual2 = obj2.join_annotation_quality(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual2 = obj2.join_annotation_quality(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual2.columns[3] == ("project1", "rejected_count/task_count__annotation")
 
         # quality_indicator_by_directoryが優先されることを確認
@@ -147,34 +115,24 @@ class TestCollectingPerformanceInfo:
             quality_indicator=QualityIndicator.POINTED_OUT_INSPECTION_COMMENT_COUNT_PER_INPUT_DATA_COUNT,
             quality_indicator_by_directory={"project1": QualityIndicator.REJECTED_COUNT_PER_TASK_COUNT},
         )
-        df_actual3 = obj3.join_annotation_quality(
-            df=df_user, df_performance=user_performance.df, project_title="project1"
-        )
+        df_actual3 = obj3.join_annotation_quality(df=df_user, df_performance=user_performance.df, project_title="project1")
         assert df_actual3.columns[3] == ("project1", "rejected_count/task_count__annotation")
 
     def test__filter_df_with_threshold(self):
         # threshold_worktime で絞り込み
         obj = CollectingPerformanceInfo(threshold_info=ThresholdInfo(threshold_worktime=6, threshold_task_count=None))
-        df_actual = obj.filter_df_with_threshold(
-            df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1"
-        )
+        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1")
         assert list(df_actual["user_id"]) == ["KX"]
 
         # threshold_task_count で絞り込み
         obj = CollectingPerformanceInfo(threshold_info=ThresholdInfo(threshold_worktime=None, threshold_task_count=40))
-        df_actual = obj.filter_df_with_threshold(
-            df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1"
-        )
+        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1")
         assert list(df_actual["user_id"]) == ["BH"]
 
         # threshold_task_count で絞り込み
         obj = CollectingPerformanceInfo(
             threshold_info=ThresholdInfo(threshold_worktime=100, threshold_task_count=100),
-            threshold_infos_by_directory={
-                ("project1", ProductivityType.ANNOTATION): ThresholdInfo(threshold_worktime=6, threshold_task_count=0)
-            },
+            threshold_infos_by_directory={("project1", ProductivityType.ANNOTATION): ThresholdInfo(threshold_worktime=6, threshold_task_count=0)},
         )
-        df_actual = obj.filter_df_with_threshold(
-            df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1"
-        )
+        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1")
         assert list(df_actual["user_id"]) == ["KX"]

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -79,7 +79,7 @@ class TestCommandLine:
         シナリオテスト。すべてのannotation系コマンドを実行する。
         前提条件：矩形の"car"ラベルに"truncation"チェックボックスが存在すること
         """
-        assert self._validate_annotation_specs_for_scenario_test(), "アノテーション仕様がシナリオテストを実行できる状態でありません。矩形の'car'ラベルを追加して、その下に'truncation'チェックボックスを追加してください。"
+        assert self._validate_annotation_specs_for_scenario_test(), "アノテーション仕様がシナリオテストを実行できる状態でありません。矩形の'car'ラベルを追加して、その下に'truncation'チェックボックスを追加してください。"  # noqa: E501
 
         task_id = target_task["task_id"]
         # インポート用のアノテーションを生成して、アノテーションをインポートする

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -39,9 +39,7 @@ class TestCommandLine:
             Trueならシナリオテストを実行できるアノテーション仕様
         """
         annotation_specs, _ = service.api.get_annotation_specs(project_id, query_params={"v": "2"})
-        car_label = more_itertools.first_true(
-            annotation_specs["labels"], pred=lambda e: get_message_for_i18n(e["label_name"]) == "car"
-        )
+        car_label = more_itertools.first_true(annotation_specs["labels"], pred=lambda e: get_message_for_i18n(e["label_name"]) == "car")
         if car_label is None:
             return False
 
@@ -70,7 +68,7 @@ class TestCommandLine:
             作成したタスク
         """
         # タスクの作成
-        new_task_id = f"test-{str(int(datetime.datetime.now().timestamp()))}"
+        new_task_id = f"test-{int(datetime.datetime.now().timestamp())!s}"
         task, _ = service.api.put_task(project_id, new_task_id, request_body={"input_data_id_list": [input_data_id]})
         yield task
         # タスクの削除
@@ -81,9 +79,7 @@ class TestCommandLine:
         シナリオテスト。すべてのannotation系コマンドを実行する。
         前提条件：矩形の"car"ラベルに"truncation"チェックボックスが存在すること
         """
-        assert (
-            self._validate_annotation_specs_for_scenario_test()
-        ), "アノテーション仕様がシナリオテストを実行できる状態でありません。矩形の'car'ラベルを追加して、その下に'truncation'チェックボックスを追加してください。"
+        assert self._validate_annotation_specs_for_scenario_test(), "アノテーション仕様がシナリオテストを実行できる状態でありません。矩形の'car'ラベルを追加して、その下に'truncation'チェックボックスを追加してください。"
 
         task_id = target_task["task_id"]
         # インポート用のアノテーションを生成して、アノテーションをインポートする

--- a/tests/test_annotation_specs.py
+++ b/tests/test_annotation_specs.py
@@ -70,7 +70,7 @@ class TestCommandLine:
             old_label_color = json.load(f)
 
         label_color = copy.deepcopy(old_label_color)
-        key = list(label_color.keys())[0]
+        key = list(label_color.keys())[0]  # noqa: RUF015
         color = label_color[key]
         new_color = (color[0], color[1], (color[2] + 1) % 256)
         label_color[key] = new_color

--- a/tests/test_annotation_specs.py
+++ b/tests/test_annotation_specs.py
@@ -53,7 +53,7 @@ class TestCommandLine:
         """
         label_colorに関するシナリオテスト。
         """
-        out_file = out_dir / f"annotation_specs_list_label_color--{str(datetime.datetime.now().timestamp())}.json"
+        out_file = out_dir / f"annotation_specs_list_label_color--{datetime.datetime.now().timestamp()!s}.json"
         main(
             [
                 self.command_name,
@@ -87,7 +87,7 @@ class TestCommandLine:
             ]
         )
 
-        out_file2 = out_dir / f"annotation_specs_list_label_color--{str(datetime.datetime.now().timestamp())}.json"
+        out_file2 = out_dir / f"annotation_specs_list_label_color--{datetime.datetime.now().timestamp()!s}.json"
         main(
             [
                 self.command_name,

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -34,7 +34,7 @@ class TestCommandLine:
             作成したタスク
         """
         # タスクの作成
-        new_task_id = f"test-{str(int(datetime.datetime.now().timestamp()))}"
+        new_task_id = f"test-{int(datetime.datetime.now().timestamp())!s}"
         task, _ = service.api.put_task(project_id, new_task_id, request_body={"input_data_id_list": [input_data_id]})
 
         yield task

--- a/tests/test_input_data.py
+++ b/tests/test_input_data.py
@@ -100,7 +100,7 @@ class TestCommandLine__put_with_json:
 
 class TestCommandLine:
     def test_scenario(self):
-        input_data_id = f"test-{str(datetime.datetime.now().timestamp())}"
+        input_data_id = f"test-{datetime.datetime.now().timestamp()!s}"
 
         json_args = [
             {

--- a/tests/test_input_data.py
+++ b/tests/test_input_data.py
@@ -35,7 +35,7 @@ class TestCommandLine__put:
                 "input_data_path": "file://tests/data/lenna.png",
             },
         ]
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             main(
                 [
                     "input_data",
@@ -62,7 +62,7 @@ class TestCommandLine__put:
                 "input_data_path": "file://tests/data/lenna2.png",
             },
         ]
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             main(
                 [
                     "input_data",

--- a/tests/test_supplementary.py
+++ b/tests/test_supplementary.py
@@ -34,11 +34,9 @@ class TestCommandLine:
             作成した入力データ
 
         """
-        new_input_data_id = f"test-{str(int(datetime.datetime.now().timestamp()))}"
+        new_input_data_id = f"test-{int(datetime.datetime.now().timestamp())!s}"
         # 入力データの作成
-        input_data = annofab_service.wrapper.put_input_data_from_file(
-            project_id, new_input_data_id, file_path="tests/data/small-lenna.png"
-        )
+        input_data = annofab_service.wrapper.put_input_data_from_file(project_id, new_input_data_id, file_path="tests/data/small-lenna.png")
         yield input_data
         # 入力データの削除
         annofab_service.api.delete_input_data(project_id, new_input_data_id)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -114,7 +114,7 @@ class TestCommandLine:
 
     @pytest.mark.submitting_job
     def test_put_task_by_count(self):
-        task_id_prefix = f"test-{str(int(datetime.datetime.now().timestamp()))}"
+        task_id_prefix = f"test-{int(datetime.datetime.now().timestamp())!s}"
         main(
             [
                 self.command_name,
@@ -137,7 +137,7 @@ class TestCommandLine:
             作成したタスク
         """
         # タスクの作成
-        new_task_id = f"test-{str(int(datetime.datetime.now().timestamp()))}"
+        new_task_id = f"test-{int(datetime.datetime.now().timestamp())!s}"
         task, _ = service.api.put_task(project_id, new_task_id, request_body={"input_data_id_list": [input_data_id]})
         yield task
         # タスクの削除
@@ -364,7 +364,7 @@ class TestCommandLine:
         `task put`コマンドでタスクを作成するテスト
         """
 
-        task_id = f"test-{str(datetime.datetime.now().timestamp())}"
+        task_id = f"test-{datetime.datetime.now().timestamp()!s}"
 
         # タスクの作成
         json_args = {task_id: [input_data_id]}


### PR DESCRIPTION
# line-lengthを120から150に変更
Ruffのv0.0.260から、line-lengthの計算が"character count"から"Unicode width"に変更された。
たとえば日本語の"あ"は2以上にカウントされるため、`line-length=120`だと長いメッセージが書きにくくなった。
したがって、`line-length = 150`を設定した。
https://github.com/astral-sh/ruff/pull/3714

