### PR TITLE
ファイルオープン時に`encoding="utf-8"`を指定する

### DIFF
--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -92,7 +92,7 @@ class MergeAnnotationMain:
         }
 
         output_json.parent.mkdir(parents=True, exist_ok=True)
-        with output_json.open("w") as f:
+        with output_json.open("w", encoding="utf-8") as f:
             json.dump(new_simple_annotation, f, ensure_ascii=False)
 
     def copy_annotation(self, parser: SimpleAnnotationParser, output_json: Path):  # noqa: ANN201
@@ -105,7 +105,7 @@ class MergeAnnotationMain:
                 self._write_outer_file(parser, anno, output_json)
 
         output_json.parent.mkdir(exist_ok=True, parents=True)
-        with output_json.open("w") as f:
+        with output_json.open("w", encoding="utf-8") as f:
             json.dump(simple_annotation, f, ensure_ascii=False)
 
     @staticmethod

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -801,7 +801,7 @@ class ListAnnotationCountMain:
 
     @staticmethod
     def get_frame_no_map(task_json_path: Path) -> dict[tuple[str, str], int]:
-        with task_json_path.open() as f:
+        with task_json_path.open(encoding="utf-8") as f:
             task_list = json.load(f)
 
         result = {}


### PR DESCRIPTION
`encoding="utf-8"`を指定しないと、Windows環境で実行する際に`UnicodeDecodeError`が発生するため、`encoding="utf-8"`を指定します。