### PR TITLE
`statistics list_annotation_duration` : コマンドを作成

### DIFF
--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -679,9 +679,7 @@ class AnnotationSpecs:
         if annotation_type is not None:
             labels_v2 = [e for e in labels_v2 if e["annotation_type"] == annotation_type]
 
-        self._labels_v1 = convert_annotation_specs_labels_v2_to_v1(
-            labels_v2=annotation_specs["labels"], additionals_v2=annotation_specs["additionals"]
-        )
+        self._labels_v1 = convert_annotation_specs_labels_v2_to_v1(labels_v2=labels_v2, additionals_v2=annotation_specs["additionals"])
 
     def label_keys(self) -> list[str]:
         """ラベル名（英語名）のキーの一覧"""

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -663,12 +663,22 @@ class LabelCountCsv:
 
 
 class AnnotationSpecs:
-    def __init__(self, service: annofabapi.Resource, project_id: str) -> None:
+    """
+
+    Args:
+        annotation_type: 出力対象のラベルの種類。
+
+    """
+    def __init__(self, service: annofabapi.Resource, project_id: str, *, annotation_type:Optional[str]=None) -> None:
         self.service = service
         self.project_id = project_id
 
         annotation_specs, _ = service.api.get_annotation_specs(project_id, query_params={"v": "2"})
         self._annotation_specs = annotation_specs
