### PR TITLE
`statistics visualize` : 引数`--temp_dir`, `--not_downlod`を追加

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -223,6 +223,7 @@ class WorktimePerDate:
         project_id: str,
         actual_worktime: ActualWorktime,
         *,
+        task_history_event_json: Optional[Path] = None,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> WorktimePerDate:
@@ -240,10 +241,7 @@ class WorktimePerDate:
         """
 
         main_obj = ListWorktimeFromTaskHistoryEventMain(service, project_id=project_id)
-        worktime_list = main_obj.get_worktime_list(
-            project_id,
-        )
-
+        worktime_list = main_obj.get_worktime_list(project_id, task_history_event_json=task_history_event_json)
         df_member = cls._get_df_member(service, project_id)
 
         df = cls.get_df_worktime(worktime_list, df_member, actual_worktime=actual_worktime)

--- a/annofabcli/statistics/visualization/visualization_source_files.py
+++ b/annofabcli/statistics/visualization/visualization_source_files.py
@@ -170,7 +170,8 @@ class VisualizationSourceFiles:
         for task_id in task_ids:
             if task_index % 100 == 0:
                 logger.debug(f"{self.logging_prefix}: タスク履歴一覧取得中 {task_index} / {len(task_ids)} 件目")
-            result[task_id] = self.annofab_service.api.get_task_histories(self.project_id, task_id)
+            sub_task_histories, _ = self.annofab_service.api.get_task_histories(self.project_id, task_id)
+            result[task_id] = sub_task_histories
             task_index += 1
 
         with self.task_history_json_path.open(mode="w", encoding="utf-8") as f:

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -134,6 +134,7 @@ class WriteCsvGraph:
                 self.service,
                 self.project_id,
                 actual_worktime=self.actual_worktime,
+                task_history_event_json=self.visualize_source_files.task_history_event_json_path,
                 start_date=self.filtering_query.start_date,
                 end_date=self.filtering_query.end_date,
             )

--- a/tests/statistics/visualization/dataframe/test_user_performance.py
+++ b/tests/statistics/visualization/dataframe/test_user_performance.py
@@ -36,7 +36,6 @@ class TestUserPerformance:
         import pandas
 
         pandas.set_option("display.max_rows", None)
-        print(actual.df.iloc[0])
 
     def test__from_df_wrapper__集計対象タスクが0件のとき(self):
         task_worktime_by_phase_user = TaskWorktimeByPhaseUser.empty()


### PR DESCRIPTION
* ダウンロードしたアノテーションZIPなどを残すために`--temp_dir`引数を追加しました。
* ダウンロードしたアノテーションZIPなどから可視化情報を出力できるようにするるため、`--not_download`オプションを追加しました。このオプションを指定するとアノテーションZIPをダウンロードせずに、`--temp_dir`に存在するファイルを読み込んで可視化情報を出力します。