### PR TITLE
`statistics visualize`: 散布図のツールチップに項目を追加する

### DIFF
--- a/annofabcli/statistics/scatter.py
+++ b/annofabcli/statistics/scatter.py
@@ -142,5 +142,5 @@ def create_hover_tool(tool_tip_items: list[str]) -> HoverTool:
         return "_".join(tmp[0 : len(tmp) - 1])
 
     detail_tooltips = [(exclude_phase_name(e), f"@{{{e}}}") for e in tool_tip_items]
-    hover_tool = HoverTool(tooltips=detail_tooltips)
+    hover_tool = HoverTool(tooltips=[("(x,y)", "($x, $y)"), *detail_tooltips])
     return hover_tool

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -912,9 +912,10 @@ class UserPerformance:
                 f"annotation_count_{phase}",
                 f"{worktime_type.value}_worktime_hour/input_data_count_{phase}",
                 f"{worktime_type.value}_worktime_hour/annotation_count_{phase}",
+                "first_working_date_",
+                "last_working_date_",
+                "working_days_",
             ]
-            if worktime_type == WorktimeType.ACTUAL:
-                tooltip_item.append("last_working_date_")
 
             hover_tool = create_hover_tool(tooltip_item)
             fig.add_tools(hover_tool)
@@ -1019,7 +1020,6 @@ class UserPerformance:
                 "user_id_",
                 "username_",
                 "biography_",
-                "last_working_date_",
                 f"monitored_worktime_hour_{phase}",
                 f"task_count_{phase}",
                 f"input_data_count_{phase}",
@@ -1028,6 +1028,9 @@ class UserPerformance:
                 f"pointed_out_inspection_comment_count_{phase}",
                 f"rejected_count/task_count_{phase}",
                 f"pointed_out_inspection_comment_count/annotation_count_{phase}",
+                "first_working_date_",
+                "last_working_date_",
+                "working_days_",
             ]
 
             hover_tool = create_hover_tool(tooltip_item)
@@ -1101,9 +1104,10 @@ class UserPerformance:
                     f"pointed_out_inspection_comment_count_{phase}",
                     f"rejected_count/task_count_{phase}",
                     f"pointed_out_inspection_comment_count/annotation_count_{phase}",
+                    "first_working_date_",
+                    "last_working_date_",
+                    "working_days_",
                 ]
-                if worktime_type == WorktimeType.ACTUAL:
-                    tooltip_item.append("last_working_date_")
 
                 hover_tool = create_hover_tool(tooltip_item)
                 fig.add_tools(hover_tool)


### PR DESCRIPTION
散布図の項目に以下を追加しました。
* `first_working_date` : 作業を開始した日
* `working_days` : 作業日数
* x,y : X座標の値とY座標の値