+
+        labels_v2 = annotation_specs["labels"]
+        if annotation_type is not None:
+            labels_v2 = [e for e in labels_v2 if e["annotation_type"] == annotation_type]
 
         self._labels_v1 = convert_annotation_specs_labels_v2_to_v1(
             labels_v2=annotation_specs["labels"], additionals_v2=annotation_specs["additionals"]

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -476,7 +476,7 @@ class AttributeCountCsv:
         value_columns = list(dict.fromkeys(value_columns).keys())
         return value_columns
 
-    def print_csv_by_task(  
+    def print_csv_by_task(
         self,
         counter_list: list[AnnotationCounterByTask],
         output_file: Path,
@@ -514,7 +514,7 @@ class AttributeCountCsv:
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
-    def print_csv_by_input_data(  
+    def print_csv_by_input_data(
         self,
         counter_list: list[AnnotationCounterByInputData],
         output_file: Path,
@@ -580,7 +580,7 @@ class LabelCountCsv:
 
         return value_columns
 
-    def print_csv_by_task( 
+    def print_csv_by_task(
         self,
         counter_list: list[AnnotationCounterByTask],
         output_file: Path,
@@ -618,7 +618,7 @@ class LabelCountCsv:
         df.fillna(0, inplace=True)
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
-    def print_csv_by_input_data(  
+    def print_csv_by_input_data(
         self,
         counter_list: list[AnnotationCounterByInputData],
         output_file: Path,
@@ -669,7 +669,8 @@ class AnnotationSpecs:
         annotation_type: 出力対象のラベルの種類。
 
     """
-    def __init__(self, service: annofabapi.Resource, project_id: str, *, annotation_type:Optional[str]=None) -> None:
+
+    def __init__(self, service: annofabapi.Resource, project_id: str, *, annotation_type: Optional[str] = None) -> None:
         self.service = service
         self.project_id = project_id
 
@@ -816,7 +817,7 @@ class ListAnnotationCountMain:
                 result[(task_id, input_data_id)] = index + 1
         return result
 
-    def print_annotation_counter_csv_by_input_data(  
+    def print_annotation_counter_csv_by_input_data(
         self,
         annotation_path: Path,
         csv_type: CsvType,
@@ -858,7 +859,7 @@ class ListAnnotationCountMain:
 
             AttributeCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_attribute_columns=attribute_columns)
 
-    def print_annotation_counter_csv_by_task(  
+    def print_annotation_counter_csv_by_task(
         self,
         annotation_path: Path,
         csv_type: CsvType,
@@ -897,7 +898,7 @@ class ListAnnotationCountMain:
 
             AttributeCountCsv().print_csv_by_task(counter_list_by_task, output_file, prior_attribute_columns=attribute_columns)
 
-    def print_annotation_counter_json_by_input_data( 
+    def print_annotation_counter_json_by_input_data(
         self,
         annotation_path: Path,
         output_file: Path,
@@ -932,7 +933,7 @@ class ListAnnotationCountMain:
             output=output_file,
         )
 
-    def print_annotation_counter_json_by_task(  
+    def print_annotation_counter_json_by_task(
         self,
         annotation_path: Path,
         output_file: Path,
@@ -951,7 +952,7 @@ class ListAnnotationCountMain:
         else:
             non_selective_attribute_name_keys = None
 
-        counter_list_by_input_data = ListAnnotationCounterByTask(
+        counter_list_by_task = ListAnnotationCounterByTask(
             non_target_attribute_names=non_selective_attribute_name_keys,
         ).get_annotation_counter_list(
             annotation_path,
@@ -960,12 +961,12 @@ class ListAnnotationCountMain:
         )
 
         print_json(
-            [e.to_dict(encode_json=True) for e in counter_list_by_input_data],
+            [e.to_dict(encode_json=True) for e in counter_list_by_task],
             is_pretty=json_is_pretty,
             output=output_file,
         )
 
-    def print_annotation_counter(  
+    def print_annotation_counter(
         self,
         annotation_path: Path,
         group_by: GroupBy,

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -278,10 +278,6 @@ class ListAnnotationCounterByInputData:
         """
         アノテーションzipまたはそれを展開したディレクトリから、ラベルごと/属性ごとのアノテーション数を集計情報を取得する。
 
-        Args:
-            simple_annotation: JSONファイルの内容
-
-
         """
 
         counter_list = []
@@ -376,12 +372,6 @@ class ListAnnotationCounterByTask:
     ) -> list[AnnotationCounterByTask]:
         """
         アノテーションzipまたはそれを展開したディレクトリから、ラベルごと/属性ごとのアノテーション数を集計情報を取得する。
-
-        Args:
-            simple_annotation: JSONファイルの内容
-            target_labels: 集計対象のラベル（label_name_en）
-            target_attributes: 集計対象の属性
-
 
         """
 

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -196,8 +196,17 @@ class ListAnnotationCounterByInputData:
         """
 
         def convert_attribute_value_to_key(value: Union[bool, str, float]) -> str:
+            """
+            アノテーションJSONに格納されている属性値を、dict用のkeyに変換する。
+
+            Notes:
+                アノテーションJSONに格納されている属性値の型はbool, str, floatの3つ
+
+            """
             if isinstance(value, bool):
-                # bool値をCSVの列名やJSONのキーとして扱う場合、`True/False`だとPythonに依存したように見えてしまうので（本当？）、`true/false`に変換する  # noqa: E501
+                # str関数で変換せずに、直接文字列を返している理由：
+                # bool値をstr関数に渡すと、`True/False`が返る。
+                # CSVの列名やJSONのキーとして扱う場合、`True/False`だとPythonに依存した表現に見えるので、`true/false`に変換する
                 if value:
                     return "true"
                 elif not value:
@@ -220,7 +229,6 @@ class ListAnnotationCounterByInputData:
         for detail in details:
             label = detail["label"]
             for attribute, value in detail["attributes"].items():
-                # 属性値を json.dumps関数で変換している理由： bool値の表現をJSONに合わせるため
                 attributes_list.append((label, attribute, convert_attribute_value_to_key(value)))
 
         annotation_count_by_attribute = collections.Counter(attributes_list)

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -476,12 +476,12 @@ class AttributeCountCsv:
         value_columns = list(dict.fromkeys(value_columns).keys())
         return value_columns
 
-    def print_csv_by_task(  # noqa: ANN201
+    def print_csv_by_task(  
         self,
         counter_list: list[AnnotationCounterByTask],
         output_file: Path,
         prior_attribute_columns: Optional[list[AttributeValueKey]] = None,
-    ):
+    ) -> None:
         def get_columns() -> list[AttributeValueKey]:
             basic_columns = [
                 ("task_id", "", ""),
@@ -514,12 +514,12 @@ class AttributeCountCsv:
 
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
-    def print_csv_by_input_data(  # noqa: ANN201
+    def print_csv_by_input_data(  
         self,
         counter_list: list[AnnotationCounterByInputData],
         output_file: Path,
         prior_attribute_columns: Optional[list[AttributeValueKey]] = None,
-    ):
+    ) -> None:
         def get_columns() -> list[AttributeValueKey]:
             basic_columns = [
                 ("task_id", "", ""),
@@ -580,12 +580,12 @@ class LabelCountCsv:
 
         return value_columns
 
-    def print_csv_by_task(  # noqa: ANN201
+    def print_csv_by_task( 
         self,
         counter_list: list[AnnotationCounterByTask],
         output_file: Path,
         prior_label_columns: Optional[list[str]] = None,
-    ):
+    ) -> None:
         def get_columns() -> list[str]:
             basic_columns = [
                 "task_id",
@@ -618,12 +618,12 @@ class LabelCountCsv:
         df.fillna(0, inplace=True)
         print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
 
-    def print_csv_by_input_data(  # noqa: ANN201
+    def print_csv_by_input_data(  
         self,
         counter_list: list[AnnotationCounterByInputData],
         output_file: Path,
         prior_label_columns: Optional[list[str]] = None,
-    ):
+    ) -> None:
         def get_columns() -> list[str]:
             basic_columns = [
                 "task_id",
@@ -816,7 +816,7 @@ class ListAnnotationCountMain:
                 result[(task_id, input_data_id)] = index + 1
         return result
 
-    def print_annotation_counter_csv_by_input_data(  # noqa: ANN201
+    def print_annotation_counter_csv_by_input_data(  
         self,
         annotation_path: Path,
         csv_type: CsvType,
@@ -826,7 +826,7 @@ class ListAnnotationCountMain:
         task_json_path: Optional[Path] = None,
         target_task_ids: Optional[Collection[str]] = None,
         task_query: Optional[TaskQuery] = None,
-    ):
+    ) -> None:
         # アノテーション仕様の非選択系の属性は、集計しないようにする。集計しても意味がないため。
         annotation_specs: Optional[AnnotationSpecs] = None
         non_selective_attribute_name_keys: Optional[list[AttributeNameKey]] = None
@@ -858,7 +858,7 @@ class ListAnnotationCountMain:
 
             AttributeCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_attribute_columns=attribute_columns)
 
-    def print_annotation_counter_csv_by_task(  # noqa: ANN201
+    def print_annotation_counter_csv_by_task(  
         self,
         annotation_path: Path,
         csv_type: CsvType,
@@ -867,7 +867,7 @@ class ListAnnotationCountMain:
         project_id: Optional[str] = None,
         target_task_ids: Optional[Collection[str]] = None,
         task_query: Optional[TaskQuery] = None,
-    ):
+    ) -> None:
         # アノテーション仕様の非選択系の属性は、集計しないようにする。集計しても意味がないため。
         annotation_specs: Optional[AnnotationSpecs] = None
         non_selective_attribute_name_keys: Optional[list[AttributeNameKey]] = None
@@ -897,7 +897,7 @@ class ListAnnotationCountMain:
 
             AttributeCountCsv().print_csv_by_task(counter_list_by_task, output_file, prior_attribute_columns=attribute_columns)
 
-    def print_annotation_counter_json_by_input_data(  # noqa: ANN201
+    def print_annotation_counter_json_by_input_data( 
         self,
         annotation_path: Path,
         output_file: Path,
@@ -907,7 +907,7 @@ class ListAnnotationCountMain:
         target_task_ids: Optional[Collection[str]] = None,
         task_query: Optional[TaskQuery] = None,
         json_is_pretty: bool = False,
-    ):
+    ) -> None:
         """ラベルごと/属性ごとのアノテーション数を入力データ単位でJSONファイルに出力します。"""
 
         # アノテーション仕様の非選択系の属性は、集計しないようにする。集計しても意味がないため。
@@ -932,7 +932,7 @@ class ListAnnotationCountMain:
             output=output_file,
         )
 
-    def print_annotation_counter_json_by_task(  # noqa: ANN201
+    def print_annotation_counter_json_by_task(  
         self,
         annotation_path: Path,
         output_file: Path,
@@ -941,7 +941,7 @@ class ListAnnotationCountMain:
         target_task_ids: Optional[Collection[str]] = None,
         task_query: Optional[TaskQuery] = None,
         json_is_pretty: bool = False,
-    ):
+    ) -> None:
         """ラベルごと/属性ごとのアノテーション数をタスク単位でJSONファイルに出力します。"""
 
         # アノテーション仕様の非選択系の属性は、集計しないようにする。集計しても意味がないため。
@@ -965,7 +965,7 @@ class ListAnnotationCountMain:
             output=output_file,
         )
 
-    def print_annotation_counter(  # noqa: ANN201
+    def print_annotation_counter(  
         self,
         annotation_path: Path,
         group_by: GroupBy,
@@ -977,7 +977,7 @@ class ListAnnotationCountMain:
         target_task_ids: Optional[Collection[str]] = None,
         task_query: Optional[TaskQuery] = None,
         csv_type: Optional[CsvType] = None,
-    ):
+    ) -> None:
         """ラベルごと/属性ごとのアノテーション数を出力します。"""
         if arg_format == FormatArgument.CSV:
             assert csv_type is not None

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -17,7 +17,7 @@ from typing import Any, Collection, Iterator, Optional, Tuple, Union
 
 import annofabapi
 import pandas
-from annofabapi.models import ProjectMemberRole, TaskPhase, TaskStatus
+from annofabapi.models import InputDataType, ProjectMemberRole, TaskPhase, TaskStatus
 from annofabapi.parser import (
     SimpleAnnotationParser,
     lazy_parse_simple_annotation_dir,
@@ -550,6 +550,11 @@ class ListAnnotationDuration(AbstractCommandLineInterface):
         project_id: Optional[str] = args.project_id
         if project_id is not None:
             super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
+            project, _ = self.service.api.get_project(project_id)
+            if project["input_data_type"] != InputDataType.MOVIE:
+                logger.warning(
+                    f"project_id='{project_id}'であるプロジェクトは、動画プロジェクトでないので、出力されれる区間アノテーションの長さはすべて0秒になります。"
+                )
 
         annotation_path = Path(args.annotation) if args.annotation is not None else None
 

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -1,0 +1,904 @@
+# pylint: disable=too-many-lines
+from __future__ import annotations
+
+import argparse
+import collections
+import copy
+import json
+import logging
+import sys
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import partial
+from pathlib import Path
+from typing import Any, Collection, Counter, Optional, Tuple, Union
+
+import annofabapi
+import pandas
+from annofabapi.models import ProjectMemberRole, TaskPhase, TaskStatus
+from annofabapi.parser import (
+    SimpleAnnotationParserByTask,
+)
+from dataclasses_json import DataClassJsonMixin, config
+
+import annofabcli
+import annofabcli.common.cli
+from annofabcli.common.cli import (
+    COMMAND_LINE_ERROR_STATUS_CODE,
+    AbstractCommandLineInterface,
+    ArgumentParser,
+    build_annofabapi_resource_and_login,
+)
+from annofabcli.common.download import DownloadingFile
+from annofabcli.common.enums import FormatArgument
+from annofabcli.common.facade import (
+    AnnofabApiFacade,
+    TaskQuery,
+    match_annotation_with_task_query,
+)
+from annofabcli.common.utils import print_csv, print_json
+
+logger = logging.getLogger(__name__)
+
+AttributeValueKey = Tuple[str, str, str]
+"""
+属性のキー.
+tuple[label_name_en, attribute_name_en, attribute_value] で表す。
+"""
+
+LabelKeys = Collection[str]
+
+AttributeNameKey = Tuple[str, str]
+"""
+属性名のキー.
+tuple[label_name_en, attribute_name_en] で表す。
+"""
+
+
+AttributeKeys = Collection[Collection]
+
+
+class CsvType(Enum):
+    """出力するCSVの種類"""
+
+    LABEL = "label"
+    """ラベルごとのアノテーション数を出力"""
+    ATTRIBUTE = "attribute"
+    """属性値ごとのアノテーション数を出力"""
+
+
+def encode_annotation_duration_second_by_attribute(
+    annotation_duration_second_by_attribute: Counter[AttributeValueKey],
+) -> dict[str, dict[str, dict[str, int]]]:
+    """annotation_duration_second_by_attributeを `{label_name: {attribute_name: {attribute_value: annotation_count}}}`のdictに変換します。
+    JSONへの変換用関数です。
+    """
+
+    def _factory() -> collections.defaultdict:
+        """入れ子の辞書を利用できるようにするための関数"""
+        return collections.defaultdict(_factory)
+
+    result: dict[str, dict[str, dict[str, int]]] = defaultdict(_factory)
+    for (label_name, attribute_name, attribute_value), annotation_duration_second in annotation_duration_second_by_attribute.items():
+        result[label_name][attribute_name][attribute_value] = annotation_duration_second
+    return result
+
+
+@dataclass(frozen=True)
+class AnnotationDuration(DataClassJsonMixin):
+    """
+    入力データまたはタスク単位の区間アノテーションの長さ情報。
+    """
+
+    task_id: str
+    status: TaskStatus
+    phase: TaskPhase
+    phase_stage: int
+
+    input_data_id: str
+    input_data_name: str
+
+    annotation_duration_second: int
+    """区間アノテーションの合計の長さ（秒）"""
+    annotation_duration_second_by_label: dict[str, float]
+    """
+    ラベルごとの区間アノテーションの長さ（秒）
+    key: ラベル名（英語）, value: 区間アノテーションの合計の長さ（秒）
+    """
+    annotation_duration_second_by_attribute: dict[AttributeValueKey, float] = field(
+        metadata=config(
+            encoder=encode_annotation_duration_second_by_attribute,
+        )
+    )
+    """属性値ごとの区間アノテーションの長さ（秒）
+    key: tuple[ラベル名(英語),属性名(英語),属性値(英語)], value: 区間アノテーションの合計の長さ（秒）
+    """
+
+
+class ListAnnotationCounterByInputData:
+    """入力データ単位で、ラベルごと/属性ごとのアノテーション数を集計情報を取得するメソッドの集まり。
+
+    Args:
+        target_labels: 集計対象のラベル（label_name_en）
+        target_attribute_names: 集計対象の属性名
+        non_target_labels: 集計対象外のラベル
+        non_target_attribute_names: 集計対象外の属性名のキー。
+        frame_no_map: key:task_id,input_data_idのtuple, value:フレーム番号
+
+    """
+
+    def __init__(
+        self,
+        *,
+        target_labels: Optional[Collection[str]] = None,
+        non_target_labels: Optional[Collection[str]] = None,
+        target_attribute_names: Optional[Collection[AttributeNameKey]] = None,
+        non_target_attribute_names: Optional[Collection[AttributeNameKey]] = None,
+        frame_no_map: Optional[dict[tuple[str, str], int]] = None,
+    ) -> None:
+        self.target_labels = set(target_labels) if target_labels is not None else None
+        self.target_attribute_names = set(target_attribute_names) if target_attribute_names is not None else None
+        self.non_target_labels = set(non_target_labels) if non_target_labels is not None else None
+        self.non_target_attribute_names = set(non_target_attribute_names) if non_target_attribute_names is not None else None
+        self.frame_no_map = frame_no_map
+
+    def get_annotation_duration(
+        self,
+        simple_annotation: dict[str, Any],
+    ) -> AnnotationDuration:
+        """
+        1個のアノテーションJSONに対して、ラベルごと/属性ごとの区間アノテーションの長さを取得する。
+
+        Args:
+            simple_annotation: アノテーションJSONファイルの内容
+        """
+
+        def calculate_annotation_duration_second(detail: dict[str, Any]) -> float:
+            """区間アノテーションのdetail情報から、区間アノテーションの長さ（秒）を計算する"""
+            return (detail["data"]["end"] - detail["data"]["start"]) / 1000
+
+        def convert_attribute_value_to_key(value: Union[bool, str, float]) -> str:
+            if isinstance(value, bool):
+                # bool値をCSVの列名やJSONのキーとして扱う場合、`True/False`だとPythonに依存したように見えてしまうので（本当？）、`true/false`に変換する  # noqa: E501
+                if value:
+                    return "true"
+                elif not value:
+                    return "false"
+            return str(value)
+
+        # 区間アノテーションのみのdetails
+        # TODO type文字列の定義をannofab-apiに定義する
+        range_details = [e for e in simple_annotation["details"] if e["type"]["_type"] == "Range"]
+
+        annotation_duration_by_label = defaultdict(float)
+        for detail in range_details:
+            annotation_duration_by_label[detail["label"]] += calculate_annotation_duration_second(detail)
+
+        if self.target_labels is not None:
+            annotation_duration_by_label = {
+                label: duration for label, duration in annotation_duration_by_label.items() if label in self.target_labels
+            }
+
+        if self.non_target_labels is not None:
+            annotation_duration_by_label = {
+                label: duration for label, duration in annotation_duration_by_label.items() if label not in self.non_target_labels
+            }
+
+        attributes_list: list[AttributeValueKey] = []
+        for detail in range_details:
+            label = detail["label"]
+            for attribute, value in detail["attributes"].items():
+                # 属性値を json.dumps関数で変換している理由： bool値の表現をJSONに合わせるため
+                attributes_list.append((label, attribute, convert_attribute_value_to_key(value)))
+
+        annotation_count_by_attribute = collections.Counter(attributes_list)
+        if self.target_attribute_names is not None:
+            annotation_count_by_attribute = collections.Counter(
+                {
+                    (label, attribute_name, attribute_value): count
+                    for (label, attribute_name, attribute_value), count in annotation_count_by_attribute.items()
+                    if (label, attribute_name) in self.target_attribute_names
+                }
+            )
+        if self.non_target_attribute_names is not None:
+            annotation_count_by_attribute = collections.Counter(
+                {
+                    (label, attribute_name, attribute_value): count
+                    for (label, attribute_name, attribute_value), count in annotation_count_by_attribute.items()
+                    if (label, attribute_name) not in self.non_target_attribute_names
+                }
+            )
+
+        task_id = simple_annotation["task_id"]
+        input_data_id = simple_annotation["input_data_id"]
+
+        return AnnotationDuration(
+            task_id=simple_annotation["task_id"],
+            phase=TaskPhase(simple_annotation["task_phase"]),
+            phase_stage=simple_annotation["task_phase_stage"],
+            status=TaskStatus(simple_annotation["task_status"]),
+            input_data_id=simple_annotation["input_data_id"],
+            input_data_name=simple_annotation["input_data_name"],
+            annotation_count=sum(annotation_count_by_label.values()),
+            annotation_duration_by_label=annotation_duration_by_label,
+            annotation_count_by_attribute=annotation_count_by_attribute,
+        )
+
+    def get_annotation_counter_list(
+        self,
+        annotation_path: Path,
+        *,
+        target_task_ids: Optional[Collection[str]] = None,
+        task_query: Optional[TaskQuery] = None,
+    ) -> list[AnnotationCounterByInputData]:
+        """
+        アノテーションzipまたはそれを展開したディレクトリから、ラベルごと/属性ごとのアノテーション数を集計情報を取得する。
+
+        Args:
+            simple_annotation: JSONファイルの内容
+
+
+        """
+
+        counter_list = []
+
+        target_task_ids = set(target_task_ids) if target_task_ids is not None else None
+
+        iter_parser = lazy_parse_simple_annotation_by_input_data(annotation_path)
+
+        logger.debug("アノテーションzip/ディレクトリを読み込み中")
+        for index, parser in enumerate(iter_parser):
+            if (index + 1) % 1000 == 0:
+                logger.debug(f"{index+1}  件目のJSONを読み込み中")
+
+            if target_task_ids is not None and parser.task_id not in target_task_ids:
+                continue
+
+            simple_annotation_dict = parser.load_json()
+            if task_query is not None:
+                if not match_annotation_with_task_query(simple_annotation_dict, task_query):
+                    continue
+
+            input_data_counter = self.get_annotation_counter(simple_annotation_dict)
+            counter_list.append(input_data_counter)
+
+        return counter_list
+
+
+class ListAnnotationCounterByTask:
+    """タスク単位で、ラベルごと/属性ごとのアノテーション数を集計情報を取得するメソッドの集まり。"""
+
+    def __init__(
+        self,
+        *,
+        target_labels: Optional[Collection[str]] = None,
+        non_target_labels: Optional[Collection[str]] = None,
+        target_attribute_names: Optional[Collection[AttributeNameKey]] = None,
+        non_target_attribute_names: Optional[Collection[AttributeNameKey]] = None,
+    ) -> None:
+        self.counter_by_input_data = ListAnnotationCounterByInputData(
+            target_labels=target_labels,
+            non_target_labels=non_target_labels,
+            target_attribute_names=target_attribute_names,
+            non_target_attribute_names=non_target_attribute_names,
+        )
+
+    def get_annotation_counter(self, task_parser: SimpleAnnotationParserByTask) -> AnnotationCounterByTask:
+        """
+        1個のタスクに対して、ラベルごと/属性ごとのアノテーション数を集計情報を取得する。
+
+        Args:
+            simple_annotation: JSONファイルの内容
+            target_labels: 集計対象のラベル（label_name_en）
+            target_attributes: 集計対象の属性
+
+
+        """
+
+        annotation_count_by_label: Counter[str] = collections.Counter()
+        annotation_count_by_attribute: Counter[Tuple[str, str, str]] = collections.Counter()
+
+        last_simple_annotation = None
+        input_data_count = 0
+        for parser in task_parser.lazy_parse():
+            # parse()メソッドは遅いので、使わない
+            simple_annotation_dict = parser.load_json()
+            input_data = self.counter_by_input_data.get_annotation_counter(simple_annotation_dict)
+            annotation_count_by_label += input_data.annotation_count_by_label
+            annotation_count_by_attribute += input_data.annotation_count_by_attribute
+            last_simple_annotation = simple_annotation_dict
+            input_data_count += 1
+
+        if last_simple_annotation is None:
+            raise RuntimeError(f"{task_parser.task_id} ディレクトリにはjsonファイルが1つも含まれていません。")
+
+        return AnnotationCounterByTask(
+            task_id=last_simple_annotation["task_id"],
+            status=TaskStatus(last_simple_annotation["task_status"]),
+            phase=TaskPhase(last_simple_annotation["task_phase"]),
+            phase_stage=last_simple_annotation["task_phase_stage"],
+            input_data_count=input_data_count,
+            annotation_count=sum(annotation_count_by_label.values()),
+            annotation_count_by_label=annotation_count_by_label,
+            annotation_count_by_attribute=annotation_count_by_attribute,
+        )
+
+    def get_annotation_counter_list(
+        self,
+        annotation_path: Path,
+        *,
+        target_task_ids: Optional[Collection[str]] = None,
+        task_query: Optional[TaskQuery] = None,
+    ) -> list[AnnotationCounterByTask]:
+        """
+        アノテーションzipまたはそれを展開したディレクトリから、ラベルごと/属性ごとのアノテーション数を集計情報を取得する。
+
+        Args:
+            simple_annotation: JSONファイルの内容
+            target_labels: 集計対象のラベル（label_name_en）
+            target_attributes: 集計対象の属性
+
+
+        """
+
+        counter_list = []
+        iter_task_parser = lazy_parse_simple_annotation_by_task(annotation_path)
+
+        target_task_ids = set(target_task_ids) if target_task_ids is not None else None
+
+        logger.debug("アノテーションzip/ディレクトリを読み込み中")
+        for task_index, task_parser in enumerate(iter_task_parser):
+            if (task_index + 1) % 1000 == 0:
+                logger.debug(f"{task_index+1}  件目のタスクディレクトリを読み込み中")
+
+            if target_task_ids is not None and task_parser.task_id not in target_task_ids:
+                continue
+
+            if task_query is not None:
+                json_file_path_list = task_parser.json_file_path_list
+                if len(json_file_path_list) == 0:
+                    continue
+
+                input_data_parser = task_parser.get_parser(json_file_path_list[0])
+                dict_simple_annotation = input_data_parser.load_json()
+                if not match_annotation_with_task_query(dict_simple_annotation, task_query):
+                    continue
+
+            task_counter = self.get_annotation_counter(task_parser)
+            counter_list.append(task_counter)
+
+        return counter_list
+
+
+class AttributeCountCsv:
+    """
+    属性値ごとのアノテーション数を記載するCSV。
+
+    Args:
+        selective_attribute_value_max_count: 選択肢系の属性の値の個数の上限。これを超えた場合は、非選択肢系属性（トラッキングIDやアノテーションリンクなど）とみなす
+
+    """  # noqa: E501
+
+    def __init__(self, selective_attribute_value_max_count: int = 20, csv_format: Optional[dict[str, Any]] = None) -> None:
+        self.csv_format = csv_format
+        self.selective_attribute_value_max_count = selective_attribute_value_max_count
+
+    def _only_selective_attribute(self, columns: list[AttributeValueKey]) -> list[AttributeValueKey]:
+        """
+        選択肢系の属性に対応する列のみ抽出する。
+        属性値の個数が多い場合、非選択肢系の属性（トラッキングIDやアノテーションリンクなど）の可能性があるため、それらを除外する。
+        CSVの列数を増やしすぎないための対策。
+        """
+        attribute_name_list: list[AttributeNameKey] = []
+        for label, attribute_name, _ in columns:
+            attribute_name_list.append((label, attribute_name))
+
+        non_selective_attribute_names = {
+            key for key, value in collections.Counter(attribute_name_list).items() if value > self.selective_attribute_value_max_count
+        }
+        if len(non_selective_attribute_names) > 0:
+            logger.debug(
+                f"以下の属性は値の個数が{self.selective_attribute_value_max_count}を超えていたため、集計しません。 :: "
+                f"{non_selective_attribute_names}"
+            )
+
+        return [
+            (label, attribute_name, attribute_value)
+            for (label, attribute_name, attribute_value) in columns
+            if (label, attribute_name) not in non_selective_attribute_names
+        ]
+
+    def _value_columns(
+        self, counter_list: Collection[AnnotationCounter], prior_attribute_columns: Optional[list[AttributeValueKey]]
+    ) -> list[AttributeValueKey]:
+        all_attr_key_set = {attr_key for c in counter_list for attr_key in c.annotation_count_by_attribute}
+        if prior_attribute_columns is not None:
+            remaining_columns = sorted(all_attr_key_set - set(prior_attribute_columns))
+            remaining_columns_only_selective_attribute = self._only_selective_attribute(remaining_columns)
+
+            # `remaining_columns_only_selective_attribute`には、属性値が空である列などが格納されている
+            # `remaining_columns_only_selective_attribute`を、`value_columns`の関連している位置に挿入する。
+            value_columns = copy.deepcopy(prior_attribute_columns)
+            for remaining_column in remaining_columns_only_selective_attribute:
+                is_inserted = False
+                for i in range(len(value_columns) - 1, -1, -1):
+                    col = value_columns[i]
+                    if col[0:2] == remaining_column[0:2]:
+                        value_columns.insert(i + 1, remaining_column)
+                        is_inserted = True
+                        break
+                if not is_inserted:
+                    value_columns.append(remaining_column)
+
+            assert len(value_columns) == len(prior_attribute_columns) + len(remaining_columns_only_selective_attribute)
+
+        else:
+            remaining_columns = sorted(all_attr_key_set)
+            value_columns = self._only_selective_attribute(remaining_columns)
+
+        # 重複している場合は、重複要素を取り除く。ただし元の順番は維持する
+        value_columns = list(dict.fromkeys(value_columns).keys())
+        return value_columns
+
+    def print_csv_by_task(  # noqa: ANN201
+        self,
+        counter_list: list[AnnotationCounterByTask],
+        output_file: Path,
+        prior_attribute_columns: Optional[list[AttributeValueKey]] = None,
+    ):
+        def get_columns() -> list[AttributeValueKey]:
+            basic_columns = [
+                ("task_id", "", ""),
+                ("status", "", ""),
+                ("phase", "", ""),
+                ("phase_stage", "", ""),
+                ("input_data_count", "", ""),
+                ("annotation_count", "", ""),
+            ]
+            value_columns = self._value_columns(counter_list, prior_attribute_columns)
+            return basic_columns + value_columns
+
+        def to_cell(c: AnnotationCounterByTask) -> dict[AttributeValueKey, Any]:
+            cell = {
+                ("task_id", "", ""): c.task_id,
+                ("status", "", ""): c.status.value,
+                ("phase", "", ""): c.phase.value,
+                ("phase_stage", "", ""): c.phase_stage,
+                ("input_data_count", "", ""): c.input_data_count,
+                ("annotation_count", "", ""): c.annotation_count,
+            }
+            cell.update(c.annotation_count_by_attribute)
+            return cell
+
+        columns = get_columns()
+        df = pandas.DataFrame([to_cell(e) for e in counter_list], columns=pandas.MultiIndex.from_tuples(columns))
+
+        # `task_id`列など`basic_columns`も`fillna`対象だが、nanではないはずので問題ない
+        df.fillna(0, inplace=True)
+
+        print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
+
+    def print_csv_by_input_data(  # noqa: ANN201
+        self,
+        counter_list: list[AnnotationCounterByInputData],
+        output_file: Path,
+        prior_attribute_columns: Optional[list[AttributeValueKey]] = None,
+    ):
+        def get_columns() -> list[AttributeValueKey]:
+            basic_columns = [
+                ("task_id", "", ""),
+                ("status", "", ""),
+                ("phase", "", ""),
+                ("phase_stage", "", ""),
+                ("input_data_id", "", ""),
+                ("input_data_name", "", ""),
+                ("frame_no", "", ""),
+                ("annotation_count", "", ""),
+            ]
+            value_columns = self._value_columns(counter_list, prior_attribute_columns)
+            return basic_columns + value_columns
+
+        def to_cell(c: AnnotationCounterByInputData) -> dict[tuple[str, str, str], Any]:
+            cell = {
+                ("input_data_id", "", ""): c.input_data_id,
+                ("input_data_name", "", ""): c.input_data_name,
+                ("frame_no", "", ""): c.frame_no,
+                ("task_id", "", ""): c.task_id,
+                ("status", "", ""): c.status.value,
+                ("phase", "", ""): c.phase.value,
+                ("phase_stage", "", ""): c.phase_stage,
+                ("annotation_count", "", ""): c.annotation_count,
+            }
+            cell.update(c.annotation_count_by_attribute)
+
+            return cell
+
+        columns = get_columns()
+        df = pandas.DataFrame([to_cell(e) for e in counter_list], columns=pandas.MultiIndex.from_tuples(columns))
+
+        # アノテーション数の列のNaNを0に変換する
+        value_columns = self._value_columns(counter_list, prior_attribute_columns)
+        df = df.fillna({column: 0 for column in value_columns})
+
+        print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
+
+
+class LabelCountCsv:
+    """
+    ラベルごとのアノテーション数を記載するCSV。
+
+
+    """
+
+    def __init__(self, csv_format: Optional[dict[str, Any]] = None) -> None:
+        self.csv_format = csv_format
+
+    def _value_columns(self, counter_list: Collection[AnnotationCounter], prior_label_columns: Optional[list[str]]) -> list[str]:
+        all_attr_key_set = {attr_key for c in counter_list for attr_key in c.annotation_count_by_label}
+        if prior_label_columns is not None:
+            remaining_columns = sorted(all_attr_key_set - set(prior_label_columns))
+            value_columns = prior_label_columns + remaining_columns
+        else:
+            remaining_columns = sorted(all_attr_key_set)
+            value_columns = remaining_columns
+
+        return value_columns
+
+    def print_csv_by_task(  # noqa: ANN201
+        self,
+        counter_list: list[AnnotationCounterByTask],
+        output_file: Path,
+        prior_label_columns: Optional[list[str]] = None,
+    ):
+        def get_columns() -> list[str]:
+            basic_columns = [
+                "task_id",
+                "status",
+                "phase",
+                "phase_stage",
+                "input_data_count",
+                "annotation_count",
+            ]
+            value_columns = self._value_columns(counter_list, prior_label_columns)
+            return basic_columns + value_columns
+
+        def to_dict(c: AnnotationCounterByTask) -> dict[str, Any]:
+            d = {
+                "task_id": c.task_id,
+                "status": c.status.value,
+                "phase": c.phase.value,
+                "phase_stage": c.phase_stage,
+                "input_data_count": c.input_data_count,
+                "annotation_count": c.annotation_count,
+            }
+            # キーをラベル名、値をラベルごとのアノテーション数にしたdictに変換する
+            d.update(c.annotation_count_by_label)
+            return d
+
+        df = pandas.DataFrame([to_dict(e) for e in counter_list], columns=get_columns())
+
+        # NaNを0に変換する
+        # `basic_columns`は必ずnanではないので、すべての列に対してfillnaを実行しても問題ないはず
+        df.fillna(0, inplace=True)
+        print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
+
+    def print_csv_by_input_data(  # noqa: ANN201
+        self,
+        counter_list: list[AnnotationCounterByInputData],
+        output_file: Path,
+        prior_label_columns: Optional[list[str]] = None,
+    ):
+        def get_columns() -> list[str]:
+            basic_columns = [
+                "task_id",
+                "status",
+                "phase",
+                "phase_stage",
+                "input_data_id",
+                "input_data_name",
+                "frame_no",
+                "annotation_count",
+            ]
+            value_columns = self._value_columns(counter_list, prior_label_columns)
+            return basic_columns + value_columns
+
+        def to_dict(c: AnnotationCounterByInputData) -> dict[str, Any]:
+            d = {
+                "input_data_id": c.input_data_id,
+                "input_data_name": c.input_data_name,
+                "frame_no": c.frame_no,
+                "task_id": c.task_id,
+                "status": c.status.value,
+                "phase": c.phase.value,
+                "phase_stage": c.phase_stage,
+                "annotation_count": c.annotation_count,
+            }
+            d.update(c.annotation_count_by_label)
+            return d
+
+        columns = get_columns()
+        df = pandas.DataFrame([to_dict(e) for e in counter_list], columns=columns)
+
+        # アノテーション数列のNaNを0に変換する
+        value_columns = self._value_columns(counter_list, prior_label_columns)
+        df = df.fillna({column: 0 for column in value_columns})
+
+        print_csv(df, output=str(output_file), to_csv_kwargs=self.csv_format)
+
+
+class ListAnnotationDurationMain:
+    def __init__(self, service: annofabapi.Resource) -> None:
+        self.service = service
+
+    @staticmethod
+    def get_frame_no_map(task_json_path: Path) -> dict[tuple[str, str], int]:
+        with task_json_path.open() as f:
+            task_list = json.load(f)
+
+        result = {}
+        for task in task_list:
+            task_id = task["task_id"]
+            input_data_id_list = task["input_data_id_list"]
+            for index, input_data_id in enumerate(input_data_id_list):
+                # 画面に合わせて1始まりにする
+                result[(task_id, input_data_id)] = index + 1
+        return result
+
+    def print_annotation_counter_csv_by_input_data(  # noqa: ANN201
+        self,
+        annotation_path: Path,
+        csv_type: CsvType,
+        output_file: Path,
+        *,
+        project_id: Optional[str] = None,
+        task_json_path: Optional[Path] = None,
+        target_task_ids: Optional[Collection[str]] = None,
+        task_query: Optional[TaskQuery] = None,
+    ):
+        # アノテーション仕様の非選択系の属性は、集計しないようにする。集計しても意味がないため。
+        annotation_specs: Optional[AnnotationSpecs] = None
+        non_selective_attribute_name_keys: Optional[list[AttributeNameKey]] = None
+        if project_id is not None:
+            annotation_specs = AnnotationSpecs(self.service, project_id)
+            non_selective_attribute_name_keys = annotation_specs.non_selective_attribute_name_keys()
+
+        frame_no_map = self.get_frame_no_map(task_json_path) if task_json_path is not None else None
+        counter_by_input_data = ListAnnotationCounterByInputData(
+            non_target_attribute_names=non_selective_attribute_name_keys, frame_no_map=frame_no_map
+        )
+        counter_list_by_input_data = counter_by_input_data.get_annotation_counter_list(
+            annotation_path,
+            target_task_ids=target_task_ids,
+            task_query=task_query,
+        )
+
+        if csv_type == CsvType.LABEL:
+            # ラベル名の列順が、アノテーション仕様にあるラベル名の順番に対応するようにする。
+            label_columns: Optional[list[str]] = None
+            if annotation_specs is not None:
+                label_columns = annotation_specs.label_keys()
+
+            LabelCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_label_columns=label_columns)
+        elif csv_type == CsvType.ATTRIBUTE:
+            attribute_columns: Optional[list[AttributeValueKey]] = None
+            if annotation_specs is not None:
+                attribute_columns = annotation_specs.selective_attribute_value_keys()
+
+            AttributeCountCsv().print_csv_by_input_data(counter_list_by_input_data, output_file, prior_attribute_columns=attribute_columns)
+
+    def print_annotation_duration_json_by_input_data(  # noqa: ANN201
+        self,
+        annotation_path: Path,
+        output_file: Path,
+        *,
+        project_id: Optional[str] = None,
+        task_json_path: Optional[Path] = None,
+        target_task_ids: Optional[Collection[str]] = None,
+        task_query: Optional[TaskQuery] = None,
+        json_is_pretty: bool = False,
+    ):
+        """ラベルごと/属性ごとのアノテーション数を入力データ単位でJSONファイルに出力します。"""
+
+        # アノテーション仕様の非選択系の属性（テキストボックス、アノテーションリンク、トラッキングIDなど）は、集計しないようにする。集計しても意味がないため。  # noqa: E501
+        if project_id is not None:
+            annotation_specs = AnnotationSpecs(self.service, project_id)
+            non_selective_attribute_name_keys = annotation_specs.non_selective_attribute_name_keys()
+        else:
+            non_selective_attribute_name_keys = None
+
+        counter_list_by_input_data = ListAnnotationCounterByInputData(
+            non_target_attribute_names=non_selective_attribute_name_keys, frame_no_map=frame_no_map
+        ).get_annotation_counter_list(
+            annotation_path,
+            target_task_ids=target_task_ids,
+            task_query=task_query,
+        )
+
+        print_json(
+            [e.to_dict(encode_json=True) for e in counter_list_by_input_data],
+            is_pretty=json_is_pretty,
+            output=output_file,
+        )
+
+    def print_annotation_counter(  # noqa: ANN201
+        self,
+        annotation_path: Path,
+        output_file: Path,
+        arg_format: FormatArgument,
+        *,
+        project_id: Optional[str] = None,
+        task_json_path: Optional[Path] = None,
+        target_task_ids: Optional[Collection[str]] = None,
+        task_query: Optional[TaskQuery] = None,
+        csv_type: Optional[CsvType] = None,
+    ):
+        """ラベルごと/属性ごとのアノテーション数を出力します。"""
+        if arg_format == FormatArgument.CSV:
+            assert csv_type is not None
+            self.print_annotation_counter_csv_by_input_data(
+                project_id=project_id,
+                annotation_path=annotation_path,
+                task_json_path=task_json_path,
+                output_file=output_file,
+                target_task_ids=target_task_ids,
+                task_query=task_query,
+                csv_type=csv_type,
+            )
+
+        elif arg_format in [FormatArgument.PRETTY_JSON, FormatArgument.JSON]:
+            json_is_pretty = arg_format == FormatArgument.PRETTY_JSON
+
+            self.print_annotation_duration_json_by_input_data(
+                project_id=project_id,
+                annotation_path=annotation_path,
+                task_json_path=task_json_path,
+                output_file=output_file,
+                target_task_ids=target_task_ids,
+                task_query=task_query,
+                json_is_pretty=json_is_pretty,
+            )
+
+
+class ListAnnotationDuration(AbstractCommandLineInterface):
+    """
+    区間アノテーションの長さ情報を出力する。
+    """
+
+    COMMON_MESSAGE = "annofabcli statistics list_annotation_duration: error:"
+
+    def validate(self, args: argparse.Namespace) -> bool:
+        if args.project_id is None and args.annotation is None:
+            print(
+                f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
+                file=sys.stderr,
+            )
+            return False
+
+        return True
+
+    def main(self) -> None:
+        args = self.args
+
+        if not self.validate(args):
+            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+
+        project_id: Optional[str] = args.project_id
+        if project_id is not None:
+            super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
+
+        annotation_path = Path(args.annotation) if args.annotation is not None else None
+
+        task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
+        task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
+
+        csv_type = CsvType(args.type)
+        output_file: Path = args.output
+        arg_format = FormatArgument(args.format)
+        main_obj = ListAnnotationCountMain(self.service)
+
+        downloading_obj = DownloadingFile(self.service)
+
+        # `NamedTemporaryFile`を使わない理由: Windowsで`PermissionError`が発生するため
+        # https://qiita.com/yuji38kwmt/items/c6f50e1fc03dafdcdda0 参考
+        with tempfile.TemporaryDirectory() as str_temp_dir:
+            # タスク全件ファイルは、フレーム番号を参照するのに利用する
+            if project_id is not None:
+                task_json_path = Path(str_temp_dir) / f"{project_id}__task.json"
+                downloading_obj.download_task_json(
+                    project_id,
+                    dest_path=str(task_json_path),
+                )
+            else:
+                task_json_path = None
+
+            func = partial(
+                main_obj.print_annotation_counter,
+                project_id=project_id,
+                task_json_path=task_json_path,
+                csv_type=csv_type,
+                arg_format=arg_format,
+                output_file=output_file,
+                target_task_ids=task_id_list,
+                task_query=task_query,
+            )
+
+            if annotation_path is None:
+                assert project_id is not None
+                annotation_path = Path(str_temp_dir) / f"{project_id}__annotation.zip"
+                downloading_obj.download_annotation_zip(
+                    project_id,
+                    dest_path=str(annotation_path),
+                    is_latest=args.latest,
+                )
+                func(annotation_path=annotation_path)
+            else:
+                func(annotation_path=annotation_path)
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    argument_parser = ArgumentParser(parser)
+
+    parser.add_argument(
+        "--annotation",
+        type=str,
+        help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--project_id",
+        type=str,
+        help="project_id。``--annotation`` が未指定のときは必須です。``--annotation`` が指定されているときに ``--project_id`` を指定すると、アノテーション仕様を参照して、集計対象の属性やCSV列順が決まります。",  # noqa: E501
+    )
+
+    parser.add_argument(
+        "--type",
+        type=str,
+        choices=[e.value for e in CsvType],
+        default=CsvType.LABEL.value,
+        help="出力するCSVの種類を指定してください。 ``--format csv`` を指定したときのみ有効なオプションです。\n"
+        "\n"
+        "* label: ラベルごとにアノテーション数が記載されているCSV\n"
+        "* attribute: 属性値ごとにアノテーション数が記載されているCSV",
+    )
+
+    argument_parser.add_format(
+        choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON],
+        default=FormatArgument.CSV,
+    )
+
+    argument_parser.add_output()
+
+    parser.add_argument(
+        "-tq",
+        "--task_query",
+        type=str,
+        help="集計対象タスクを絞り込むためのクエリ条件をJSON形式で指定します。使用できるキーは task_id, status, phase, phase_stage です。"
+        " ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
+    )
+    argument_parser.add_task_id(required=False)
+
+    parser.add_argument(
+        "--latest",
+        action="store_true",
+        help="``--annotation`` を指定しないとき、最新のアノテーションzipを参照します。このオプションを指定すると、アノテーションzipを更新するのに数分待ちます。",  # noqa: E501
+    )
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def main(args: argparse.Namespace) -> None:
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    ListAnnotationDuration(service, facade, args).main()
+
+
+def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
+    subcommand_name = "list_annotation_duration"
+    subcommand_help = "区間アノテーション（動画プロジェクト専用）に対して、各ラベル、各属性値の区間の長さ（秒）を出力します。"
+    epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog)
+    parse_args(parser)
+    return parser

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -628,8 +628,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         default=CsvType.LABEL.value,
         help="出力するCSVの種類を指定してください。 ``--format csv`` を指定したときのみ有効なオプションです。\n"
         "\n"
-        "* label: ラベルごとにアノテーション数が記載されているCSV\n"
-        "* attribute: 属性値ごとにアノテーション数が記載されているCSV",
+        "* label: ラベルごとに区間アノテーションの長さが記載されているCSV\n"
+        "* attribute: 属性値ごとに区間アノテーションの長さが記載されているCSV",
     )
 
     argument_parser.add_format(
@@ -671,7 +671,7 @@ def main(args: argparse.Namespace) -> None:
 
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "list_annotation_duration"
-    subcommand_help = "区間アノテーション（動画プロジェクト専用）に対して、各ラベル、各属性値の区間の長さ（秒）を出力します。"
+    subcommand_help = "ラベルごとまたは属性値ごとに区間アノテーションの長さ（秒）を出力します。"
     epilog = "オーナロールまたはアノテーションユーザロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=subcommand_help, epilog=epilog)
     parse_args(parser)

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -115,7 +115,7 @@ class AnnotationDuration(DataClassJsonMixin):
     input_data_id: str
     input_data_name: str
 
-    annotation_duration_second: int
+    annotation_duration_second: float
     """
     区間アノテーションの合計の長さ（秒）
     `sum(annotation_duration_second_by_label.values())`と一致する
@@ -197,7 +197,7 @@ class ListAnnotationDurationByInputData:
         # TODO type文字列の定義をannofab-apiに定義する
         range_details = [e for e in simple_annotation["details"] if e["data"]["_type"] == "Range"]
 
-        annotation_duration_by_label = defaultdict(float)
+        annotation_duration_by_label: dict[str, float] = defaultdict(float)
         for detail in range_details:
             annotation_duration_by_label[detail["label"]] += calculate_annotation_duration_second(detail)
 
@@ -211,7 +211,7 @@ class ListAnnotationDurationByInputData:
                 label: duration for label, duration in annotation_duration_by_label.items() if label not in self.non_target_labels
             }
 
-        annotation_duration_by_attribute = defaultdict(float)
+        annotation_duration_by_attribute: dict[AttributeValueKey, float] = defaultdict(float)
         for detail in range_details:
             label = detail["label"]
             if label not in annotation_duration_by_label:
@@ -377,7 +377,7 @@ class AnnotationDurationCsvByAttribute:
         prior_attribute_columns: Optional[list[AttributeValueKey]] = None,
     ) -> pandas.DataFrame:
         def to_cell(c: AnnotationDuration) -> dict[tuple[str, str, str], Any]:
-            cell = {
+            cell: dict[AttributeValueKey, Any] = {
                 ("input_data_id", "", ""): c.input_data_id,
                 ("input_data_name", "", ""): c.input_data_name,
                 ("task_id", "", ""): c.task_id,
@@ -438,7 +438,7 @@ class AnnotationDurationCsvByLabel:
         prior_label_columns: Optional[list[str]] = None,
     ) -> pandas.DataFrame:
         def to_dict(c: AnnotationDuration) -> dict[str, Any]:
-            d = {
+            d: dict[str, Any] = {
                 "input_data_id": c.input_data_id,
                 "input_data_name": c.input_data_name,
                 "task_id": c.task_id,
@@ -483,7 +483,7 @@ class ListAnnotationDurationMain:
 
         annotation_duration_list = ListAnnotationDurationByInputData(
             non_target_attribute_names=non_selective_attribute_name_keys
-        ).get_annotation_counter_list(
+        ).get_annotation_duration_list(
             annotation_path,
             target_task_ids=target_task_ids,
             task_query=task_query,
@@ -619,7 +619,7 @@ class ListAnnotationDuration(AbstractCommandLineInterface):
             task_json_path = None
 
             func = partial(
-                main_obj.print_annotation_counter,
+                main_obj.print_annotation_duration,
                 project_id=project_id,
                 task_json_path=task_json_path,
                 csv_type=csv_type,

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -566,7 +566,6 @@ class ListAnnotationDuration(AbstractCommandLineInterface):
         arg_format = FormatArgument(args.format)
         main_obj = ListAnnotationDurationMain(self.service)
 
-
         downloading_obj = DownloadingFile(self.service)
 
         func = partial(
@@ -580,8 +579,17 @@ class ListAnnotationDuration(AbstractCommandLineInterface):
         )
 
         if annotation_path is None:
+            assert project_id is not None
+
             if args.temp_dir is not None:
-                assert project_id is not None
+                annotation_path = args.temp_dir / f"{project_id}__annotation.zip"
+                downloading_obj.download_annotation_zip(
+                    project_id,
+                    dest_path=annotation_path,
+                    is_latest=args.latest,
+                )
+                func(annotation_path=annotation_path)
+            else:
                 # `NamedTemporaryFile`を使わない理由: Windowsで`PermissionError`が発生するため
                 # https://qiita.com/yuji38kwmt/items/c6f50e1fc03dafdcdda0 参考
                 with tempfile.TemporaryDirectory() as str_temp_dir:
@@ -592,14 +600,6 @@ class ListAnnotationDuration(AbstractCommandLineInterface):
                         is_latest=args.latest,
                     )
                     func(annotation_path=annotation_path)
-            else:
-                annotation_path = args.temp_dir / f"{project_id}__annotation.zip"
-                downloading_obj.download_annotation_zip(
-                    project_id,
-                    dest_path=str(output_file),
-                    is_latest=args.latest,
-                )
-                func(annotation_path=output_file)
 
         else:
             func(annotation_path=annotation_path)

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import Any, Collection, Counter, Iterator, Optional, Tuple, Union
+from typing import Any, Collection, Iterator, Optional, Tuple, Union
 
 import annofabapi
 import pandas
@@ -85,8 +85,8 @@ def lazy_parse_simple_annotation_by_input_data(annotation_path: Path) -> Iterato
 
 
 def encode_annotation_duration_second_by_attribute(
-    annotation_duration_second_by_attribute: Counter[AttributeValueKey],
-) -> dict[str, dict[str, dict[str, int]]]:
+    annotation_duration_second_by_attribute: dict[AttributeValueKey, float],
+) -> dict[str, dict[str, dict[str, float]]]:
     """annotation_duration_second_by_attributeを `{label_name: {attribute_name: {attribute_value: annotation_count}}}`のdictに変換します。
     JSONへの変換用関数です。
     """
@@ -95,7 +95,7 @@ def encode_annotation_duration_second_by_attribute(
         """入れ子の辞書を利用できるようにするための関数"""
         return collections.defaultdict(_factory)
 
-    result: dict[str, dict[str, dict[str, int]]] = defaultdict(_factory)
+    result: dict[str, dict[str, dict[str, float]]] = defaultdict(_factory)
     for (label_name, attribute_name, attribute_value), annotation_duration_second in annotation_duration_second_by_attribute.items():
         result[label_name][attribute_name][attribute_value] = annotation_duration_second
     return result

--- a/annofabcli/statistics/subcommand_statistics.py
+++ b/annofabcli/statistics/subcommand_statistics.py
@@ -5,6 +5,7 @@ import annofabcli
 import annofabcli.common.cli
 import annofabcli.stat_visualization.merge_visualization_dir
 import annofabcli.statistics.list_annotation_count
+import annofabcli.statistics.list_annotation_duration
 import annofabcli.statistics.list_worktime
 import annofabcli.statistics.summarize_task_count
 import annofabcli.statistics.summarize_task_count_by_task_id_group
@@ -18,6 +19,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     # サブコマンドの定義
     annofabcli.statistics.list_annotation_count.add_parser(subparsers)
+    annofabcli.statistics.list_annotation_duration.add_parser(subparsers)
     annofabcli.statistics.list_worktime.add_parser(subparsers)
     annofabcli.statistics.summarize_task_count.add_parser(subparsers)
     annofabcli.statistics.summarize_task_count_by_task_id_group.add_parser(subparsers)

--- a/docs/command_reference/statistics/index.rst
+++ b/docs/command_reference/statistics/index.rst
@@ -17,6 +17,7 @@ Available Commands
 
 
    list_annotation_count
+   list_annotation_duration
    list_worktime
    summarize_task_count
    summarize_task_count_by_task_id_group

--- a/docs/command_reference/statistics/list_annotation_count.rst
+++ b/docs/command_reference/statistics/list_annotation_count.rst
@@ -55,7 +55,7 @@ Examples
         "status": "complete",
         "phase": "acceptance",
         "phase_stage": 1,
-        "input_data_count": 10
+        "input_data_count": 10,
     }
     ]  
 
@@ -137,7 +137,8 @@ JSON出力
         "status": "complete",
         "phase": "acceptance",
         "phase_stage": 1,
-        "input_data_count": 10
+        "input_data_count": 10,
+        "frame_no": 1        
     }
     ]  
 

--- a/docs/command_reference/statistics/list_annotation_duration.rst
+++ b/docs/command_reference/statistics/list_annotation_duration.rst
@@ -1,0 +1,108 @@
+==========================================
+statistics list_annotation_duration
+==========================================
+
+Description
+=================================
+
+ラベルごとまたは属性値ごとに区間アノテーションの長さ（秒）を出力します。
+区間アノテーションは動画プロジェクト用のアノテーションです。
+
+区間アノテーションの長さは、ダウンロードしたアノテーションZIPから算出します。
+
+
+Examples
+=================================
+
+
+JSON出力
+--------------------------
+
+
+.. code-block::
+
+    $ annofabcli statistics list_annotation_duration --project_id prj1 \
+     --output out.json --format pretty_json
+
+
+.. code-block:: json
+    :caption: out.json
+
+    [
+    {
+        "task_id": "sample_task_00",
+        "status": "not_started",
+        "phase": "annotation",
+        "phase_stage": 1,
+        "input_data_id": "sample_video_00.mp4",
+        "input_data_name": "sample_video_00.mp4",
+        "annotation_duration_second": 21.333,
+        "annotation_duration_second_by_label": {
+            "traffic_light": 21.333
+        },
+        "annotation_duration_second_by_attribute": {
+            "traffic_light": {
+                "color": {
+                    "red": 13.2,
+                    "green": 8.133,
+                }
+            }
+        }
+    }
+    ]
+
+
+
+* ``annotation_duration_second`` : 区間アノテーションの合計の長さ（秒）
+* ``annotation_duration_second_by_label`` : ラベルごとの区間アノテーションの長さ（秒）（ ``{label_name: annotation_duration}``）
+* ``annotation_duration_second_by_attribute`` : 属性値ごとの区間アノテーションの長さ（秒）（ ``{label_name: {attribute_name: {attribute_value: annotation_duration}}}``）
+
+
+``annotation_duration_second_by_attribute`` に格納される属性の種類は以下の通りです。
+
+* ドロップダウン
+* ラジオボタン
+* チェックボックス
+
+※ ``--project_id`` を指定しない場合は、上記以外の属性の種類（たとえばトラッキングID）も集計されます。
+
+
+CSV出力
+--------------------------
+
+CSVを出力する場合は、``--type`` で集計単位を指定してください。
+
+* ``label`` : ラベルごとの集計（デフォルト値）
+* ``attribute`` : 属性値ごとの集計
+
+
+.. code-block::
+
+    $ annofabcli statistics list_annotation_count --project_id prj1 \
+    --format csv --type label --output out_by_task_label.csv 
+
+.. csv-table:: out_by_label.csv 
+    :header-rows: 1
+    :file: list_annotation_duration/out_by_label.csv
+
+
+.. code-block::
+
+    $ annofabcli statistics list_annotation_count --project_id prj1 \
+    --format csv --type attribute --output out_by_attribute.csv 
+
+.. csv-table:: out_by_label.csv 
+    :header-rows: 1
+    :file: list_annotation_duration/out_by_attribute.csv
+
+
+
+Usage Details
+=================================
+
+.. argparse::
+   :ref: annofabcli.statistics.list_annotation_duration.add_parser
+   :prog: annofabcli statistics list_annotation_duration
+   :nosubcommands:
+   :nodefaultconst:
+

--- a/docs/command_reference/statistics/list_annotation_duration/out_by_attribute.csv
+++ b/docs/command_reference/statistics/list_annotation_duration/out_by_attribute.csv
@@ -1,0 +1,5 @@
+﻿task_id,status,phase,phase_stage,input_data_id,input_data_name,annotation_duration_second,label-A,label-A,label-B,label-B,label-B
+,,,,,,,is_lighted,is_lighted,color,color,color
+,,,,,,,true,false,red,green,yellow
+task1,not_started,acceptance,1,input_data1,input_data1,73,10,1,40,20,2
+task2,on_hold,inspection,1,input_data2,input_data2,62,20,1,30,10,1

--- a/docs/command_reference/statistics/list_annotation_duration/out_by_label.csv
+++ b/docs/command_reference/statistics/list_annotation_duration/out_by_label.csv
@@ -1,0 +1,3 @@
+﻿task_id,status,phase,phase_stage,input_data_id,input_data_name,annotation_duration_second,label-A,label-B,label-C
+task1,not_started,acceptance,1,input_data1,input_data1,170,43,77,50
+task2,complete,acceptance,1,input_data2,input_data2,64,35,9,20

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from annofabcli.statistics.list_annotation_duration import AnnotationDurationCsvByLabel, ListAnnotationDurationByInputData
+from annofabcli.statistics.list_annotation_duration import (
+    AnnotationDurationCsvByAttribute,
+    AnnotationDurationCsvByLabel,
+    ListAnnotationDurationByInputData,
+)
 
 output_dir = Path("./tests/out/statistics/list_annotation_duration")
 data_dir = Path("./tests/data/statistics/")
@@ -119,4 +123,24 @@ class Test__AnnotationDurationCsvByLabel:
             "annotation_duration_second": 26.0,
             "traffic_light": 21.0,
             "traffic_light_for_pedestrian": 5.0,
+        }
+
+
+class Test__AnnotationDurationCsvByAttribute:
+    def test__create_df(self) -> None:
+        annotation_duration = ListAnnotationDurationByInputData().get_annotation_duration(ANNOTATION)
+        df = AnnotationDurationCsvByAttribute().create_df([annotation_duration])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row.to_dict() == {
+            ("task_id", "", ""): "task1",
+            ("phase", "", ""): "acceptance",
+            ("phase_stage", "", ""): 1,
+            ("status", "", ""): "complete",
+            ("input_data_id", "", ""): "input1",
+            ("input_data_name", "", ""): "input1",
+            ("annotation_duration_second", "", ""): 26.0,
+            ("traffic_light", "color", "green"): 8.0,
+            ("traffic_light", "color", "red"): 13.0,
+            ("traffic_light_for_pedestrian", "color", "green"): 5.0,
         }

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -9,43 +9,45 @@ output_dir = Path("./tests/out/statistics/list_annotation_duration")
 data_dir = Path("./tests/data/statistics/")
 output_dir.mkdir(exist_ok=True, parents=True)
 
+ANNOTATION = {
+    "task_id": "task1",
+    "task_phase": "acceptance",
+    "task_phase_stage": 1,
+    "task_status": "complete",
+    "input_data_id": "input1",
+    "input_data_name": "input1",
+    "details": [
+        {
+            "label": "entire_video",
+            "data": {"_type": "Classification"},
+            "attributes": {"weather": "fine"},
+        },
+        {
+            "label": "traffic_light",
+            "data": {"begin": 3000, "end": 16000, "_type": "Range"},
+            "attributes": {"color": "red"},
+        },
+        {
+            "label": "traffic_light",
+            "data": {"begin": 16000, "end": 24000, "_type": "Range"},
+            "attributes": {"color": "green"},
+        },
+        {
+            "label": "traffic_light_for_pedestrian",
+            "data": {"begin": 4000, "end": 9000, "_type": "Range"},
+            "attributes": {"color": "green"},
+        },
+    ],
+}
+
 
 class TestListAnnotationDurationByInputData:
     def test_get_annotation_duration(self) -> None:
-        annotation = {
-            "task_id": "task1",
-            "task_phase": "acceptance",
-            "task_phase_stage": 1,
-            "task_status": "complete",
-            "input_data_id": "input1",
-            "input_data_name": "input1",
-            "details": [
-                {
-                    "label": "entire_video",
-                    "data": {"_type": "Classification"},
-                    "attributes": {"weather": "fine"},
-                },
-                {
-                    "label": "traffic_light",
-                    "data": {"begin": 3000, "end": 16000, "_type": "Range"},
-                    "attributes": {"color": "red"},
-                },
-                {
-                    "label": "traffic_light",
-                    "data": {"begin": 16000, "end": 24000, "_type": "Range"},
-                    "attributes": {"color": "green"},
-                },
-                {
-                    "label": "traffic_light_for_pedestrian",
-                    "data": {"begin": 4000, "end": 9000, "_type": "Range"},
-                    "attributes": {"color": "green"},
-                },
-            ],
-        }
 
-        annotation_duration = ListAnnotationDurationByInputData().get_annotation_duration(annotation)
+        annotation_duration = ListAnnotationDurationByInputData().get_annotation_duration(ANNOTATION)
         assert annotation_duration.input_data_id == "input1"
         assert annotation_duration.task_id == "task1"
+        assert annotation_duration.annotation_duration_second == 26.0
         assert annotation_duration.annotation_duration_second_by_label == {
             "traffic_light": 21.0,
             "traffic_light_for_pedestrian": 5.0,
@@ -58,15 +60,22 @@ class TestListAnnotationDurationByInputData:
             }
         )
 
-    #     counter2 = ListAnnotationDurationByInputData(target_labels=["climatic"], target_attribute_names=[("bird", "occluded")]).get_annotation_counter(
-    #         annotation
-    #     )
-    #     assert counter2.annotation_count_by_label == collections.Counter({"climatic": 1})
-    #     assert counter2.annotation_count_by_attribute == collections.Counter(
-    #         {
-    #             ("bird", "occluded", "true"): 2,
-    #         }
-    #     )
+    def test_get_annotation_duration__target_labels引数を指定する(self) -> None:
+        annotation_duration = ListAnnotationDurationByInputData(target_labels=["traffic_light"]).get_annotation_counter(
+            ANNOTATION
+        )
+        assert annotation_duration.annotation_duration_second == 26.0
+        assert annotation_duration.annotation_duration_second_by_label == {
+            "traffic_light": 21.0,
+            "traffic_light_for_pedestrian": 5.0,
+        }
+        assert annotation_duration.annotation_duration_second_by_attribute == collections.Counter(
+            {
+                ("traffic_light", "color", "green"): 8.0,
+                ("traffic_light", "color", "red"): 13.0,
+                ("traffic_light_for_pedestrian", "color", "green"): 5.0,
+            }
+        )
 
     # def test_get_annotation_counter_list(self):
     #     counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -1,4 +1,3 @@
-import collections
 from pathlib import Path
 
 from annofabcli.statistics.list_annotation_duration import (
@@ -43,7 +42,6 @@ ANNOTATION = {
 
 class TestListAnnotationDurationByInputData:
     def test_get_annotation_duration(self) -> None:
-
         annotation_duration = ListAnnotationDurationByInputData().get_annotation_duration(ANNOTATION)
         assert annotation_duration.input_data_id == "input1"
         assert annotation_duration.task_id == "task1"
@@ -52,16 +50,35 @@ class TestListAnnotationDurationByInputData:
             "traffic_light": 21.0,
             "traffic_light_for_pedestrian": 5.0,
         }
-        assert annotation_duration.annotation_duration_second_by_attribute == collections.Counter(
-            {
-                ("traffic_light", "color", "green"): 8.0,
-                ("traffic_light", "color", "red"): 13.0,
-                ("traffic_light_for_pedestrian", "color", "green"): 5.0,
-            }
-        )
+        assert annotation_duration.annotation_duration_second_by_attribute == {
+            ("traffic_light", "color", "green"): 8.0,
+            ("traffic_light", "color", "red"): 13.0,
+            ("traffic_light_for_pedestrian", "color", "green"): 5.0,
+        }
 
     def test_get_annotation_duration__target_labels引数を指定する(self) -> None:
-        annotation_duration = ListAnnotationDurationByInputData(target_labels=["traffic_light"]).get_annotation_counter(
+        annotation_duration = ListAnnotationDurationByInputData(target_labels=["traffic_light"]).get_annotation_duration(ANNOTATION)
+        assert annotation_duration.annotation_duration_second == 21.0
+        assert annotation_duration.annotation_duration_second_by_label == {
+            "traffic_light": 21.0,
+        }
+        assert annotation_duration.annotation_duration_second_by_attribute == {
+            ("traffic_light", "color", "green"): 8.0,
+            ("traffic_light", "color", "red"): 13.0,
+        }
+
+    def test_get_annotation_duration__non_target_labels引数を指定する(self) -> None:
+        annotation_duration = ListAnnotationDurationByInputData(non_target_labels=["traffic_light"]).get_annotation_duration(ANNOTATION)
+        assert annotation_duration.annotation_duration_second == 5.0
+        assert annotation_duration.annotation_duration_second_by_label == {
+            "traffic_light_for_pedestrian": 5.0,
+        }
+        assert annotation_duration.annotation_duration_second_by_attribute == {
+            ("traffic_light_for_pedestrian", "color", "green"): 5.0,
+        }
+
+    def test_get_annotation_duration__target_attribute_names引数を指定する(self) -> None:
+        annotation_duration = ListAnnotationDurationByInputData(target_attribute_names=[("traffic_light", "color")]).get_annotation_duration(
             ANNOTATION
         )
         assert annotation_duration.annotation_duration_second == 26.0
@@ -69,13 +86,23 @@ class TestListAnnotationDurationByInputData:
             "traffic_light": 21.0,
             "traffic_light_for_pedestrian": 5.0,
         }
-        assert annotation_duration.annotation_duration_second_by_attribute == collections.Counter(
-            {
-                ("traffic_light", "color", "green"): 8.0,
-                ("traffic_light", "color", "red"): 13.0,
-                ("traffic_light_for_pedestrian", "color", "green"): 5.0,
-            }
+        assert annotation_duration.annotation_duration_second_by_attribute == {
+            ("traffic_light", "color", "green"): 8.0,
+            ("traffic_light", "color", "red"): 13.0,
+        }
+
+    def test_get_annotation_duration__non_target_attribute_names引数を指定する(self) -> None:
+        annotation_duration = ListAnnotationDurationByInputData(non_target_attribute_names=[("traffic_light", "color")]).get_annotation_duration(
+            ANNOTATION
         )
+        assert annotation_duration.annotation_duration_second == 26.0
+        assert annotation_duration.annotation_duration_second_by_label == {
+            "traffic_light": 21.0,
+            "traffic_light_for_pedestrian": 5.0,
+        }
+        assert annotation_duration.annotation_duration_second_by_attribute == {
+            ("traffic_light_for_pedestrian", "color", "green"): 5.0,
+        }
 
     # def test_get_annotation_counter_list(self):
     #     counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -1,0 +1,73 @@
+import collections
+from pathlib import Path
+
+from annofabcli.statistics.list_annotation_duration import (
+    ListAnnotationDurationByInputData,
+)
+
+output_dir = Path("./tests/out/statistics/list_annotation_duration")
+data_dir = Path("./tests/data/statistics/")
+output_dir.mkdir(exist_ok=True, parents=True)
+
+
+class TestListAnnotationDurationByInputData:
+    def test_get_annotation_duration(self) -> None:
+        annotation = {
+            "task_id": "task1",
+            "task_phase": "acceptance",
+            "task_phase_stage": 1,
+            "task_status": "complete",
+            "input_data_id": "input1",
+            "input_data_name": "input1",
+            "details": [
+                {
+                    "label": "entire_video",
+                    "data": {"_type": "Classification"},
+                    "attributes": {"weather": "fine"},
+                },
+                {
+                    "label": "traffic_light",
+                    "data": {"begin": 3000, "end": 16000, "_type": "Range"},
+                    "attributes": {"color": "red"},
+                },
+                {
+                    "label": "traffic_light",
+                    "data": {"begin": 16000, "end": 24000, "_type": "Range"},
+                    "attributes": {"color": "green"},
+                },
+                {
+                    "label": "traffic_light_for_pedestrian",
+                    "data": {"begin": 4000, "end": 9000, "_type": "Range"},
+                    "attributes": {"color": "green"},
+                },
+            ],
+        }
+
+        annotation_duration = ListAnnotationDurationByInputData().get_annotation_duration(annotation)
+        assert annotation_duration.input_data_id == "input1"
+        assert annotation_duration.task_id == "task1"
+        assert annotation_duration.annotation_duration_second_by_label == {
+            "traffic_light": 21.0,
+            "traffic_light_for_pedestrian": 5.0,
+        }
+        assert annotation_duration.annotation_duration_second_by_attribute == collections.Counter(
+            {
+                ("traffic_light", "color", "green"): 8.0,
+                ("traffic_light", "color", "red"): 13.0,
+                ("traffic_light_for_pedestrian", "color", "green"): 5.0,
+            }
+        )
+
+    #     counter2 = ListAnnotationDurationByInputData(target_labels=["climatic"], target_attribute_names=[("bird", "occluded")]).get_annotation_counter(
+    #         annotation
+    #     )
+    #     assert counter2.annotation_count_by_label == collections.Counter({"climatic": 1})
+    #     assert counter2.annotation_count_by_attribute == collections.Counter(
+    #         {
+    #             ("bird", "occluded", "true"): 2,
+    #         }
+    #     )
+
+    # def test_get_annotation_counter_list(self):
+    #     counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")
+    #     assert len(counter_list) == 4

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
-from annofabcli.statistics.list_annotation_duration import (
-    ListAnnotationDurationByInputData,
-)
+from annofabcli.statistics.list_annotation_duration import AnnotationDurationCsvByLabel, ListAnnotationDurationByInputData
 
 output_dir = Path("./tests/out/statistics/list_annotation_duration")
 data_dir = Path("./tests/data/statistics/")
@@ -104,6 +102,21 @@ class TestListAnnotationDurationByInputData:
             ("traffic_light_for_pedestrian", "color", "green"): 5.0,
         }
 
-    # def test_get_annotation_counter_list(self):
-    #     counter_list = ListAnnotationCounterByInputData().get_annotation_counter_list(data_dir / "simple-annotations.zip")
-    #     assert len(counter_list) == 4
+
+class Test__AnnotationDurationCsvByLabel:
+    def test__create_df(self) -> None:
+        annotation_duration = ListAnnotationDurationByInputData().get_annotation_duration(ANNOTATION)
+        df = AnnotationDurationCsvByLabel().create_df([annotation_duration])
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row.to_dict() == {
+            "task_id": "task1",
+            "phase": "acceptance",
+            "phase_stage": 1,
+            "status": "complete",
+            "input_data_id": "input1",
+            "input_data_name": "input1",
+            "annotation_duration_second": 26.0,
+            "traffic_light": 21.0,
+            "traffic_light_for_pedestrian": 5.0,
+        }


### PR DESCRIPTION
```
$ annofabcli statistics list_annotation_duration --project_id prj1 --format pretty_json --output out.json
```

```
    {
        "annotation_duration_second": 123.456,
        "annotation_duration_second_by_label": {
            "car": 60.123,
            "bike": 10.123,
            ...
        },
        "annotation_duration_second_by_attribute": {
            "car": {
                "occlusion": {
                    "false": 10.123,
                    "true": 20.123
                },
                "type": {
                    "normal": 10.123,
                    "bus":20.123
                }
            },
            "bike": {
                "occlusion": {
                    "false": 10.123,
                    "true": 20.123
                }
            }
        },
        "task_id": "task1",
        "status": "complete",
        "phase": "acceptance",
        "phase_stage": 1,
        "input_data_id": "input1",
        "input_data_name": "input1"
       
    }
```