### PR TITLE
`statistics visualize` : `全体の生産性と品質.csv`を出力したときに発生するエラーを修正

### DIFF
--- a/tests/statistics/visualization/dataframe/test_user_performance.py
+++ b/tests/statistics/visualization/dataframe/test_user_performance.py
@@ -33,6 +33,10 @@ class TestUserPerformance:
         assert actual.df[("user_id", "")][0] == "alice"
         assert actual.df[("real_actual_worktime_hour", "sum")][0] == 6
         assert actual.df[("task_count", "annotation")][0] == 1
+        import pandas
+
+        pandas.set_option("display.max_rows", None)
+        print(actual.df.iloc[0])
 
     def test__from_df_wrapper__集計対象タスクが0件のとき(self):
         task_worktime_by_phase_user = TaskWorktimeByPhaseUser.empty()


### PR DESCRIPTION
# エラー内容
`全体の生産性と品質.csv`を出力するときにエラーが発生
```
Traceback (most recent call last):
  File "index.pyx", line 768, in pandas._libs.index.BaseMultiIndexCodesEngine.get_loc
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    raise KeyError(key) from err
KeyError: 'stdev__monitored_worktime_hour/annotation_count'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/pandas/core/indexes/multi.py", line 3053, in get_loc
    return self._engine.get_loc(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "index.pyx", line 771, in pandas._libs.index.BaseMultiIndexCodesEngine.get_loc
KeyError: ('stdev__monitored_worktime_hour/annotation_count', 'annotation')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/annofabcli/statistics/visualize_statistics.py", line 99, in wrapped
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/annofabcli/statistics/visualize_statistics.py", line 165, in write_user_performance
    user_performance = UserPerformance.from_df_wrapper(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/annofabcli/statistics/visualization/dataframe/user_performance.py", line 527, in from_df_wrapper
    cls._add_ratio_column_for_productivity_per_user(df, phase_list=phase_list)
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/annofabcli/statistics/visualization/dataframe/user_performance.py", line 152, in _add_ratio_column_for_productivity_per_user
    df[("stdev__monitored_worktime_hour/annotation_count", phase)] * ratio__actual_vs_monitored_worktime
    ~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/pandas/core/frame.py", line 4089, in __getitem__
    return self._getitem_multilevel(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/pandas/core/frame.py", line 4147, in _getitem_multilevel
    loc = self.columns.get_loc(key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kcitde/.cache/pypoetry/virtualenvs/kcitde-annotation-to-slack-OBHEOexS-py3.11/lib/python3.11/site-packages/pandas/core/indexes/multi.py", line 3055, in get_loc
    raise KeyError(key) from err
KeyError: ('stdev__monitored_worktime_hour/annotation_count', 'annotation')
```

# 原因
`monitored_worktime_hour/annotation_count`にinfが含まれると、標準偏差がNaNになる。
そしてNaNが含まれているデータをpivot_tableで処理すると、NaNはdropされるため、列に"annotation"が含まれない。
それにより後続の処理で失敗する。

```
        df_stdev2 = pandas.pivot_table(
            df_stdev, values=["worktime_hour/input_data_count", "worktime_hour/annotation_count"], index="account_id", columns="phase"
        )
```

# 対応策
* infが含まれているデータはinfを除外してから標準偏差を算出する
* pivot_tableでは`dropna=False`を指定する

