### PR TITLE
`pyproject.toml`で無視していたRuffのルールを、一部適用する

### DIFF
--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -185,7 +185,7 @@ class ChangeAnnotationAttributesMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"タスク'{task_id}'のアノテーションの属性の変更に失敗しました。", exc_info=True)
             return False
 
-    def change_annotation_attributes_for_task_list(
+    def change_annotation_attributes_for_task_list(  # noqa: ANN201
         self,
         task_id_list: List[str],
         annotation_query: AnnotationQueryForAPI,

--- a/annofabcli/annotation/change_annotation_properties.py
+++ b/annofabcli/annotation/change_annotation_properties.py
@@ -51,7 +51,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
         self.project_id = project_id
         self.dump_annotation_obj = DumpAnnotationMain(service, project_id)
 
-    def change_annotation_properties(
+    def change_annotation_properties(  # noqa: ANN201
         self,
         task_id: str,
         annotation_list: List[SingleAnnotation],
@@ -93,7 +93,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
                 annotations_for_api.append(annotations)
             return annotations_for_api
 
-        def _to_request_body_elm(annotation: Dict[str, Any]):
+        def _to_request_body_elm(annotation: Dict[str, Any]):  # noqa: ANN202
             return self.service.api.put_annotation(
                 annotation["project_id"],
                 annotation["task_id"],
@@ -130,7 +130,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
         annotation_list = self.service.wrapper.get_all_annotation_list(self.project_id, query_params={"query": dict_query})
         return annotation_list
 
-    def change_properties_for_task(  # pylint: disable=too-many-return-statements
+    def change_properties_for_task(  # pylint: disable=too-many-return-statements  # noqa: PLR0911, PLR0912
         self,
         task_id: str,
         properties: AnnotationDetailForCli,
@@ -179,7 +179,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
                 )
                 changed_operator = True
 
-        else:
+        else:  # noqa: PLR5501
             if not can_put_annotation(dict_task, self.service.api.account_id):
                 logger.debug(
                     f"タスク'{task_id}'は、過去に誰かに割り当てられたタスクで、現在の担当者が自分自身でないため、アノテーションのプロパティの変更をスキップします。"
@@ -236,7 +236,7 @@ class ChangePropertiesOfAnnotationMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"task_id={task_id}: アノテーションのプロパティの変更に失敗しました。", exc_info=True)
             return False
 
-    def change_annotation_properties_task_list(
+    def change_annotation_properties_task_list(  # noqa: ANN201
         self,
         task_id_list: List[str],
         properties: AnnotationDetailForCli,

--- a/annofabcli/annotation/copy_annotation.py
+++ b/annofabcli/annotation/copy_annotation.py
@@ -35,23 +35,23 @@ class CopyTargetMixin:
 class CopyTarget(CopyTargetMixin, ABC):
     @property
     @abstractmethod
-    def src(self):
+    def src(self):  # noqa: ANN201
         pass
 
     @property
     @abstractmethod
-    def dest(self):
+    def dest(self):  # noqa: ANN201
         pass
 
 
 @dataclass(frozen=True)
 class CopyTargetByTask(CopyTarget):
     @property
-    def src(self):
+    def src(self):  # noqa: ANN201
         return f"{self.src_task_id}"
 
     @property
-    def dest(self):
+    def dest(self):  # noqa: ANN201
         return f"{self.dest_task_id}"
 
 
@@ -61,11 +61,11 @@ class CopyTargetByInputData(CopyTarget):
     dest_input_data_id: str
 
     @property
-    def src(self):
+    def src(self):  # noqa: ANN201
         return f"{self.src_task_id}/{self.src_input_data_id}"
 
     @property
-    def dest(self):
+    def dest(self):  # noqa: ANN201
         return f"{self.dest_task_id}/{self.dest_input_data_id}"
 
 
@@ -307,7 +307,7 @@ class CopyAnnotationMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'へコピーするのに失敗しました。", exc_info=True)
             return False
 
-    def copy_annotations(self, copy_target_list: list[CopyTarget], *, parallelism: Optional[int] = None):
+    def copy_annotations(self, copy_target_list: list[CopyTarget], *, parallelism: Optional[int] = None):  # noqa: ANN201
         if parallelism is not None:
             with multiprocessing.Pool(parallelism) as pool:
                 result_bool_list = pool.map(self.copy_annotation_wrapper, copy_target_list)

--- a/annofabcli/annotation/delete_annotation.py
+++ b/annofabcli/annotation/delete_annotation.py
@@ -49,7 +49,7 @@ class DeleteAnnotationMain(AbstractCommandLineWithConfirmInterface):
         self.project_id = project_id
         self.dump_annotation_obj = DumpAnnotationMain(service, project_id)
 
-    def delete_annotation_list(self, annotation_list: list[dict[str, Any]]):
+    def delete_annotation_list(self, annotation_list: list[dict[str, Any]]):  # noqa: ANN201
         """
         アノテーション一覧を削除する。
 
@@ -141,7 +141,7 @@ class DeleteAnnotationMain(AbstractCommandLineWithConfirmInterface):
         except requests.HTTPError:
             logger.warning(f"task_id={task_id}: アノテーションの削除に失敗しました。", exc_info=True)
 
-    def delete_annotation_for_task_list(
+    def delete_annotation_for_task_list(  # noqa: ANN201
         self,
         task_id_list: List[str],
         annotation_query: Optional[AnnotationQueryForAPI] = None,

--- a/annofabcli/annotation/download_annotation_zip.py
+++ b/annofabcli/annotation/download_annotation_zip.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingAnnotationZip(AbstractCommandLineInterface):
-    def download_annotation_zip(self, project_id: str, output_zip: Path, is_latest: bool, should_download_full_annotation: bool = False):
+    def download_annotation_zip(self, project_id: str, output_zip: Path, is_latest: bool, should_download_full_annotation: bool = False):  # noqa: ANN201
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
 
         project_title = self.facade.get_project_title(project_id)

--- a/annofabcli/annotation/dump_annotation.py
+++ b/annofabcli/annotation/dump_annotation.py
@@ -84,7 +84,7 @@ class DumpAnnotationMain:
             logger.warning(f"タスク'{task_id}'のアノテーション情報のダンプに失敗しました。", exc_info=True)
             return False
 
-    def dump_annotation(self, task_id_list: List[str], output_dir: Path, parallelism: Optional[int] = None):
+    def dump_annotation(self, task_id_list: List[str], output_dir: Path, parallelism: Optional[int] = None):  # noqa: ANN201
         project_title = self.facade.get_project_title(self.project_id)
         logger.info(f"プロジェクト'{project_title}'に対して、タスク{len(task_id_list)} 件のアノテーションをファイルに保存します。")
 

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -229,7 +229,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
         def _get_annotation_id(arg_label_info: LabelV1) -> str:
             if detail.annotation_id is not None:
                 return detail.annotation_id
-            else:
+            else:  # noqa: PLR5501
                 if arg_label_info["annotation_type"] == DefaultAnnotationType.CLASSIFICATION.value:
                     # 全体アノテーションの場合、annotation_idはlabel_idである必要がある
                     return arg_label_info["label_id"]
@@ -447,7 +447,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
                 )
                 changed_operator = True
 
-        else:
+        else:  # noqa: PLR5501
             if not can_put_annotation(task, self.service.api.account_id):
                 logger.debug(
                     f"タスク'{task_id}'は、過去に誰かに割り当てられたタスクで、現在の担当者が自分自身でないため、アノテーションのインポートをスキップします。"
@@ -480,7 +480,7 @@ class ImportAnnotationMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"task_id='{task_parser.task_id}' のアノテーションのインポートに失敗しました。", exc_info=True)
             return False
 
-    def main(
+    def main(  # noqa: ANN201
         self,
         iter_task_parser: Iterator[SimpleAnnotationParserByTask],
         target_task_ids: Optional[set[str]] = None,

--- a/annofabcli/annotation/restore_annotation.py
+++ b/annofabcli/annotation/restore_annotation.py
@@ -165,7 +165,7 @@ class RestoreAnnotationMain(AbstractCommandLineWithConfirmInterface):
                 )
                 changed_operator = True
 
-        else:
+        else:  # noqa: PLR5501
             if not can_put_annotation(task, self.service.api.account_id):
                 logger.debug(
                     f"タスク'{task_id}'は、過去に誰かに割り当てられたタスクで、現在の担当者が自分自身でないため、アノテーションのリストアをスキップします。"
@@ -198,7 +198,7 @@ class RestoreAnnotationMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"task_id={task_parser.task_id} のアノテーションのリストアに失敗しました。", exc_info=True)
             return False
 
-    def main(
+    def main(  # noqa: ANN201
         self,
         annotation_dir: Path,
         target_task_ids: Optional[set[str]] = None,

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -29,7 +29,7 @@ class PrintAnnotationSpecsLabel(AbstractCommandLineInterface):
 
     COMMON_MESSAGE = "annofabcli annotation_specs list_label: error:"
 
-    def print_annotation_specs_label(self, project_id: str, arg_format: str, output: Optional[str] = None, history_id: Optional[str] = None):
+    def print_annotation_specs_label(self, project_id: str, arg_format: str, output: Optional[str] = None, history_id: Optional[str] = None):  # noqa: ANN201
         # [REMOVE_V2_PARAM]
         annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"history_id": history_id, "v": "2"})
         labels_v1 = convert_annotation_specs_labels_v2_to_v1(labels_v2=annotation_specs["labels"], additionals_v2=annotation_specs["additionals"])

--- a/annofabcli/comment/download_comment_json.py
+++ b/annofabcli/comment/download_comment_json.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingComment(AbstractCommandLineInterface):
-    def download_comment_json(self, project_id: str, output_file: Path):
+    def download_comment_json(self, project_id: str, output_file: Path):  # noqa: ANN201
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
         project_title = self.facade.get_project_title(project_id)
         logger.info(f"{project_title} のコメント全件ファイルをダウンロードします。")

--- a/annofabcli/comment/list_comment.py
+++ b/annofabcli/comment/list_comment.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ListingComments(AbstractCommandLineInterface):
-    def get_comments(self, project_id: str, task_id: str, input_data_id: str):
+    def get_comments(self, project_id: str, task_id: str, input_data_id: str):  # noqa: ANN201
         comments, _ = self.service.api.get_comments(project_id, task_id, input_data_id, query_params={"v": "2"})
         return comments
 

--- a/annofabcli/common/annofab/project.py
+++ b/annofabcli/common/annofab/project.py
@@ -11,12 +11,12 @@ class Project:
         project, _ = service.api.get_project(project_id)
         self.project = project
 
-    def is_3d_annotation_editor_available(self):
+    def is_3d_annotation_editor_available(self):  # noqa: ANN201
         """標準の3次元アノテーションエディタを利用できるか"""
         configuration = self.project["configuration"]
         return configuration["plugin_id"] == EditorPluginId.THREE_DIMENSION
 
-    def is_3d_annotation_type_available(self):
+    def is_3d_annotation_type_available(self):  # noqa: ANN201
         """3次元のアノテーション種類を利用できるか"""
         configuration = self.project["configuration"]
         return configuration["extended_specs_plugin_id"] == ExtendSpecsPluginId.THREE_DIMENSION

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -411,7 +411,7 @@ class ArgumentParser:
     def __init__(self, parser: argparse.ArgumentParser) -> None:
         self.parser = parser
 
-    def add_project_id(self, help_message: Optional[str] = None):
+    def add_project_id(self, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--project_id` 引数を追加
         """
@@ -420,7 +420,7 @@ class ArgumentParser:
 
         self.parser.add_argument("-p", "--project_id", type=str, required=True, help=help_message)
 
-    def add_task_id(self, required: bool = True, help_message: Optional[str] = None):
+    def add_task_id(self, required: bool = True, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--task_id` 引数を追加
         """
@@ -429,7 +429,7 @@ class ArgumentParser:
 
         self.parser.add_argument("-t", "--task_id", type=str, required=required, nargs="+", help=help_message)
 
-    def add_input_data_id(self, required: bool = True, help_message: Optional[str] = None):
+    def add_input_data_id(self, required: bool = True, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--input_data_id` 引数を追加
         """
@@ -441,7 +441,7 @@ class ArgumentParser:
 
         self.parser.add_argument("-i", "--input_data_id", type=str, required=required, nargs="+", help=help_message)
 
-    def add_format(self, choices: List[FormatArgument], default: FormatArgument, help_message: Optional[str] = None):
+    def add_format(self, choices: List[FormatArgument], default: FormatArgument, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--format` 引数を追加
         """
@@ -450,7 +450,7 @@ class ArgumentParser:
 
         self.parser.add_argument("-f", "--format", type=str, choices=[e.value for e in choices], default=default.value, help=help_message)
 
-    def add_csv_format(self, help_message: Optional[str] = None):
+    def add_csv_format(self, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--csv_format` 引数を追加
         """
@@ -463,7 +463,7 @@ class ArgumentParser:
 
         self.parser.add_argument("--csv_format", type=str, help=help_message)
 
-    def add_output(self, required: bool = False, help_message: Optional[str] = None):
+    def add_output(self, required: bool = False, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--output` 引数を追加
         """
@@ -472,7 +472,7 @@ class ArgumentParser:
 
         self.parser.add_argument("-o", "--output", type=str, required=required, help=help_message)
 
-    def add_query(self, help_message: Optional[str] = None):
+    def add_query(self, help_message: Optional[str] = None):  # noqa: ANN201
         """
         '--query` 引数を追加
         """
@@ -481,7 +481,7 @@ class ArgumentParser:
 
         self.parser.add_argument("-q", "--query", type=str, help=help_message)
 
-    def add_task_query(self, required: bool = False, help_message: Optional[str] = None):
+    def add_task_query(self, required: bool = False, help_message: Optional[str] = None):  # noqa: ANN201
         if help_message is None:
             help_message = (
                 "タスクを絞り込むためのクエリ条件をJSON形式で指定します。"
@@ -547,7 +547,7 @@ class AbstractCommandLineWithoutWebapiInterface(abc.ABC):
         self.args = args
         self.process_common_args(args)
 
-    def process_common_args(self, args: argparse.Namespace):
+    def process_common_args(self, args: argparse.Namespace):  # noqa: ANN201
         """
         共通のコマンドライン引数を処理する。
         Args:
@@ -645,7 +645,7 @@ class PrettyHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaul
         # https://qiita.com/yuji38kwmt/items/c7c4d487e3188afd781e 参照
         return super()._format_action(action) + "\n"
 
-    def _get_help_string(self, action):  # noqa: ANN001
+    def _get_help_string(self, action):  # noqa: ANN001, ANN202
         # 必須な引数には、引数の説明の後ろに"(required)"を付ける
         help = action.help  # noqa: A001 # pylint: disable=redefined-builtin
         if action.required:
@@ -680,7 +680,7 @@ class AbstractCommandLineInterface(AbstractCommandLineWithoutWebapiInterface):
         self.facade = facade
         super().__init__(args)
 
-    def validate_project(
+    def validate_project(  # noqa: ANN201
         self,
         project_id: str,
         project_member_roles: Optional[List[ProjectMemberRole]] = None,

--- a/annofabcli/common/download.py
+++ b/annofabcli/common/download.py
@@ -38,7 +38,7 @@ class DownloadingFile:
     def get_max_wait_minutes(wait_options: WaitOptions) -> float:
         return wait_options.max_tries * wait_options.interval / 60
 
-    def _wait_for_completion(
+    def _wait_for_completion(  # noqa: ANN202
         self,
         project_id: str,
         job_type: ProjectJobType,
@@ -60,7 +60,7 @@ class DownloadingFile:
         if not result:
             raise UpdatedFileForDownloadingError(f"{filetype}の更新処理が{max_wait_minutes}分以内に完了しない、または更新処理に失敗しました。")
 
-    async def download_annotation_zip_with_async(
+    async def download_annotation_zip_with_async(  # noqa: ANN201
         self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None
     ):
         loop = asyncio.get_event_loop()
@@ -68,7 +68,7 @@ class DownloadingFile:
         result = await loop.run_in_executor(None, partial_func)
         return result
 
-    def download_annotation_zip(
+    def download_annotation_zip(  # noqa: ANN201
         self,
         project_id: str,
         dest_path: Union[str, Path],
@@ -78,7 +78,7 @@ class DownloadingFile:
     ):
         """アノテーションZIPをダウンロードします。"""
 
-        def download_annotation_zip():
+        def download_annotation_zip():  # noqa: ANN202
             if should_download_full_annotation:
                 self.service.wrapper.download_full_annotation_archive(project_id, dest_path)
             else:
@@ -99,7 +99,7 @@ class DownloadingFile:
                 else:
                     raise e
 
-    def wait_until_updated_annotation_zip(self, project_id: str, wait_options: Optional[WaitOptions] = None):
+    def wait_until_updated_annotation_zip(self, project_id: str, wait_options: Optional[WaitOptions] = None):  # noqa: ANN201
         job_id = None
         try:
             job = self.service.api.post_annotation_archive_update(project_id)[0]["job"]
@@ -116,7 +116,7 @@ class DownloadingFile:
 
         self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_ANNOTATION, wait_options=wait_options, job_id=job_id)
 
-    async def download_input_data_json_with_async(
+    async def download_input_data_json_with_async(  # noqa: ANN201
         self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None
     ):
         loop = asyncio.get_event_loop()
@@ -124,7 +124,7 @@ class DownloadingFile:
         result = await loop.run_in_executor(None, partial_func)
         return result
 
-    def download_input_data_json(
+    def download_input_data_json(  # noqa: ANN201
         self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None
     ):
         if is_latest:
@@ -142,7 +142,7 @@ class DownloadingFile:
                 else:
                     raise e
 
-    def wait_until_updated_input_data_json(self, project_id: str, wait_options: Optional[WaitOptions] = None):
+    def wait_until_updated_input_data_json(self, project_id: str, wait_options: Optional[WaitOptions] = None):  # noqa: ANN201
         job_id = None
         try:
             job = self.service.api.post_project_inputs_update(project_id)[0]["job"]
@@ -158,7 +158,7 @@ class DownloadingFile:
 
         self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_INPUTS_LIST, wait_options=wait_options, job_id=job_id)
 
-    async def download_task_json_with_async(
+    async def download_task_json_with_async(  # noqa: ANN201
         self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None
     ):
         loop = asyncio.get_event_loop()
@@ -166,7 +166,7 @@ class DownloadingFile:
         result = await loop.run_in_executor(None, partial_func)
         return result
 
-    def download_task_json(self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None):
+    def download_task_json(self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None):  # noqa: ANN201
         if is_latest:
             self.wait_until_updated_task_json(project_id, wait_options)
             self.service.wrapper.download_project_tasks_url(project_id, dest_path)
@@ -182,7 +182,7 @@ class DownloadingFile:
                 else:
                     raise e
 
-    def wait_until_updated_task_json(self, project_id: str, wait_options: Optional[WaitOptions] = None):
+    def wait_until_updated_task_json(self, project_id: str, wait_options: Optional[WaitOptions] = None):  # noqa: ANN201
         job_id = None
         try:
             job = self.service.api.post_project_tasks_update(project_id)[0]["job"]
@@ -198,7 +198,7 @@ class DownloadingFile:
 
         self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_TASKS_LIST, wait_options=wait_options, job_id=job_id)
 
-    async def download_task_history_json_with_async(self, project_id: str, dest_path: Union[str, Path]):
+    async def download_task_history_json_with_async(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         非同期でタスク履歴全件ファイルをダウンロードする。
 
@@ -207,7 +207,7 @@ class DownloadingFile:
         """
         return self.download_task_history_json(project_id, dest_path=dest_path)
 
-    def download_task_history_json(self, project_id: str, dest_path: Union[str, Path]):
+    def download_task_history_json(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         タスク履歴全件ファイルをダウンロードする。
 
@@ -227,7 +227,7 @@ class DownloadingFile:
                 ) from e
             raise e
 
-    def download_task_history_event_json(self, project_id: str, dest_path: Union[str, Path]):
+    def download_task_history_event_json(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         タスク履歴イベント全件ファイルをダウンロードする。
 
@@ -247,7 +247,7 @@ class DownloadingFile:
                 ) from e
             raise e
 
-    async def download_task_history_event_json_with_async(self, project_id: str, dest_path: Union[str, Path]):
+    async def download_task_history_event_json_with_async(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         非同期でタスク履歴全件ファイルをダウンロードする。
 
@@ -257,7 +257,7 @@ class DownloadingFile:
         """
         return self.download_task_history_event_json(project_id, dest_path=dest_path)
 
-    async def download_inspection_json_with_async(self, project_id: str, dest_path: Union[str, Path]):
+    async def download_inspection_json_with_async(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         非同期で検査コメント全件ファイルをダウンロードする。
 
@@ -267,7 +267,7 @@ class DownloadingFile:
 
         return self.download_inspection_comment_json(project_id, dest_path=dest_path)
 
-    def download_inspection_comment_json(self, project_id: str, dest_path: Union[str, Path]):
+    def download_inspection_comment_json(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         検査コメント全件ファイルをダウンロードする。
 
@@ -284,7 +284,7 @@ class DownloadingFile:
                 ) from e
             raise e
 
-    async def download_comment_json_with_async(self, project_id: str, dest_path: Union[str, Path]):
+    async def download_comment_json_with_async(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         非同期でコメント全件ファイルをダウンロードする。
 
@@ -294,7 +294,7 @@ class DownloadingFile:
 
         return self.download_comment_json(project_id, dest_path=dest_path)
 
-    def download_comment_json(self, project_id: str, dest_path: Union[str, Path]):
+    def download_comment_json(self, project_id: str, dest_path: Union[str, Path]):  # noqa: ANN201
         """
         コメント全件ファイルをダウンロードする。
 

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -128,7 +128,7 @@ def match_annotation_with_task_query(annotation: Dict[str, Any], task_query: Opt
     return True
 
 
-def match_task_with_query(  # pylint: disable=too-many-return-statements
+def match_task_with_query(  # pylint: disable=too-many-return-statements  # noqa: PLR0911
     task: Task, task_query: Optional[TaskQuery]
 ) -> bool:
     """
@@ -315,7 +315,7 @@ class AnnofabApiFacade:
             組織メンバ。見つからない場合はNone
         """
 
-        def update_organization_members():
+        def update_organization_members():  # noqa: ANN202
             organization_name = self.get_organization_name_from_project_id(project_id)
             members = self.service.wrapper.get_all_organization_members(organization_name)
             self._organization_members = (project_id, members)
@@ -498,7 +498,7 @@ class AnnofabApiFacade:
             task_query.account_id = self.get_account_id_from_user_id(project_id, task_query.user_id)
         return task_query
 
-    def validate_project(
+    def validate_project(  # noqa: ANN201
         self,
         project_id: str,
         project_member_roles: Optional[List[ProjectMemberRole]] = None,

--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -136,7 +136,7 @@ def fill_annotation_list(
     return draw
 
 
-def write_annotation_image(
+def write_annotation_image(  # noqa: ANN201
     parser: SimpleAnnotationParser,
     image_size: InputDataSize,
     label_color_dict: Dict[str, RGB],
@@ -299,7 +299,7 @@ def write_annotation_images_from_path(
     """  # noqa: E501
 
     def _get_image_size(input_data_id: str) -> Optional[InputDataSize]:
-        def _get_image_size_from_system_metadata(arg_input_data: Dict[str, Any]):
+        def _get_image_size_from_system_metadata(arg_input_data: Dict[str, Any]):  # noqa: ANN202
             # 入力データの`input_data.system_metadata.original_resolution`を参照して、画像サイズを決める。
             original_resolution = arg_input_data["system_metadata"]["original_resolution"]
             if original_resolution is not None and (original_resolution.get("width") is not None and original_resolution.get("height") is not None):

--- a/annofabcli/common/utils.py
+++ b/annofabcli/common/utils.py
@@ -84,7 +84,7 @@ def print_json(target: Any, is_pretty: bool = False, output: Optional[Union[str,
         output_string(json.dumps(target, ensure_ascii=False), output)
 
 
-def print_csv(df: pandas.DataFrame, output: Optional[Union[str, Path]] = None, to_csv_kwargs: Optional[Dict[str, Any]] = None):
+def print_csv(df: pandas.DataFrame, output: Optional[Union[str, Path]] = None, to_csv_kwargs: Optional[Dict[str, Any]] = None):  # noqa: ANN201
     if output is not None:
         Path(output).parent.mkdir(parents=True, exist_ok=True)
 
@@ -106,7 +106,7 @@ def print_id_list(id_list: List[Any], output: Optional[Union[str, Path]]) -> Non
     output_string(s, output)
 
 
-def print_according_to_format(
+def print_according_to_format(  # noqa: ANN201
     target: Any,  # noqa: ANN401
     arg_format: FormatArgument,
     output: Optional[Union[str, Path]] = None,
@@ -155,7 +155,7 @@ def print_according_to_format(
         print_id_list(inspection_id_list, output)
 
 
-def to_filename(s: str):
+def to_filename(s: str):  # noqa: ANN201
     """
     文字列をファイル名に使えるよう変換する。ファイル名に使えない文字は"__"に変換する。
     Args:
@@ -231,7 +231,7 @@ def get_cache_dir() -> Path:
     return cache_home_dir_path / "annofabcli"
 
 
-def read_multiheader_csv(csv_file: str, header_row_count: int = 2, **kwargs) -> pandas.DataFrame:
+def read_multiheader_csv(csv_file: str, header_row_count: int = 2, **kwargs) -> pandas.DataFrame:  # noqa: ANN003
     """
     複数ヘッダ行のCSVを読み込む。その際、"Unnamed"の列名は空文字に変更する。
 
@@ -279,7 +279,7 @@ def _catch_exception(function: Callable[..., Any]) -> Callable[..., Any]:
     Exceptionをキャッチしてログにstacktraceを出力する。
     """
 
-    def wrapped(*args, **kwargs):
+    def wrapped(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
         try:
             return function(*args, **kwargs)
         except Exception as e:  # pylint: disable=broad-except

--- a/annofabcli/common/visualize.py
+++ b/annofabcli/common/visualize.py
@@ -43,7 +43,7 @@ class AddProps:
         self._specs_labels: Optional[list[dict[str, Any]]] = None
         self._specs_inspection_phrases: Optional[list[dict[str, Any]]] = None
 
-    def _set_annotation_specs(self):
+    def _set_annotation_specs(self):  # noqa: ANN202
         """
         アノテーション仕様に関する情報をインスタンス変数に格納します。
         """
@@ -215,7 +215,7 @@ class AddProps:
 
         """
 
-        def add_commenter_info():
+        def add_commenter_info():  # noqa: ANN202
             commenter_user_id = None
             commenter_username = None
 
@@ -258,7 +258,7 @@ class AddProps:
 
         """
 
-        def add_commenter_info():
+        def add_commenter_info():  # noqa: ANN202
             commenter_user_id = None
             commenter_username = None
 

--- a/annofabcli/experimental/list_out_of_range_annotation_for_movie.py
+++ b/annofabcli/experimental/list_out_of_range_annotation_for_movie.py
@@ -19,11 +19,11 @@ from annofabcli.common.facade import AnnofabApiFacade
 logger = logging.getLogger(__name__)
 
 
-def _millisecond_to_hour(millisecond: int):
+def _millisecond_to_hour(millisecond: int):  # noqa: ANN202
     return millisecond / 1000 / 3600
 
 
-def _get_time_range(str_data: str):
+def _get_time_range(str_data: str):  # noqa: ANN202
     tmp_list = str_data.split(",")
     return (int(tmp_list[0]), int(tmp_list[1]))
 
@@ -193,7 +193,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.set_defaults(subcommand_func=main)
 
 
-def add_parser(subparsers: argparse._SubParsersAction):
+def add_parser(subparsers: argparse._SubParsersAction):  # noqa: ANN201
     subcommand_name = "list_out_of_range_annotation_for_movie"
     subcommand_help = "動画範囲外のアノテーションを探すためのCSVを出力します。"
     description = "動画範囲外のアノテーションを探すためのCSVを出力します。最後尾のアノテーションの開始時間、終了時間を出力します。"

--- a/annofabcli/filesystem/draw_annotation.py
+++ b/annofabcli/filesystem/draw_annotation.py
@@ -96,31 +96,31 @@ class DrawingAnnotationForOneImage:
             アノテーションを描画した状態のDrawing Object
         """
 
-        def draw_segmentation(data_uri: str, color: Color):
+        def draw_segmentation(data_uri: str, color: Color):  # noqa: ANN202
             # 外部ファイルを描画する
             with parser.open_outer_file(data_uri) as f:
                 with Image.open(f) as outer_image:
                     draw.bitmap([0, 0], outer_image, fill=color)
 
-        def draw_bounding_box(data: Dict[str, Any], color: Color):
+        def draw_bounding_box(data: Dict[str, Any], color: Color):  # noqa: ANN202
             xy = [
                 (data["left_top"]["x"], data["left_top"]["y"]),
                 (data["right_bottom"]["x"], data["right_bottom"]["y"]),
             ]
             draw.rectangle(xy, outline=color, width=self.drawing_options.line_width)
 
-        def draw_single_point(data: Dict[str, Any], color: Color, radius: int = 2):
+        def draw_single_point(data: Dict[str, Any], color: Color, radius: int = 2):  # noqa: ANN202
             point_x = data["point"]["x"]
             point_y = data["point"]["y"]
             draw.ellipse([(point_x - radius, point_y - radius), (point_x + radius, point_y + radius)], fill=color)
 
-        def draw_closed_polyline(data: Dict[str, Any], color: Color):
+        def draw_closed_polyline(data: Dict[str, Any], color: Color):  # noqa: ANN202
             points = data["points"]
             first_point = points[0]
             xy = [(e["x"], e["y"]) for e in points] + [(first_point["x"], first_point["y"])]
             draw.line(xy, fill=color, width=self.drawing_options.line_width)
 
-        def draw_polyline(data: Dict[str, Any], color: Color):
+        def draw_polyline(data: Dict[str, Any], color: Color):  # noqa: ANN202
             xy = [(e["x"], e["y"]) for e in data["points"]]
             draw.line(xy, fill=color, width=self.drawing_options.line_width)
 
@@ -157,7 +157,7 @@ class DrawingAnnotationForOneImage:
 
         return draw
 
-    def main(
+    def main(  # noqa: ANN201
         self,
         parser: SimpleAnnotationParser,
         image_file: Optional[Path],
@@ -212,7 +212,7 @@ def create_is_target_parser_func(
     return is_target_parser
 
 
-def draw_annotation_all(
+def draw_annotation_all(  # noqa: ANN201, PLR0913
     iter_parser: Iterator[SimpleAnnotationParser],
     image_dir: Optional[Path],
     input_data_id_relation_dict: Optional[Dict[str, str]],

--- a/annofabcli/filesystem/filter_annotation.py
+++ b/annofabcli/filesystem/filter_annotation.py
@@ -30,7 +30,7 @@ class FilterQuery:
     exclude_input_data_name_set: Optional[Set[str]] = None
 
 
-def match_query(  # pylint: disable=too-many-return-statements
+def match_query(  # pylint: disable=too-many-return-statements  # noqa: PLR0911
     annotation: Dict[str, Any], filter_query: FilterQuery
 ) -> bool:
     if filter_query.task_query is not None and not match_annotation_with_task_query(annotation, filter_query.task_query):

--- a/annofabcli/filesystem/mask_user_info.py
+++ b/annofabcli/filesystem/mask_user_info.py
@@ -133,7 +133,7 @@ def _get_tuple_column(df: pandas.DataFrame, column: str) -> Union[str, Tuple]:
         return column
 
 
-def replace_by_columns(
+def replace_by_columns(  # noqa: ANN201
     df: pandas.DataFrame,
     replacement_dict: Dict[str, str],
     main_column: Union[str, Tuple],
@@ -239,7 +239,7 @@ def create_replacement_dict_by_biography(
     return {key: f"category-{value}" for key, value in tmp_replace_dict_by_biography.items()}
 
 
-def replace_user_info_by_user_id(df: pandas.DataFrame, replacement_dict_by_user_id: Dict[str, str]):
+def replace_user_info_by_user_id(df: pandas.DataFrame, replacement_dict_by_user_id: Dict[str, str]):  # noqa: ANN201
     """
     user_id, username, account_id 列を, マスクする。
 
@@ -260,7 +260,7 @@ def replace_user_info_by_user_id(df: pandas.DataFrame, replacement_dict_by_user_
     replace_by_columns(df, replacement_dict_by_user_id, main_column=user_id_column, sub_columns=sub_columns)
 
 
-def replace_biography(df: pandas.DataFrame, replacement_dict_by_user_id: Dict[str, str], replacement_dict_by_biography: Dict[str, str]):
+def replace_biography(df: pandas.DataFrame, replacement_dict_by_user_id: Dict[str, str], replacement_dict_by_biography: Dict[str, str]):  # noqa: ANN201
     """
     biography 列を, マスクする。
 

--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -54,7 +54,7 @@ class MergeAnnotationMain:
     def _is_segmentation(anno: Dict[str, Any]) -> bool:
         return anno["data"]["_type"] in ["Segmentation", "SegmentationV2"]
 
-    def write_merged_annotation(self, parser1: SimpleAnnotationParser, parser2: SimpleAnnotationParser, output_json: Path):
+    def write_merged_annotation(self, parser1: SimpleAnnotationParser, parser2: SimpleAnnotationParser, output_json: Path):  # noqa: ANN201
         simple_annotation1 = parser1.load_json()
         simple_annotation2 = parser2.load_json()
         details1 = simple_annotation1["details"]
@@ -95,7 +95,7 @@ class MergeAnnotationMain:
         with output_json.open("w") as f:
             json.dump(new_simple_annotation, f, ensure_ascii=False)
 
-    def copy_annotation(self, parser: SimpleAnnotationParser, output_json: Path):
+    def copy_annotation(self, parser: SimpleAnnotationParser, output_json: Path):  # noqa: ANN201
         simple_annotation = parser.load_json()
         details = simple_annotation["details"]
 
@@ -141,7 +141,7 @@ class MergeAnnotationMain:
 
         return is_target_parser
 
-    def main(
+    def main(  # noqa: ANN201
         self,
         annotation_path1: Path,
         annotation_path2: Path,

--- a/annofabcli/input_data/delete_input_data.py
+++ b/annofabcli/input_data/delete_input_data.py
@@ -66,7 +66,7 @@ class DeleteInputData(AbstractCommandLineInterface):
         )
         return self.confirm_processing(message_for_confirm)
 
-    def delete_input_data(self, project_id: str, input_data_id: str, input_data_index: int, delete_supplementary: bool, force: bool):
+    def delete_input_data(self, project_id: str, input_data_id: str, input_data_index: int, delete_supplementary: bool, force: bool):  # noqa: ANN201
         input_data = self.service.wrapper.get_input_data_or_none(project_id, input_data_id)
         if input_data is None:
             logger.info(f"input_data_id={input_data_id} は存在しません。")
@@ -115,7 +115,7 @@ class DeleteInputData(AbstractCommandLineInterface):
                 )
         return True
 
-    def delete_input_data_list(self, project_id: str, input_data_id_list: List[str], delete_supplementary: bool, force: bool):
+    def delete_input_data_list(self, project_id: str, input_data_id_list: List[str], delete_supplementary: bool, force: bool):  # noqa: ANN201
         """
         タスクに使われていない入力データを削除する。
         """

--- a/annofabcli/input_data/download_input_data_json.py
+++ b/annofabcli/input_data/download_input_data_json.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingInputData(AbstractCommandLineInterface):
-    def download_input_data_json(self, project_id: str, output_file: Path, is_latest: bool):
+    def download_input_data_json(self, project_id: str, output_file: Path, is_latest: bool):  # noqa: ANN201
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
         project_title = self.facade.get_project_title(project_id)
         logger.info(f"{project_title} の入力データ全件ファイルをダウンロードします。")

--- a/annofabcli/input_data/list_input_data.py
+++ b/annofabcli/input_data/list_input_data.py
@@ -131,7 +131,7 @@ class ListInputData(AbstractCommandLineInterface):
 
         return input_data_list
 
-    def print_input_data(
+    def print_input_data(  # noqa: ANN201
         self,
         project_id: str,
         input_data_query: Optional[Dict[str, Any]] = None,

--- a/annofabcli/input_data/list_input_data_merged_task.py
+++ b/annofabcli/input_data/list_input_data_merged_task.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_WAIT_OPTIONS = WaitOptions(interval=60, max_tries=360)
 
 
-def millisecond_to_hour(millisecond: int):
+def millisecond_to_hour(millisecond: int):  # noqa: ANN201
     return millisecond / 1000 / 3600
 
 
@@ -70,7 +70,7 @@ class ListInputDataMergedTaskMain:
             )
         return df
 
-    def create_input_data_merged_task(
+    def create_input_data_merged_task(  # noqa: ANN201
         self,
         input_data_list: List[Dict[str, Any]],
         task_list: List[Dict[str, Any]],
@@ -131,7 +131,7 @@ class ListInputDataMergedTask(AbstractCommandLineInterface):
 
         return True
 
-    def download_json_files(self, project_id: str, output_dir: Path, is_latest: bool, wait_options: WaitOptions):
+    def download_json_files(self, project_id: str, output_dir: Path, is_latest: bool, wait_options: WaitOptions):  # noqa: ANN201
         loop = asyncio.get_event_loop()
         downloading_obj = DownloadingFile(self.service)
         gather = asyncio.gather(

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -120,7 +120,7 @@ class SubPutInputData:
         self.facade = facade
         self.all_yes = all_yes
 
-    def put_input_data(self, project_id: str, csv_input_data: InputDataForPut, last_updated_datetime: Optional[str] = None):
+    def put_input_data(self, project_id: str, csv_input_data: InputDataForPut, last_updated_datetime: Optional[str] = None):  # noqa: ANN201
         request_body: Dict[str, Any] = {"last_updated_datetime": last_updated_datetime}
 
         file_path = get_file_scheme_path(csv_input_data.input_data_path)
@@ -279,7 +279,7 @@ class PutInputData(AbstractCommandLineInterface):
 
     @staticmethod
     def get_input_data_list_from_df(df: pandas.DataFrame) -> List[CsvInputData]:
-        def create_input_data(e: Any):  # noqa: ANN401
+        def create_input_data(e: Any):  # noqa: ANN202, ANN401
             input_data_id = e.input_data_id if not pandas.isna(e.input_data_id) else None
             sign_required: Optional[bool] = e.sign_required if pandas.notna(e.sign_required) else None
             return CsvInputData(

--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -56,7 +56,7 @@ class UpdateMetadataMain(AbstractCommandLineWithConfirmInterface):
         logger.debug(f"{logging_prefix} 入力データを更新しました。input_data_id={input_data['input_data_id']}")
         return True
 
-    def set_metadata_to_input_data_wrapper(self, tpl: Tuple[int, str], project_id: str, metadata: Dict[str, Any], overwrite_metadata: bool = False):
+    def set_metadata_to_input_data_wrapper(self, tpl: Tuple[int, str], project_id: str, metadata: Dict[str, Any], overwrite_metadata: bool = False):  # noqa: ANN201
         input_data_index, input_data_id = tpl
         return self.set_metadata_to_input_data(
             project_id,
@@ -66,7 +66,7 @@ class UpdateMetadataMain(AbstractCommandLineWithConfirmInterface):
             input_data_index=input_data_index,
         )
 
-    def update_metadata_of_input_data(
+    def update_metadata_of_input_data(  # noqa: ANN201
         self,
         project_id: str,
         input_data_id_list: List[str],

--- a/annofabcli/instruction/copy_instruction.py
+++ b/annofabcli/instruction/copy_instruction.py
@@ -19,7 +19,7 @@ class CopyInstruction(AbstractCommandLineInterface):
     作業ガイドをコピーする。
     """
 
-    def validate_projects(self, src_project_id: str, dest_project_id: str):
+    def validate_projects(self, src_project_id: str, dest_project_id: str):  # noqa: ANN201
         """
         適切なRoleが付与されているかを確認する。
 

--- a/annofabcli/instruction/download_instruction.py
+++ b/annofabcli/instruction/download_instruction.py
@@ -24,7 +24,7 @@ class DownloadInstructionMain:
         self.service = service
         self.facade = AnnofabApiFacade(service)
 
-    def download_instruction_image(self, project_id: str, instruction_image_url: str, dest_path: Path):
+    def download_instruction_image(self, project_id: str, instruction_image_url: str, dest_path: Path):  # noqa: ANN201
         """
         HTTP GETで取得した内容をファイルに保存する（ダウンロードする）
         """
@@ -81,7 +81,7 @@ class DownloadInstructionMain:
 
         return pq.outer_html()
 
-    def download_instruction(self, project_id: str, output_dir: Path, history_id: Optional[str] = None, is_download_image: bool = False):
+    def download_instruction(self, project_id: str, output_dir: Path, history_id: Optional[str] = None, is_download_image: bool = False):  # noqa: ANN201
         """
         作業ガイドをダウンロードする
 

--- a/annofabcli/instruction/upload_instruction.py
+++ b/annofabcli/instruction/upload_instruction.py
@@ -48,7 +48,7 @@ class UploadInstruction(AbstractCommandLineInterface):
     作業ガイドをアップロードする
     """
 
-    def upload_html_to_instruction(self, project_id: str, html_path: Path, temp_dir: Path):
+    def upload_html_to_instruction(self, project_id: str, html_path: Path, temp_dir: Path):  # noqa: ANN201, PLR0912
         with html_path.open(encoding="utf-8") as f:
             file_content = f.read()
         pq_html = pyquery.PyQuery(file_content)
@@ -66,7 +66,7 @@ class UploadInstruction(AbstractCommandLineInterface):
 
             if src_value.startswith("data:"):
                 img_path = save_image_from_data_uri_scheme(src_value, temp_dir=temp_dir)
-            else:
+            else:  # noqa: PLR5501
                 if src_value[0] == "/":
                     img_path = Path(src_value)
                 else:
@@ -103,7 +103,7 @@ class UploadInstruction(AbstractCommandLineInterface):
         self.update_instruction(project_id, html_data)
         logger.info("作業ガイドを更新しました。")
 
-    def update_instruction(self, project_id: str, html_data: str):
+    def update_instruction(self, project_id: str, html_data: str):  # noqa: ANN201
         histories, _ = self.service.api.get_instruction_history(project_id)
         if len(histories) > 0:
             last_updated_datetime = histories[0]["updated_datetime"]

--- a/annofabcli/job/delete_job.py
+++ b/annofabcli/job/delete_job.py
@@ -22,7 +22,7 @@ class DeleteJobMain:
         self.service = service
         self.facade = AnnofabApiFacade(service)
 
-    def delete_job_list(self, project_id: str, job_type: ProjectJobType, job_id_list: List[str]):
+    def delete_job_list(self, project_id: str, job_type: ProjectJobType, job_id_list: List[str]):  # noqa: ANN201
         job_list = self.service.wrapper.get_all_project_job(project_id, query_params={"type": job_type.value})
         exists_job_id_set = {e["job_id"] for e in job_list}
 

--- a/annofabcli/job/wait_job.py
+++ b/annofabcli/job/wait_job.py
@@ -25,7 +25,7 @@ class WaitJobMain:
         self.service = service
         self.facade = AnnofabApiFacade(service)
 
-    def wait_job(self, project_id: str, job_type: ProjectJobType, wait_options: WaitOptions, job_id: Optional[str] = None):
+    def wait_job(self, project_id: str, job_type: ProjectJobType, wait_options: WaitOptions, job_id: Optional[str] = None):  # noqa: ANN201
         MAX_WAIT_MINUTE = wait_options.max_tries * wait_options.interval / 60
         logger.info(f"job_type='{job_type.value}', job_id='{job_id}' :: ジョブが完了するまで、最大{MAX_WAIT_MINUTE}分間待ちます。")
         result = self.service.wrapper.wait_until_job_finished(

--- a/annofabcli/project/change_project_status.py
+++ b/annofabcli/project/change_project_status.py
@@ -15,7 +15,7 @@ from annofabcli.common.facade import AnnofabApiFacade
 logger = logging.getLogger(__name__)
 
 
-def create_minimal_dataframe(project_list: List[Project]):
+def create_minimal_dataframe(project_list: List[Project]):  # noqa: ANN201
     """必要最小限の列であるDataFrameを作成する"""
     df = pandas.DataFrame(project_list)
     df["last_tasks_updated_datetime"] = [e["summary"]["last_tasks_updated_datetime"] for e in project_list]
@@ -77,7 +77,7 @@ class ChanegProjectStatusMain:
 
         """
 
-        def remove_key(arg_key: str):
+        def remove_key(arg_key: str):  # noqa: ANN202
             if arg_key in project_query:
                 logger.info(f"project_query から、`{arg_key}`　キーを削除しました。")
                 project_query.pop(arg_key)
@@ -122,7 +122,7 @@ class ChanegProjectStatusMain:
         self.service.api.put_project(project_id, request_body=project)
         return True
 
-    def change_status_for_project_list(self, project_id_list: List[str], status: ProjectStatus, force_suspend: bool = False):
+    def change_status_for_project_list(self, project_id_list: List[str], status: ProjectStatus, force_suspend: bool = False):  # noqa: ANN201
         """
         複数のプロジェクトに対して、プロジェクトのステータスを変更する。
 

--- a/annofabcli/project/copy_project.py
+++ b/annofabcli/project/copy_project.py
@@ -46,7 +46,7 @@ class CopyProject(AbstractCommandLineInterface):
     プロジェクトをコピーする
     """
 
-    def copy_project(
+    def copy_project(  # noqa: ANN201
         self,
         src_project_id: str,
         dest_project_id: str,

--- a/annofabcli/project/diff_projects.py
+++ b/annofabcli/project/diff_projects.py
@@ -36,15 +36,15 @@ class DiffTarget(Enum):
     SETTINGS = "settings"
 
 
-def sorted_inspection_phrases(phrases: List[Dict[str, Any]]):
+def sorted_inspection_phrases(phrases: List[Dict[str, Any]]):  # noqa: ANN201
     return sorted(phrases, key=lambda e: e["id"])
 
 
-def sorted_project_members(project_members: List[Dict[str, Any]]):
+def sorted_project_members(project_members: List[Dict[str, Any]]):  # noqa: ANN201
     return sorted(project_members, key=lambda e: e["user_id"])
 
 
-def create_ignored_label(label: Dict[str, Any]):
+def create_ignored_label(label: Dict[str, Any]):  # noqa: ANN201
     """
     比較対象外のkeyを削除したラベル情報を生成する
     """
@@ -194,7 +194,7 @@ class DiffProjects(AbstractCommandLineInterface):
 
         for label_name in label_names:
 
-            def get_label_func(label_name: str, label: Dict[str, Any]):
+            def get_label_func(label_name: str, label: Dict[str, Any]):  # noqa: ANN202
                 return AnnofabApiFacade.get_label_name_en(label) == label_name
 
             label1 = more_itertools.first_true(labels1, pred=functools.partial(get_label_func, label_name))
@@ -325,7 +325,7 @@ class DiffProjects(AbstractCommandLineInterface):
             logger.info("プロジェクト設定は同じ")
             return False, diff_message
 
-    def validate_projects(self, project_id1: str, project_id2: str):
+    def validate_projects(self, project_id1: str, project_id2: str):  # noqa: ANN201
         """
         適切なRoleが付与されているかを確認する。
 

--- a/annofabcli/project/list_project.py
+++ b/annofabcli/project/list_project.py
@@ -22,7 +22,7 @@ from annofabcli.common.utils import get_columns_with_priority
 logger = logging.getLogger(__name__)
 
 
-def create_minimal_dataframe(project_list: List[Project]):
+def create_minimal_dataframe(project_list: List[Project]):  # noqa: ANN201
     """必要最小限の列であるDataFrameを作成する"""
     df = pandas.DataFrame(project_list)
     df["last_tasks_updated_datetime"] = [e["summary"]["last_tasks_updated_datetime"] for e in project_list]
@@ -88,7 +88,7 @@ class ListProjectMain:
 
         """
 
-        def remove_key(arg_key: str):
+        def remove_key(arg_key: str):  # noqa: ANN202
             if arg_key in project_query:
                 logger.info(f"project_query から、`{arg_key}`　キーを削除しました。")
                 project_query.pop(arg_key)

--- a/annofabcli/project/put_project.py
+++ b/annofabcli/project/put_project.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class PutProject(AbstractCommandLineInterface):
-    def put_project(
+    def put_project(  # noqa: ANN201
         self,
         organization: str,
         title: str,

--- a/annofabcli/project/update_annotation_zip.py
+++ b/annofabcli/project/update_annotation_zip.py
@@ -83,7 +83,7 @@ class SubUpdateAnnotationZip:
         else:
             return True
 
-    def _wait_for_completion_updated_annotation(self, project_id: str, wait_options: Optional[WaitOptions] = None):
+    def _wait_for_completion_updated_annotation(self, project_id: str, wait_options: Optional[WaitOptions] = None):  # noqa: ANN202
         """
         アノテーションzipの更新が完了するまで待ちます。
         """

--- a/annofabcli/project_member/change_project_members.py
+++ b/annofabcli/project_member/change_project_members.py
@@ -46,7 +46,7 @@ class ChangeProjectMembers(AbstractCommandLineInterface):
 
         """
 
-        def get_value(key: str):
+        def get_value(key: str):  # noqa: ANN202
             if member_info is None:
                 return old_member[key]
 
@@ -68,7 +68,7 @@ class ChangeProjectMembers(AbstractCommandLineInterface):
         updated_project_member = self.service.api.put_project_member(project_id, user_id, request_body=request_body)[0]
         return updated_project_member
 
-    def change_project_members(
+    def change_project_members(  # noqa: ANN201
         self,
         project_id: str,
         user_id_list: Collection[str],

--- a/annofabcli/project_member/copy_project_members.py
+++ b/annofabcli/project_member/copy_project_members.py
@@ -30,7 +30,7 @@ class CopyProjectMembers(AbstractCommandLineInterface):
         self.src_project_title = project_title1
         self.dest_project_title = project_title2
 
-    def validate_projects(self, src_project_id: str, dest_project_id: str):
+    def validate_projects(self, src_project_id: str, dest_project_id: str):  # noqa: ANN201
         """
         適切なRoleが付与されているかを確認する。
 
@@ -92,7 +92,7 @@ class CopyProjectMembers(AbstractCommandLineInterface):
 
         return updated_project_members
 
-    def copy_project_members(self, src_project_id: str, dest_project_id: str, delete_dest: bool = False):
+    def copy_project_members(self, src_project_id: str, dest_project_id: str, delete_dest: bool = False):  # noqa: ANN201
         """
         プロジェクトメンバを、別のプロジェクトにコピーする。
 
@@ -140,7 +140,7 @@ class CopyProjectMembers(AbstractCommandLineInterface):
             src_account_ids = [e["account_id"] for e in src_project_members]
             deleted_dest_members = [e for e in dest_project_members if e["account_id"] not in src_account_ids]
 
-            def to_inactive(arg_member: dict[str, Any]):
+            def to_inactive(arg_member: dict[str, Any]):  # noqa: ANN202
                 arg_member["member_status"] = "inactive"
                 return arg_member
 

--- a/annofabcli/project_member/drop_project_members.py
+++ b/annofabcli/project_member/drop_project_members.py
@@ -19,7 +19,7 @@ class DropProjectMembersMain:
         self.service = service
         self.facade = AnnofabApiFacade(service)
 
-    def drop_project_members(self, project_id: str, user_id_list: List[str]):
+    def drop_project_members(self, project_id: str, user_id_list: List[str]):  # noqa: ANN201
         """
         複数ユーザをプロジェクトメンバから脱退させる
 
@@ -30,7 +30,7 @@ class DropProjectMembersMain:
         """
         dest_project_members = self.service.wrapper.get_all_project_members(project_id)
 
-        def get_project_member(user_id: str):
+        def get_project_member(user_id: str):  # noqa: ANN202
             return first_true(dest_project_members, pred=lambda e: e["user_id"] == user_id)
 
         project_title = self.facade.get_project_title(project_id)
@@ -54,13 +54,13 @@ class DropProjectMembersMain:
                 logger.warning(e)
                 logger.warning(f"{project_title}({project_id}) のプロジェクトメンバから、{user_id} を脱退させられませんでした。")
 
-    def drop_role_with_organization(self, organization_name: str, user_id_list: List[str]):
+    def drop_role_with_organization(self, organization_name: str, user_id_list: List[str]):  # noqa: ANN201
         projects = self.service.wrapper.get_all_projects_of_organization(organization_name, query_params={"account_id": self.service.api.account_id})
 
         project_id_list = [e["project_id"] for e in projects]
         self.drop_role_with_project_id(project_id_list, user_id_list=user_id_list)
 
-    def drop_role_with_project_id(self, project_id_list: List[str], user_id_list: List[str]):
+    def drop_role_with_project_id(self, project_id_list: List[str], user_id_list: List[str]):  # noqa: ANN201
         for project_id in project_id_list:
             try:
                 if not self.facade.my_role_is_owner(project_id):

--- a/annofabcli/project_member/invite_project_members.py
+++ b/annofabcli/project_member/invite_project_members.py
@@ -20,7 +20,7 @@ class InviteProjectMemberMain:
         self.service = service
         self.facade = AnnofabApiFacade(service)
 
-    def invite_project_members(self, project_id: str, user_id_list: List[str], member_role: ProjectMemberRole):
+    def invite_project_members(self, project_id: str, user_id_list: List[str], member_role: ProjectMemberRole):  # noqa: ANN201
         """
         プロジェクトに、複数ユーザをプロジェクトメンバに追加する
 
@@ -34,7 +34,7 @@ class InviteProjectMemberMain:
         """
         dest_project_members = self.service.wrapper.get_all_project_members(project_id)
 
-        def get_project_member(user_id: str):
+        def get_project_member(user_id: str):  # noqa: ANN202
             return first_true(dest_project_members, pred=lambda e: e["user_id"] == user_id)
 
         project_title = self.facade.get_project_title(project_id)
@@ -61,12 +61,12 @@ class InviteProjectMemberMain:
                     f"{project_title}({project_id}) のプロジェクトメンバに、{user_id} を {member_role.value} ロールで追加できませんでした。"
                 )
 
-    def assign_role_with_organization(self, organization_name: str, user_id_list: List[str], member_role: ProjectMemberRole):
+    def assign_role_with_organization(self, organization_name: str, user_id_list: List[str], member_role: ProjectMemberRole):  # noqa: ANN201
         projects = self.service.wrapper.get_all_projects_of_organization(organization_name, query_params={"account_id": self.service.api.account_id})
         project_id_list = [e["project_id"] for e in projects]
         self.assign_role_with_project_id(project_id_list, user_id_list=user_id_list, member_role=member_role)
 
-    def assign_role_with_project_id(self, project_id_list: List[str], user_id_list: List[str], member_role: ProjectMemberRole):
+    def assign_role_with_project_id(self, project_id_list: List[str], user_id_list: List[str], member_role: ProjectMemberRole):  # noqa: ANN201
         for project_id in project_id_list:
             try:
                 if not self.facade.my_role_is_owner(project_id):

--- a/annofabcli/project_member/list_users.py
+++ b/annofabcli/project_member/list_users.py
@@ -34,7 +34,7 @@ class ListUser(AbstractCommandLineInterface):
         "sampling_acceptance_rate",
     ]
 
-    def get_all_project_members(self, project_id: str, include_inactive: bool = False):
+    def get_all_project_members(self, project_id: str, include_inactive: bool = False):  # noqa: ANN201
         query_params = {}
         if include_inactive:
             query_params.update({"include_inactive_member": ""})

--- a/annofabcli/project_member/put_project_members.py
+++ b/annofabcli/project_member/put_project_members.py
@@ -44,7 +44,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
     def member_exists(members: List[Dict[str, Any]], user_id: str) -> bool:
         return PutProjectMembers.find_member(members, user_id) is not None
 
-    def invite_project_member(self, project_id: str, member: Member, old_project_members: List[Dict[str, Any]]):
+    def invite_project_member(self, project_id: str, member: Member, old_project_members: List[Dict[str, Any]]):  # noqa: ANN201
         old_member = self.find_member(old_project_members, member.user_id)
         last_updated_datetime = old_member["updated_datetime"] if old_member is not None else None
 
@@ -58,7 +58,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
         updated_project_member = self.service.api.put_project_member(project_id, member.user_id, request_body=request_body)[0]
         return updated_project_member
 
-    def delete_project_member(self, project_id: str, deleted_member: Dict[str, Any]):
+    def delete_project_member(self, project_id: str, deleted_member: Dict[str, Any]):  # noqa: ANN201
         request_body = {
             "member_status": ProjectMemberStatus.INACTIVE.value,
             "member_role": deleted_member["member_role"],
@@ -67,7 +67,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
         updated_project_member = self.service.api.put_project_member(project_id, deleted_member["user_id"], request_body=request_body)[0]
         return updated_project_member
 
-    def put_project_members(self, project_id: str, members: List[Member], delete: bool = False):
+    def put_project_members(self, project_id: str, members: List[Member], delete: bool = False):  # noqa: ANN201
         """
         プロジェクトメンバを一括で登録する。
 
@@ -143,7 +143,7 @@ class PutProjectMembers(AbstractCommandLineInterface):
 
     @staticmethod
     def get_members_from_csv(csv_path: Path) -> List[Member]:
-        def create_member(e):  # noqa: ANN001
+        def create_member(e):  # noqa: ANN001, ANN202
             return Member(
                 user_id=e.user_id,
                 member_role=ProjectMemberRole(e.member_role),

--- a/annofabcli/stat_visualization/mask_visualization_dir.py
+++ b/annofabcli/stat_visualization/mask_visualization_dir.py
@@ -89,7 +89,7 @@ def create_replacement_dict(
     )
 
 
-def write_line_graph(task: Task, output_project_dir: ProjectDir, user_id_list: Optional[List[str]] = None, minimal_output: bool = False):
+def write_line_graph(task: Task, output_project_dir: ProjectDir, user_id_list: Optional[List[str]] = None, minimal_output: bool = False):  # noqa: ANN201
     output_project_dir.write_cumulative_line_graph(
         AnnotatorCumulativeProductivity.from_task(task),
         phase=TaskPhase.ANNOTATION,

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -48,14 +48,14 @@ class WritingVisualizationFile:
         self.minimal_output = minimal_output
 
     @_catch_exception
-    def write_user_performance(self, user_performance: UserPerformance):
+    def write_user_performance(self, user_performance: UserPerformance):  # noqa: ANN201
         """ユーザごとの生産性と品質に関するファイルを出力する。"""
         self.output_project_dir.write_user_performance(user_performance)
         # ユーザーごとの散布図を出力
         self.output_project_dir.write_user_performance_scatter_plot(user_performance)
 
     @_catch_exception
-    def write_whole_performance(self, whole_performance: WholePerformance):
+    def write_whole_performance(self, whole_performance: WholePerformance):  # noqa: ANN201
         """全体の生産性と品質に関するファイルを出力する。"""
         self.output_project_dir.write_whole_performance(whole_performance)
 
@@ -185,7 +185,7 @@ class MergingVisualizationFile:
         return merge_info
 
 
-def merge_visualization_dir(  # pylint: disable=too-many-statements
+def merge_visualization_dir(  # pylint: disable=too-many-statements  # noqa: ANN201
     project_dir_list: List[ProjectDir],
     output_project_dir: ProjectDir,
     user_id_list: Optional[List[str]] = None,

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -171,7 +171,7 @@ class CollectingPerformanceInfo:
 
         return ThresholdInfo(threshold_worktime=worktime, threshold_task_count=task_count)
 
-    def filter_df_with_threshold(self, df: pandas.DataFrame, phase: TaskPhase, project_title: str):
+    def filter_df_with_threshold(self, df: pandas.DataFrame, phase: TaskPhase, project_title: str):  # noqa: ANN201
         """
         引数`df`をインタンスとして持っている閾値情報でフィルタリングする。
         """
@@ -223,7 +223,7 @@ class CollectingPerformanceInfo:
 
         productivity_indicator = self.productivity_indicator_by_directory.get(project_title, self.productivity_indicator)
 
-        def _join_inspection():
+        def _join_inspection():  # noqa: ANN202
             phase = TaskPhase.INSPECTION
             if (self.productivity_indicator.value, phase.value) not in df_performance.columns:
                 return df
@@ -236,7 +236,7 @@ class CollectingPerformanceInfo:
 
             return df.join(df_tmp)
 
-        def _join_acceptance():
+        def _join_acceptance():  # noqa: ANN202
             phase = TaskPhase.ACCEPTANCE
             if (productivity_indicator.value, phase.value) not in df_performance.columns:
                 return df
@@ -341,7 +341,7 @@ class CollectingPerformanceInfo:
 def to_rank(series: pandas.Series) -> pandas.Series:
     quantile = list(series.quantile([0.25, 0.5, 0.75]))
 
-    def _to_point(value: float):
+    def _to_point(value: float):  # noqa: ANN202
         if numpy.isnan(value):
             return numpy.nan
         elif value < quantile[0]:
@@ -461,7 +461,7 @@ class WritingCsv:
         self.threshold_deviation_user_count = threshold_deviation_user_count
         self.user_ids = user_ids
 
-    def write(self, df: pandas.DataFrame, csv_basename: str, output_dir: Path):
+    def write(self, df: pandas.DataFrame, csv_basename: str, output_dir: Path):  # noqa: ANN201
         print_csv(df, str(output_dir / f"{csv_basename}__original.csv"))
 
         # 偏差値のCSVを出力

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -62,7 +62,7 @@ class LineGraph:
         width: int = 1200,
         height: int = 1000,
         tooltip_columns: Optional[list[str]] = None,
-        **figure_kwargs,
+        **figure_kwargs,  # noqa: ANN003
     ) -> None:
         fig = figure(
             title=title,
@@ -89,7 +89,7 @@ class LineGraph:
         self.marker_glyphs: dict[str, GlyphRenderer] = {}
         """key:凡例, value: 描画しているマーカー"""
 
-    def add_secondary_y_axis(
+    def add_secondary_y_axis(  # noqa: ANN201
         self,
         axis_label: str,
         *,
@@ -134,7 +134,7 @@ class LineGraph:
         legend_label: str,
         color: Optional[Any] = None,  # noqa: ANN401
         is_secondary_y_axis: bool = False,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> tuple[GlyphRenderer, GlyphRenderer]:
         """
         折れ線を追加する
@@ -177,7 +177,7 @@ class LineGraph:
         legend_label: str,
         color: Optional[Any] = None,  # noqa: ANN401
         is_secondary_y_axis: bool = False,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> tuple[GlyphRenderer, GlyphRenderer]:
         """
         移動平均用の折れ線を追加する
@@ -211,7 +211,7 @@ class LineGraph:
         """
         self.configure_legend()
 
-    def configure_legend(self):
+    def configure_legend(self):  # noqa: ANN201
         """
         凡例を設定します。
 

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -90,7 +90,7 @@ def encode_annotation_count_by_attribute(
     JSONへの変換用関数です。
     """
 
-    def _factory():
+    def _factory():  # noqa: ANN202
         """入れ子の辞書を利用できるようにするための関数"""
         return collections.defaultdict(_factory)
 
@@ -476,7 +476,7 @@ class AttributeCountCsv:
         value_columns = list(dict.fromkeys(value_columns).keys())
         return value_columns
 
-    def print_csv_by_task(
+    def print_csv_by_task(  # noqa: ANN201
         self,
         counter_list: list[AnnotationCounterByTask],
         output_file: Path,
@@ -514,7 +514,7 @@ class AttributeCountCsv:
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
-    def print_csv_by_input_data(
+    def print_csv_by_input_data(  # noqa: ANN201
         self,
         counter_list: list[AnnotationCounterByInputData],
         output_file: Path,
@@ -580,7 +580,7 @@ class LabelCountCsv:
 
         return value_columns
 
-    def print_csv_by_task(
+    def print_csv_by_task(  # noqa: ANN201
         self,
         counter_list: list[AnnotationCounterByTask],
         output_file: Path,
@@ -618,7 +618,7 @@ class LabelCountCsv:
         df.fillna(0, inplace=True)
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
-    def print_csv_by_input_data(
+    def print_csv_by_input_data(  # noqa: ANN201
         self,
         counter_list: list[AnnotationCounterByInputData],
         output_file: Path,
@@ -806,7 +806,7 @@ class ListAnnotationCountMain:
                 result[(task_id, input_data_id)] = index + 1
         return result
 
-    def print_annotation_counter_csv_by_input_data(
+    def print_annotation_counter_csv_by_input_data(  # noqa: ANN201
         self,
         annotation_path: Path,
         csv_type: CsvType,
@@ -848,7 +848,7 @@ class ListAnnotationCountMain:
 
             AttributeCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_attribute_columns=attribute_columns)
 
-    def print_annotation_counter_csv_by_task(
+    def print_annotation_counter_csv_by_task(  # noqa: ANN201
         self,
         annotation_path: Path,
         csv_type: CsvType,
@@ -887,7 +887,7 @@ class ListAnnotationCountMain:
 
             AttributeCountCsv().print_csv_by_task(counter_list_by_task, output_file, prior_attribute_columns=attribute_columns)
 
-    def print_annotation_counter_json_by_input_data(
+    def print_annotation_counter_json_by_input_data(  # noqa: ANN201
         self,
         annotation_path: Path,
         output_file: Path,
@@ -922,7 +922,7 @@ class ListAnnotationCountMain:
             output=output_file,
         )
 
-    def print_annotation_counter_json_by_task(
+    def print_annotation_counter_json_by_task(  # noqa: ANN201
         self,
         annotation_path: Path,
         output_file: Path,
@@ -955,7 +955,7 @@ class ListAnnotationCountMain:
             output=output_file,
         )
 
-    def print_annotation_counter(
+    def print_annotation_counter(  # noqa: ANN201
         self,
         annotation_path: Path,
         group_by: GroupBy,

--- a/annofabcli/statistics/list_worktime.py
+++ b/annofabcli/statistics/list_worktime.py
@@ -107,7 +107,7 @@ def get_df_worktime(task_history_event_list: list[WorktimeFromTaskHistoryEvent],
 
 
 class ListWorktimeFromTaskHistoryEvent(AbstractCommandLineInterface):
-    def print_worktime_list(
+    def print_worktime_list(  # noqa: ANN201
         self,
         project_id: str,
         task_history_event_json: Optional[Path],

--- a/annofabcli/statistics/scatter.py
+++ b/annofabcli/statistics/scatter.py
@@ -54,7 +54,7 @@ class ScatterGraph:
         width: int = 1200,
         height: int = 1000,
         tooltip_columns: Optional[list[str]] = None,
-        **figure_kwargs,
+        **figure_kwargs,  # noqa: ANN003
     ) -> None:
         fig = figure(
             title=title,
@@ -224,7 +224,7 @@ class ScatterGraph:
         if self._hover_tool is not None and self._scatter_glyphs is not None:
             self._hover_tool.renderers = list(self._scatter_glyphs.values())  # type: ignore[assignment]
 
-    def configure_legend(self):
+    def configure_legend(self):  # noqa: ANN201
         """
         凡例を設定します。
 

--- a/annofabcli/statistics/summarize_task_count_by_task_id_group.py
+++ b/annofabcli/statistics/summarize_task_count_by_task_id_group.py
@@ -111,7 +111,7 @@ def create_task_count_summary_df(
 
     """
 
-    def add_columns_if_not_exists(df: pandas.DataFrame, column: str):
+    def add_columns_if_not_exists(df: pandas.DataFrame, column: str):  # noqa: ANN202
         if column not in df.columns:
             df[column] = 0
 

--- a/annofabcli/statistics/summarize_task_count_by_user.py
+++ b/annofabcli/statistics/summarize_task_count_by_user.py
@@ -77,7 +77,7 @@ def create_task_count_summary_df(task_list: List[Task]) -> pandas.DataFrame:
 
     """
 
-    def add_columns_if_not_exists(df: pandas.DataFrame, column: str):
+    def add_columns_if_not_exists(df: pandas.DataFrame, column: str):  # noqa: ANN202
         if column not in df.columns:
             df[column] = 0
 

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -71,7 +71,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
 
         return True
 
-    def _plot(
+    def _plot(  # noqa: ANN202
         self,
         line_graph_list: list[LineGraph],
         columns_list: list[tuple[str, str]],
@@ -209,7 +209,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         df = df.drop(["task_count"], axis=1)
         return df
 
-    def plot_annotation_metrics(
+    def plot_annotation_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -276,7 +276,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         ]
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_input_data_metrics(
+    def plot_input_data_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -339,7 +339,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_task_metrics(
+    def plot_task_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -450,7 +450,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         return df
 
-    def plot_annotation_metrics(
+    def plot_annotation_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -504,7 +504,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_input_data_metrics(
+    def plot_input_data_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -552,7 +552,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_task_metrics(
+    def plot_task_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -641,7 +641,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         return df
 
-    def plot_annotation_metrics(
+    def plot_annotation_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -695,7 +695,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_input_data_metrics(
+    def plot_input_data_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -743,7 +743,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_task_metrics(
+    def plot_task_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,

--- a/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
@@ -79,7 +79,7 @@ class AbstractPhaseProductivityPerDate(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def to_csv(self, output_file: Path):
+    def to_csv(self, output_file: Path):  # noqa: ANN201
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -188,7 +188,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
 
         return df2
 
-    def plot_annotation_metrics(
+    def plot_annotation_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -322,7 +322,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
 
         self._plot(line_graph_list, output_file)
 
-    def plot_input_data_metrics(
+    def plot_input_data_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -562,7 +562,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
         )
         return df2
 
-    def plot_annotation_metrics(
+    def plot_annotation_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -670,7 +670,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
 
         self._plot(line_graph_list, output_file)
 
-    def plot_input_data_metrics(
+    def plot_input_data_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -885,7 +885,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
         )
         return df2
 
-    def plot_annotation_metrics(
+    def plot_annotation_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,
@@ -996,7 +996,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
 
         self._plot(line_graph_list, output_file)
 
-    def plot_input_data_metrics(
+    def plot_input_data_metrics(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,

--- a/annofabcli/statistics/visualization/dataframe/task.py
+++ b/annofabcli/statistics/visualization/dataframe/task.py
@@ -228,7 +228,7 @@ class Task:
         df_merged = pandas.concat(df_list)
         return Task(df_merged)
 
-    def plot_histogram_of_worktime(
+    def plot_histogram_of_worktime(  # noqa: ANN201
         self,
         output_file: Path,
         bins: int = 20,
@@ -306,7 +306,7 @@ class Task:
         bokeh.plotting.save(bokeh_obj)
         logger.debug(f"'{output_file}'を出力しました。")
 
-    def plot_histogram_of_others(
+    def plot_histogram_of_others(  # noqa: ANN201
         self,
         output_file: Path,
         bins: int = 20,

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -36,7 +36,7 @@ class WorktimeType(Enum):
     MONITORED = "monitored"
 
     @property
-    def worktime_type_name(self):
+    def worktime_type_name(self) -> str:
         if self.value == "actual":
             worktime_name = "実績時間"
         elif self.value == "monitored":
@@ -55,7 +55,7 @@ class PerformanceUnit(Enum):
     INPUT_DATA_COUNT = "input_data_count"
 
     @property
-    def performance_unit_name(self):
+    def performance_unit_name(self) -> str:
         if self.value == "annotation_count":
             performance_unit_name = "アノテーション"
         elif self.value == "input_data_count":

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -41,7 +41,7 @@ SECONDARY_Y_RANGE_RATIO = 1.05
 """
 
 
-def _plot_and_moving_average(
+def _plot_and_moving_average(  # noqa: ANN202
     line_graph: LineGraph,
     source: ColumnDataSource,
     x_column: str,
@@ -49,7 +49,7 @@ def _plot_and_moving_average(
     legend_name: str,
     color: str,
     is_secondary_y_axis: bool = False,
-    **kwargs,
+    **kwargs,  # noqa: ANN003
 ):
     """
     折れ線と1週間移動平均をプロットします。
@@ -220,11 +220,11 @@ class WholeProductivityPerCompletedDate:
         生産性情報などの列を追加する。
         """
 
-        def add_cumsum_column(df: pandas.DataFrame, column: str):
+        def add_cumsum_column(df: pandas.DataFrame, column: str):  # noqa: ANN202
             """累積情報の列を追加"""
             df[f"cumsum_{column}"] = df[column].cumsum()
 
-        def add_velocity_column(df: pandas.DataFrame, numerator_column: str, denominator_column: str):
+        def add_velocity_column(df: pandas.DataFrame, numerator_column: str, denominator_column: str):  # noqa: ANN202
             """速度情報の列を追加"""
             df[f"{numerator_column}/{denominator_column}"] = df[numerator_column] / df[denominator_column]
             # 1週間移動平均も出力
@@ -276,7 +276,7 @@ class WholeProductivityPerCompletedDate:
             sum_row.name = str_date
             return sum_row
 
-        def date_range():
+        def date_range():  # noqa: ANN202
             lower_date = min(df1["date"].min(), df2["date"].min())
             upper_date = max(df1["date"].max(), df2["date"].max())
             return pandas.date_range(start=lower_date, end=upper_date)
@@ -315,7 +315,7 @@ class WholeProductivityPerCompletedDate:
             """
         )
 
-    def plot(self, output_file: Path):
+    def plot(self, output_file: Path):  # noqa: ANN201
         """
         全体の生産量や生産性をプロットする
 
@@ -327,7 +327,7 @@ class WholeProductivityPerCompletedDate:
 
         """
 
-        def add_velocity_columns(df: pandas.DataFrame):
+        def add_velocity_columns(df: pandas.DataFrame):  # noqa: ANN202
             for denominator in ["input_data_count", "annotation_count"]:
                 for category in [
                     "actual",
@@ -876,7 +876,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         日毎の全体の生産量から、累計情報、生産性の列を追加する。
         """
 
-        def add_velocity_column(df: pandas.DataFrame, numerator_column: str, denominator_column: str):
+        def add_velocity_column(df: pandas.DataFrame, numerator_column: str, denominator_column: str):  # noqa: ANN202
             df[f"{numerator_column}/{denominator_column}"] = df[numerator_column] / df[denominator_column]
 
             df[f"{numerator_column}/{denominator_column}{WEEKLY_MOVING_AVERAGE_COLUMN_SUFFIX}"] = get_weekly_moving_average(
@@ -1004,7 +1004,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
             sum_row.name = str_date
             return sum_row
 
-        def date_range():
+        def date_range():  # noqa: ANN202
             lower_date = min(df1["first_annotation_started_date"].min(), df2["first_annotation_started_date"].min())
             upper_date = max(df1["first_annotation_started_date"].max(), df2["first_annotation_started_date"].max())
             return pandas.date_range(start=lower_date, end=upper_date)
@@ -1035,7 +1035,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         cls._add_velocity_columns(sum_df)
         return cls(sum_df)
 
-    def plot(self, output_file: Path):
+    def plot(self, output_file: Path):  # noqa: ANN201
         """
         全体の生産量や生産性をプロットする
         """

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -340,7 +340,7 @@ class WorktimePerDate:
 
         return df
 
-    def plot_cumulatively(
+    def plot_cumulatively(  # noqa: ANN201
         self,
         output_file: Path,
         target_user_id_list: Optional[list[str]] = None,

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -108,7 +108,7 @@ class ProjectDir(DataClassJsonMixin):
         obj.plot_histogram_of_worktime(self.project_dir / "histogram/ヒストグラム-作業時間.html")
         obj.plot_histogram_of_others(self.project_dir / "histogram/ヒストグラム.html")
 
-    def write_cumulative_line_graph(
+    def write_cumulative_line_graph(  # noqa: ANN201
         self,
         obj: AbstractPhaseCumulativeProductivity,
         phase: TaskPhase,
@@ -144,7 +144,7 @@ class ProjectDir(DataClassJsonMixin):
         phase_name = self.get_phase_name_for_filename(phase)
         obj.to_csv(self.project_dir / Path(f"{phase_name}者_{phase_name}開始日list.csv"))
 
-    def write_performance_line_graph_per_date(
+    def write_performance_line_graph_per_date(  # noqa: ANN201
         self, obj: AbstractPhaseProductivityPerDate, phase: TaskPhase, user_id_list: Optional[List[str]] = None
     ):
         """
@@ -202,13 +202,13 @@ class ProjectDir(DataClassJsonMixin):
             self.project_dir / self.FILENAME_WHOLE_PRODUCTIVITY_PER_FIRST_ANNOTATION_STARTED_DATE
         )
 
-    def write_whole_productivity_per_first_annotation_started_date(self, obj: WholeProductivityPerFirstAnnotationStartedDate):
+    def write_whole_productivity_per_first_annotation_started_date(self, obj: WholeProductivityPerFirstAnnotationStartedDate):  # noqa: ANN201
         """
         教師付開始日ごとの生産性と品質の情報を書き込みます。
         """
         obj.to_csv(self.project_dir / self.FILENAME_WHOLE_PRODUCTIVITY_PER_FIRST_ANNOTATION_STARTED_DATE)
 
-    def write_whole_productivity_line_graph_per_annotation_started_date(self, obj: WholeProductivityPerFirstAnnotationStartedDate):
+    def write_whole_productivity_line_graph_per_annotation_started_date(self, obj: WholeProductivityPerFirstAnnotationStartedDate):  # noqa: ANN201
         """
         横軸が教師付開始日、縦軸が全体の生産性などをプロットした折れ線グラフを出力します。
         """

--- a/annofabcli/statistics/visualization/visualization_source_files.py
+++ b/annofabcli/statistics/visualization/visualization_source_files.py
@@ -41,7 +41,7 @@ class VisualizationSourceFiles:
 
         self.logging_prefix = f"project_id='{project_id}'"
 
-    def download(self):
+    def download(self):  # noqa: ANN201
         pass
 
     def read_tasks_json(

--- a/annofabcli/statistics/visualize_annotation_count.py
+++ b/annofabcli/statistics/visualize_annotation_count.py
@@ -76,7 +76,7 @@ def _only_selective_attribute(columns: list[AttributeValueKey]) -> list[Attribut
     ]
 
 
-def plot_label_histogram(
+def plot_label_histogram(  # noqa: ANN201
     counter_list: Sequence[AnnotationCounter],
     group_by: GroupBy,
     output_file: Path,
@@ -138,7 +138,7 @@ def plot_label_histogram(
     logger.info(f"'{output_file}'を出力しました。")
 
 
-def plot_attribute_histogram(
+def plot_attribute_histogram(  # noqa: ANN201
     counter_list: Sequence[AnnotationCounter],
     group_by: GroupBy,
     output_file: Path,
@@ -206,7 +206,7 @@ class VisualizeAnnotationCount(AbstractCommandLineInterface):
 
         return True
 
-    def visualize_annotation_count(
+    def visualize_annotation_count(  # noqa: ANN201
         self,
         group_by: GroupBy,
         annotation_path: Path,

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -95,7 +95,7 @@ class WriteCsvGraph:
         Exceptionをキャッチしてログにstacktraceを出力する。
         """
 
-        def wrapped(*args, **kwargs):
+        def wrapped(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
             try:
                 return function(*args, **kwargs)
             except Exception:  # pylint: disable=broad-except
@@ -246,7 +246,7 @@ class WriteCsvGraph:
 
 
 class VisualizingStatisticsMain:
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         service: annofabapi.Resource,
         *,
@@ -297,7 +297,7 @@ class VisualizingStatisticsMain:
         )
         project_dir.write_project_info(project_summary)
 
-    def visualize_statistics(
+    def visualize_statistics(  # noqa: ANN201
         self,
         project_id: str,
         output_project_dir: Path,
@@ -439,7 +439,7 @@ class VisualizeStatistics(AbstractCommandLineInterface):
 
         return True
 
-    def visualize_statistics(
+    def visualize_statistics(  # noqa: ANN201, PLR0913
         self,
         temp_dir: Path,
         task_query: Optional[TaskQuery],

--- a/annofabcli/supplementary/delete_supplementary_data.py
+++ b/annofabcli/supplementary/delete_supplementary_data.py
@@ -122,7 +122,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
                 continue
         return deleted_count
 
-    def delete_supplementary_data_list(self, project_id: str, input_data_dict: InputDataSupplementaryDataDict):
+    def delete_supplementary_data_list(self, project_id: str, input_data_dict: InputDataSupplementaryDataDict):  # noqa: ANN201
         deleted_count = 0
         total_count = sum(len(e) for e in input_data_dict.values())
         for input_data_id, supplementary_data_id_list in input_data_dict.items():
@@ -169,7 +169,7 @@ class DeleteSupplementaryDataMain(AbstractCommandLineWithConfirmInterface):
 
         return deleted_count
 
-    def delete_supplementary_data_list_by_input_data_id(self, project_id: str, input_data_id_list: List[str]):
+    def delete_supplementary_data_list_by_input_data_id(self, project_id: str, input_data_id_list: List[str]):  # noqa: ANN201
         dict_deleted_count: Dict[str, int] = {}
         for input_data_id in input_data_id_list:
             input_data = self.service.wrapper.get_input_data_or_none(project_id, input_data_id)

--- a/annofabcli/supplementary/list_supplementary_data.py
+++ b/annofabcli/supplementary/list_supplementary_data.py
@@ -53,7 +53,7 @@ class ListSupplementaryData(AbstractCommandLineInterface):
         """
         if task_id_list is not None:
             input_data_id_list = self.get_input_data_id_from_task(project_id, task_id_list)
-        else:
+        else:  # noqa: PLR5501
             if input_data_id_list is None:
                 logger.warning("input_data_id_listとtask_id_listの両方がNoneです。")
                 return

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -76,7 +76,7 @@ class SubPutSupplementaryData:
         self.all_yes = all_yes
         self.supplementary_data_cache: Dict[str, List[SupplementaryData]] = {}
 
-    def put_supplementary_data(self, project_id: str, supplementary_data: SupplementaryDataForPut):
+    def put_supplementary_data(self, project_id: str, supplementary_data: SupplementaryDataForPut):  # noqa: ANN201
         file_path = get_file_scheme_path(supplementary_data.supplementary_data_path)
         if file_path is not None:
             request_body = {
@@ -279,7 +279,7 @@ class PutSupplementaryData(AbstractCommandLineInterface):
 
     @staticmethod
     def get_supplementary_data_list_from_csv(csv_path: Path) -> List[CsvSupplementaryData]:
-        def create_supplementary_data(e: Any):  # noqa: ANN401
+        def create_supplementary_data(e: Any):  # noqa: ANN202, ANN401
             supplementary_data_id = e.supplementary_data_id if not pandas.isna(e.supplementary_data_id) else None
             supplementary_data_type = e.supplementary_data_type if not pandas.isna(e.supplementary_data_type) else None
             return CsvSupplementaryData(

--- a/annofabcli/task/cancel_acceptance.py
+++ b/annofabcli/task/cancel_acceptance.py
@@ -138,7 +138,7 @@ class CancelAcceptanceMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"タスク'{task_id}'の受け入れ取り消しに失敗しました。", exc_info=True)
             return False
 
-    def cancel_acceptance_for_task_list(
+    def cancel_acceptance_for_task_list(  # noqa: ANN201
         self,
         task_id_list: List[str],
         acceptor: Optional[User] = None,

--- a/annofabcli/task/change_status_to_break.py
+++ b/annofabcli/task/change_status_to_break.py
@@ -92,7 +92,7 @@ class ChangeStatusToBreakMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"タスク'{task_id}'のステータスの変更に失敗しました。", exc_info=True)
             return False
 
-    def change_status_to_break(
+    def change_status_to_break(  # noqa: ANN201
         self,
         project_id: str,
         task_id_list: List[str],

--- a/annofabcli/task/change_status_to_on_hold.py
+++ b/annofabcli/task/change_status_to_on_hold.py
@@ -183,7 +183,7 @@ class ChangingStatusToOnHoldMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"タスク'{task_id}'のステータスの変更に失敗しました。", exc_info=True)
             return False
 
-    def change_status_to_on_hold(
+    def change_status_to_on_hold(  # noqa: ANN201
         self,
         task_id_list: list[str],
         *,

--- a/annofabcli/task/complete_tasks.py
+++ b/annofabcli/task/complete_tasks.py
@@ -74,7 +74,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
 
         return task_dict
 
-    def reply_inspection_comment(
+    def reply_inspection_comment(  # noqa: ANN201
         self,
         task: Task,
         input_data_id: str,
@@ -101,7 +101,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
 
         return self.service.api.batch_update_comments(task.project_id, task.task_id, input_data_id, request_body=request_body)[0]
 
-    def update_status_of_inspections(
+    def update_status_of_inspections(  # noqa: ANN201
         self,
         task: Task,
         input_data_id: str,
@@ -410,7 +410,7 @@ class CompleteTasksMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"タスク'{task_id}'のフェーズを完了状態にするのに失敗しました。", exc_info=True)
             return False
 
-    def complete_task_list(
+    def complete_task_list(  # noqa: ANN201
         self,
         project_id: str,
         task_id_list: List[str],

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -215,7 +215,7 @@ class DeleteTaskMain(AbstractCommandLineWithConfirmInterface):
         annotation_list = self.service.wrapper.get_all_annotation_list(self.project_id, query_params=query_params)
         return annotation_list
 
-    def delete_task_list(
+    def delete_task_list(  # noqa: ANN201
         self,
         task_id_list: List[str],
         task_query: Optional[TaskQuery] = None,

--- a/annofabcli/task/download_task_json.py
+++ b/annofabcli/task/download_task_json.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingTaskJson(AbstractCommandLineInterface):
-    def download_task_json(self, project_id: str, output_file: Path, is_latest: bool):
+    def download_task_json(self, project_id: str, output_file: Path, is_latest: bool):  # noqa: ANN201
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
         project_title = self.facade.get_project_title(project_id)
         logger.info(f"{project_title} のタスク全件ファイルをダウンロードします。")

--- a/annofabcli/task/list_all_tasks_added_task_history.py
+++ b/annofabcli/task/list_all_tasks_added_task_history.py
@@ -40,7 +40,7 @@ class ListAllTasksAddedTaskHistoryMain:
         self.downloading_obj = DownloadingFile(self.service)
         self.facade = AnnofabApiFacade(self.service)
 
-    def get_detail_task_list(
+    def get_detail_task_list(  # noqa: ANN201
         self,
         task_list: list[dict[str, Any]],
         task_history_dict: TaskHistoryDict,
@@ -113,7 +113,7 @@ class ListAllTasksAddedTaskHistoryMain:
         filtered_task_list = [e for e in task_list if self.match_task_with_conditions(e, task_query=task_query, task_id_set=task_id_set)]
         return filtered_task_list
 
-    def get_task_list_added_task_history(
+    def get_task_list_added_task_history(  # noqa: ANN201
         self,
         task_json_path: Optional[Path],
         task_history_json_path: Optional[Path],

--- a/annofabcli/task/list_tasks.py
+++ b/annofabcli/task/list_tasks.py
@@ -53,7 +53,7 @@ class ListTasksMain:
 
         """
 
-        def remove_key(arg_key: str):
+        def remove_key(arg_key: str):  # noqa: ANN202
             if arg_key in task_query:
                 logger.info(f"タスク検索クエリから、`{arg_key}`　キーを削除しました。")
                 task_query.pop(arg_key)

--- a/annofabcli/task/list_tasks_added_task_history.py
+++ b/annofabcli/task/list_tasks_added_task_history.py
@@ -227,7 +227,7 @@ class AddingAdditionalInfoToTask:
 
         return task
 
-    def add_additional_info_to_task(self, task: dict[str, Any]):
+    def add_additional_info_to_task(self, task: dict[str, Any]):  # noqa: ANN201
         """タスクの付加的情報を、タスクに追加する。
         以下の列を追加する。
         * user_id
@@ -244,7 +244,7 @@ class AddingAdditionalInfoToTask:
         # タスク情報から取得できる、付加的な情報を追加する
         self.visualize.add_properties_to_task(task)
 
-    def add_task_history_additional_info_to_task(self, task: dict[str, Any], task_histories: list[TaskHistory]):
+    def add_task_history_additional_info_to_task(self, task: dict[str, Any], task_histories: list[TaskHistory]):  # noqa: ANN201
         """タスク履歴から取得できる付加的情報を、タスクに追加する。
         以下の列を追加する。
         * annotation_worktime_hour
@@ -356,7 +356,7 @@ class TasksAddedTaskHistoryOutput:
 
         return base_columns + task_history_columns
 
-    def output(self, output_path: Path, output_format: FormatArgument):
+    def output(self, output_path: Path, output_format: FormatArgument):  # noqa: ANN201
         task_list = self.task_list
         if len(task_list) == 0:
             logger.info("タスク一覧の件数が0件のため、出力しません。")

--- a/annofabcli/task/put_tasks.py
+++ b/annofabcli/task/put_tasks.py
@@ -113,7 +113,7 @@ class PuttingTaskMain:
             logger.warning(f"タスク'{task_id}'の登録に失敗しました。", exc_info=True)
             return False
 
-    def put_task_list(self, task_relation_dict: TaskInputRelation):
+    def put_task_list(self, task_relation_dict: TaskInputRelation):  # noqa: ANN201
         logger.debug("'put_task' WebAPIを用いてタスクを生成します。")
         success_count = 0
         if self.parallelism is None:

--- a/annofabcli/task/reject_tasks.py
+++ b/annofabcli/task/reject_tasks.py
@@ -38,7 +38,7 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
         self.comment_data = comment_data
         AbstractCommandLineWithConfirmInterface.__init__(self, all_yes)
 
-    def add_inspection_comment(
+    def add_inspection_comment(  # noqa: ANN201
         self,
         project_id: str,
         task: dict[str, Any],
@@ -116,7 +116,7 @@ class RejectTasksMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"{task_id}: 担当者の変更、または作業中状態への変更に失敗しました。", exc_info=True)
             raise
 
-    def _can_reject_task(
+    def _can_reject_task(  # noqa: ANN202
         self,
         task: dict[str, Any],
         assign_last_annotator: bool,

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -87,7 +87,7 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
             logger.warning(f"タスク'{task_id}'のメタデータの更新に失敗しました。", exc_info=True)
             return False
 
-    def update_metadata_of_task(
+    def update_metadata_of_task(  # noqa: ANN201
         self,
         project_id: str,
         task_ids: Collection[str],
@@ -130,13 +130,13 @@ class UpdateMetadataOfTaskMain(AbstractCommandLineWithConfirmInterface):
 
             logger.info(f"{success_count} / {len(task_ids)} 件のタスクのmetadataを変更しました。")
 
-    def update_metadata_with_patch_tasks_metadata_api_wrapper(self, tpl: tuple[int, int, list[str]], project_id: str, metadata: Metadata):
+    def update_metadata_with_patch_tasks_metadata_api_wrapper(self, tpl: tuple[int, int, list[str]], project_id: str, metadata: Metadata):  # noqa: ANN201
         global_start_position, global_stop_position, task_id_list = tpl
         logger.debug(f"{global_start_position+1} 〜 {global_stop_position} 件目のタスクのmetadataを更新します。")
         request_body = {task_id: metadata for task_id in task_id_list}
         self.service.api.patch_tasks_metadata(project_id, request_body=request_body)
 
-    def update_metadata_with_patch_tasks_metadata_api(self, project_id: str, task_ids: Collection[str], metadata: Metadata):
+    def update_metadata_with_patch_tasks_metadata_api(self, project_id: str, task_ids: Collection[str], metadata: Metadata):  # noqa: ANN201
         """patch_tasks_metadata webapiを呼び出して、タスクのメタデータを更新します。
         注意：メタデータは上書きされます。
         """

--- a/annofabcli/task_history/download_task_history_json.py
+++ b/annofabcli/task_history/download_task_history_json.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingTaskHistory(AbstractCommandLineInterface):
-    def download_task_history_json(self, project_id: str, output_file: Path):
+    def download_task_history_json(self, project_id: str, output_file: Path):  # noqa: ANN201
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
         project_title = self.facade.get_project_title(project_id)
         logger.info(f"{project_title} のタスク履歴全件ファイルをダウンロードします。")

--- a/annofabcli/task_history/list_all_task_history.py
+++ b/annofabcli/task_history/list_all_task_history.py
@@ -77,7 +77,7 @@ class ListTaskHistoryWithJsonMain:
 
 
 class ListTaskHistoryWithJson(AbstractCommandLineInterface):
-    def print_task_history_list(
+    def print_task_history_list(  # noqa: ANN201
         self,
         project_id: str,
         task_history_json: Optional[Path],

--- a/annofabcli/task_history_event/download_task_history_event_json.py
+++ b/annofabcli/task_history_event/download_task_history_event_json.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class DownloadingTaskHistoryEvent(AbstractCommandLineInterface):
-    def download_task_history_event_json(self, project_id: str, output_file: Path):
+    def download_task_history_event_json(self, project_id: str, output_file: Path):  # noqa: ANN201
         super().validate_project(project_id, [ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
         project_title = self.facade.get_project_title(project_id)
         logger.info(f"{project_title} のタスク履歴イベント全件ファイルをダウンロードします。")

--- a/annofabcli/task_history_event/list_worktime.py
+++ b/annofabcli/task_history_event/list_worktime.py
@@ -220,7 +220,7 @@ class ListWorktimeFromTaskHistoryEventMain:
 
 
 class ListWorktimeFromTaskHistoryEvent(AbstractCommandLineInterface):
-    def print_worktime_from_task_history_event(
+    def print_worktime_from_task_history_event(  # noqa: ANN201
         self,
         project_id: str,
         task_history_event_json: Optional[Path],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,17 +130,17 @@ ignore = [
     "PLR2004", # magic-value-comparison: listのサイズで判定するときがよくあるため
     "ANN101", # missing-type-self: 引数selfには型ヒントは付けていないため
     "ANN102", # missing-type-cls: 引数clsには型ヒントは付けていないため
-    "ANN002", # missing-type-args
-    "ANN003", # missing-type-kwargs
+    # "ANN002", # missing-type-args
+    # "ANN003", # missing-type-kwargs
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
-    "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。またPython3.11以降ｈ
+    "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。
     "FIX", # TODOやFIXMEを使うため無視する
     "TD", # TODOコメントの書き方に気にしていないので無視する
 
     # いずれ無視しないようにする
-    "ANN201", # missing-return-type-public-function:
-    "ANN202", # missing-return-type-private-function:
-    "PLR",  # pylint Refactor
+    # "ANN201", # missing-return-type-public-function:
+    # "ANN202", # missing-return-type-private-function:
+    # "PLR",  # pylint Refactor
 
     # 以下のルールはannofabcliのコードに合っていないので無効化した
     "RSE", # flake8-raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,17 +130,10 @@ ignore = [
     "PLR2004", # magic-value-comparison: listのサイズで判定するときがよくあるため
     "ANN101", # missing-type-self: 引数selfには型ヒントは付けていないため
     "ANN102", # missing-type-cls: 引数clsには型ヒントは付けていないため
-    # "ANN002", # missing-type-args
-    # "ANN003", # missing-type-kwargs
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
     "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。
     "FIX", # TODOやFIXMEを使うため無視する
     "TD", # TODOコメントの書き方に気にしていないので無視する
-
-    # いずれ無視しないようにする
-    # "ANN201", # missing-return-type-public-function:
-    # "ANN202", # missing-return-type-private-function:
-    # "PLR",  # pylint Refactor
 
     # 以下のルールはannofabcliのコードに合っていないので無効化した
     "RSE", # flake8-raise

--- a/scripts/mask_user_info_for_all_visualization_dir.py
+++ b/scripts/mask_user_info_for_all_visualization_dir.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 
-def execute_mask_user_info_command(project_dir: Path, output_project_dir: Path, remainder_options: Optional[list[str]]):
+def execute_mask_user_info_command(project_dir: Path, output_project_dir: Path, remainder_options: Optional[list[str]]) -> None:
     command = [
         "annofabcli",
         "stat_visualization",

--- a/scripts/mask_user_info_for_rating_performance.py
+++ b/scripts/mask_user_info_for_rating_performance.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 
-def execute_mask_user_info_command(csv_path: Path, output_csv: Path, remainder_options: Optional[list[str]]):
+def execute_mask_user_info_command(csv_path: Path, output_csv: Path, remainder_options: Optional[list[str]]) -> None:
     command = [
         "annofabcli",
         "filesystem",


### PR DESCRIPTION
以前はpyproject.tomlで以下のルールを無視していました。

```
    "ANN002", # missing-type-args
    "ANN003", # missing-type-kwargs
    "ANN201", # missing-return-type-public-function:
    "ANN202", # missing-return-type-private-function:
    "PLR",  # pylint Refactor
```

少しずつこのルールに適用するために、pyproject.tomlでは無視しないようにして、`noqa`コメントを付与して無視するようにしました。
