### PR TITLE
`statistics visualize`: 折れ線グラフで、指定したユーザーの折れ線を太くする

### DIFF
--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -301,7 +301,7 @@ class LineGraph:
 
         for (let legendLabel in lineGlyphs) {
             if (selectedLegendLabel.includes(legendLabel)) {
-                lineGlyphs[legendLabel].glyph.line_width = 2;
+                lineGlyphs[legendLabel].glyph.line_width = 4;
             } else {
                 lineGlyphs[legendLabel].glyph.line_width = 1;
             }

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -43,6 +43,12 @@ class LineGraph:
     第2のY軸用の内部的な名前
     """
 
+    DEFAULT_LINE_WIDTH: int = 1
+    """折れ線の太さ"""
+
+    DEFAULT_SCATTER_SIZE: int = 4
+    """マーカーのサイズ"""
+
     @staticmethod
     def _create_hover_tool(tool_tip_items: Optional[List[str]] = None) -> HoverTool:
         """
@@ -158,13 +164,14 @@ class LineGraph:
             source=source,
             legend_label=legend_label,
             line_color=color,
-            line_width=1,
+            line_width=self.DEFAULT_SCATTER_SIZE,
             **new_kwargs,
         )
         scatter = self.figure.scatter(
             x=x_column,
             y=y_column,
             source=source,
+            size=self.DEFAULT_SCATTER_SIZE,
             legend_label=legend_label,
             color=color,
             **new_kwargs,
@@ -199,7 +206,7 @@ class LineGraph:
             source=source,
             legend_label=legend_label,
             line_color=color,
-            line_width=1,
+            line_width=self.DEFAULT_SCATTER_SIZE,
             line_dash="dashed",
             line_alpha=0.6,
             **new_kwargs,
@@ -276,11 +283,12 @@ class LineGraph:
 
         args = {"glyph_list": glyph_list}
         code = """
-            let size = ( "0" in this.active) ? 4 : 0
+            let size = ( "0" in this.active) ? %s : 0
             for (let glyph of glyph_list) {
                 glyph.size = size
             }
         """
+        code = code % (self.DEFAULT_SCATTER_SIZE)
         checkbox_group.js_on_change("active", CustomJS(code=code, args=args))
         return checkbox_group
 
@@ -303,10 +311,11 @@ class LineGraph:
             if (selectedLegendLabel.includes(legendLabel)) {
                 lineGlyphs[legendLabel].glyph.line_width = 4;
             } else {
-                lineGlyphs[legendLabel].glyph.line_width = 1;
+                lineGlyphs[legendLabel].glyph.line_width = %s;
             }
         }
         """
+        code = code % (self.DEFAULT_LINE_WIDTH)
         options = [(username, f"{user_id}:{username}") for user_id, username in users]
         multi_choice = MultiChoice(options=options, title="Find User:", width=300)
         multi_choice.js_on_change(

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -276,12 +276,12 @@ class LineGraph:
 
         args = {"glyph_list": glyph_list}
         code = """
-            let radius = ( "0" in this.active) ? null : 0
+            let size = ( "0" in this.active) ? 4 : 0
             for (let glyph of glyph_list) {
-                glyph.radius = radius
+                glyph.size = size
             }
         """
-        checkbox_group.js_on_event("button_click", CustomJS(code=code, args=args))
+        checkbox_group.js_on_change("active", CustomJS(code=code, args=args))
         return checkbox_group
 
     def create_multi_choice_widget_for_searching_user(self, users: list[tuple[str, str]]) -> MultiChoice:
@@ -299,13 +299,6 @@ class LineGraph:
         # 選択されたユーザーのフォントスタイルを太字にする
         code = """
         const selectedLegendLabel = this.value;
-        for (let legendLabel in markerGlyphs) {
-            if (selectedLegendLabel.includes(legendLabel)) {
-                markerGlyphs[legendLabel].glyph.size = 8;
-            } else {
-                markerGlyphs[legendLabel].glyph.size = 4;
-            }
-        }
 
         for (let legendLabel in lineGlyphs) {
             if (selectedLegendLabel.includes(legendLabel)) {

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -140,7 +140,12 @@ class LineGraph:
         """
         折れ線を追加する
 
-        is_secondary_y_axis
+        Args:
+            is_secondary_y_axis: Y軸の第2軸を設定するか
+
+        Returns:
+            折れ線のglyph, 折れ線のマーカーのglyph
+
         """
         new_kwargs = copy.deepcopy(kwargs)
         if is_secondary_y_axis:
@@ -155,7 +160,7 @@ class LineGraph:
             line_width=1,
             **new_kwargs,
         )
-        circle = self.figure.circle(
+        scatter = self.figure.scatter(
             x=x_column,
             y=y_column,
             source=source,
@@ -165,9 +170,9 @@ class LineGraph:
         )
 
         self.line_glyphs[legend_label] = line
-        self.marker_glyphs[legend_label] = circle
+        self.marker_glyphs[legend_label] = scatter
 
-        return (line, circle)
+        return (line, scatter)
 
     def add_moving_average_line(
         self,

--- a/annofabcli/statistics/linegraph.py
+++ b/annofabcli/statistics/linegraph.py
@@ -287,11 +287,10 @@ class LineGraph:
     def create_multi_choice_widget_for_searching_user(self, users: list[tuple[str, str]]) -> MultiChoice:
         """
         特定のユーザーを探すためのMultiChoiceウィジェットを追加します。
+        指定したユーザーの折れ線グラフを太くします。
 
         Args:
             users: ユーザーのリスト。tuple[user_id, username]
-        Notes:
-            2回以上実行しても意味がありません。
 
         """
         args = {"markerGlyphs": self.marker_glyphs, "lineGlyphs": self.line_glyphs}
@@ -302,13 +301,13 @@ class LineGraph:
 
         for (let legendLabel in lineGlyphs) {
             if (selectedLegendLabel.includes(legendLabel)) {
-                lineGlyphs[legendLabel].glyph.line_width = 4;
+                lineGlyphs[legendLabel].glyph.line_width = 2;
             } else {
                 lineGlyphs[legendLabel].glyph.line_width = 1;
             }
         }
         """
-        options = [(user_id, f"{user_id}:{username}") for user_id, username in users]
+        options = [(username, f"{user_id}:{username}") for user_id, username in users]
         multi_choice = MultiChoice(options=options, title="Find User:", width=300)
         multi_choice.js_on_change(
             "value",

--- a/annofabcli/statistics/scatter.py
+++ b/annofabcli/statistics/scatter.py
@@ -31,6 +31,10 @@ def get_color_from_palette(index: int) -> str:
 
 
 class ScatterGraph:
+    DEFAULT_USER_TEXT_FONT_STYLE = "normal"
+
+    DEFAULT_USER_TEXT_FONT_SIZE = ("7pt",)
+
     @staticmethod
     def create_hover_tool(tool_tip_items: list[str]) -> HoverTool:
         """
@@ -153,8 +157,8 @@ class ScatterGraph:
                 # listで渡している理由: https://qiita.com/yuji38kwmt/items/5fad41f6db0090a80af4
                 text=[username],
                 legend_label=legend_label,
-                text_font_style="normal",
-                text_font_size="7pt",
+                text_font_style=self.DEFAULT_USER_TEXT_FONT_STYLE,
+                text_font_size=self.DEFAULT_USER_TEXT_FONT_SIZE,
             )
 
     def plot_bubble(
@@ -209,8 +213,8 @@ class ScatterGraph:
                 # listで渡している理由: https://qiita.com/yuji38kwmt/items/5fad41f6db0090a80af4
                 text=[username],
                 legend_label=legend_label,
-                text_font_style="normal",
-                text_font_size="7pt",
+                text_font_style=self.DEFAULT_USER_TEXT_FONT_STYLE,
+                text_font_size=self.DEFAULT_USER_TEXT_FONT_SIZE,
                 text_align="center",
                 text_baseline="middle",
                 muted_alpha=0.2,
@@ -270,11 +274,12 @@ class ScatterGraph:
                 textGlyphs[userId].glyph.text_font_style='bold';
                 textGlyphs[userId].glyph.text_font_size='11pt';
             } else {
-                textGlyphs[userId].glyph.text_font_style='normal';
-                textGlyphs[userId].glyph.text_font_size='7pt';
+                textGlyphs[userId].glyph.text_font_style=%s;
+                textGlyphs[userId].glyph.text_font_size=%s;
             }
         }
         """
+        code = code % (self.DEFAULT_USER_TEXT_FONT_STYLE, self.DEFAULT_USER_TEXT_FONT_SIZE)
         options = [(user_id, f"{user_id}:{username}") for user_id, username in users]
         multi_choice = MultiChoice(options=options, title="Find User:", width=300)
         multi_choice.js_on_change(

--- a/annofabcli/statistics/scatter.py
+++ b/annofabcli/statistics/scatter.py
@@ -33,7 +33,7 @@ def get_color_from_palette(index: int) -> str:
 class ScatterGraph:
     DEFAULT_USER_TEXT_FONT_STYLE = "normal"
 
-    DEFAULT_USER_TEXT_FONT_SIZE = ("7pt",)
+    DEFAULT_USER_TEXT_FONT_SIZE = "7pt"
 
     @staticmethod
     def create_hover_tool(tool_tip_items: list[str]) -> HoverTool:
@@ -274,8 +274,8 @@ class ScatterGraph:
                 textGlyphs[userId].glyph.text_font_style='bold';
                 textGlyphs[userId].glyph.text_font_size='11pt';
             } else {
-                textGlyphs[userId].glyph.text_font_style=%s;
-                textGlyphs[userId].glyph.text_font_size=%s;
+                textGlyphs[userId].glyph.text_font_style='%s';
+                textGlyphs[userId].glyph.text_font_size='%s';
             }
         }
         """

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -71,13 +71,13 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
 
         return True
 
-    def _plot(  # noqa: ANN202
+    def _plot(
         self,
         line_graph_list: list[LineGraph],
         columns_list: list[tuple[str, str]],
         user_id_list: list[str],
         output_file: Path,
-    ):
+    ) -> None:
         """
         折れ線グラフを、HTMLファイルに出力します。
 
@@ -106,6 +106,8 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
         required_columns = get_required_columns()
 
         line_count = 0
+        ploted_users: list[tuple[str, str]] = []
+
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df[f"first_{self.phase.value}_user_id"] == user_id]
             if df_subset.empty:
@@ -120,6 +122,8 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
             for line_graph, (x_column, y_column) in zip(line_graph_list, columns_list):
                 line_graph.add_line(source, x_column=x_column, y_column=y_column, legend_label=username, color=color)
 
+            ploted_users.append((user_id, username))
+
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
@@ -131,7 +135,9 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
             show_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=False)
             checkbox_group = line_graph.create_checkbox_displaying_markers()
 
-            widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group])
+            multi_choice_widget = line_graph.create_multi_choice_widget_for_searching_user(ploted_users)
+
+            widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group, multi_choice_widget])
             graph_group = bokeh.layouts.row([line_graph.figure, widgets])  # type: ignore[list-item]
             graph_group_list.append(graph_group)
 

--- a/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
@@ -49,7 +49,7 @@ class AbstractPhaseProductivityPerDate(abc.ABC):
         return True
 
     @staticmethod
-    def _plot(line_graph_list: list[LineGraph], output_file: Path) -> None:
+    def _plot(line_graph_list: list[LineGraph], plotted_users: list[tuple[str, str]], output_file: Path) -> None:
         """
         折れ線グラフを、HTMLファイルに出力します。
         """
@@ -66,6 +66,9 @@ class AbstractPhaseProductivityPerDate(abc.ABC):
             if len(line_graph.marker_glyphs) > 0:
                 checkbox_group = line_graph.create_checkbox_displaying_markers()
                 widget_list.append(checkbox_group)
+
+            multi_choice_widget = line_graph.create_multi_choice_widget_for_searching_user(plotted_users)
+            widget_list.append(multi_choice_widget)
 
             widgets = bokeh.layouts.column(widget_list)
             graph_group = bokeh.layouts.row([line_graph.figure, widgets])  # type: ignore[list-item]
@@ -277,6 +280,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
         logger.debug(f"{output_file} を出力します。")
 
         line_count = 0
+        ploted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df["first_annotation_user_id"] == user_id]
             if df_subset.empty:
@@ -315,12 +319,13 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
                         legend_label=username,
                         color=color,
                     )
+            ploted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        self._plot(line_graph_list, output_file)
+        self._plot(line_graph_list, ploted_users, output_file)
 
     def plot_input_data_metrics(  # noqa: ANN201
         self,
@@ -406,6 +411,7 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
 
         line_count = 0
 
+        plotted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df["first_annotation_user_id"] == user_id]
             if df_subset.empty:
@@ -445,12 +451,13 @@ class AnnotatorProductivityPerDate(AbstractPhaseProductivityPerDate):
                         legend_label=username,
                         color=color,
                     )
+            plotted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        self._plot(line_graph_list, output_file)
+        self._plot(line_graph_list, plotted_users, output_file)
 
     def to_csv(self, output_file: Path) -> None:
         if not self._validate_df_for_output(output_file):
@@ -629,6 +636,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
         logger.debug(f"{output_file} を出力します。")
 
         line_count = 0
+        plotted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df["first_inspection_user_id"] == user_id]
             if df_subset.empty:
@@ -663,12 +671,13 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
                         legend_label=username,
                         color=color,
                     )
+            plotted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        self._plot(line_graph_list, output_file)
+        self._plot(line_graph_list, plotted_users, output_file)
 
     def plot_input_data_metrics(  # noqa: ANN201
         self,
@@ -737,6 +746,7 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
         logger.debug(f"{output_file} を出力します。")
 
         line_count = 0
+        plotted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df["first_inspection_user_id"] == user_id]
             if df_subset.empty:
@@ -772,12 +782,13 @@ class InspectorProductivityPerDate(AbstractPhaseProductivityPerDate):
                         legend_label=username,
                         color=color,
                     )
+            plotted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        self._plot(line_graph_list, output_file)
+        self._plot(line_graph_list, plotted_users, output_file)
 
     def to_csv(self, output_file: Path) -> None:
         """
@@ -953,6 +964,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
         logger.debug(f"{output_file} を出力します。")
 
         line_count = 0
+        plotted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df["first_acceptance_user_id"] == user_id]
             if df_subset.empty:
@@ -989,12 +1001,13 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
                         legend_label=username,
                         color=color,
                     )
+            plotted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        self._plot(line_graph_list, output_file)
+        self._plot(line_graph_list, plotted_users, output_file)
 
     def plot_input_data_metrics(  # noqa: ANN201
         self,
@@ -1062,6 +1075,7 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
         logger.debug(f"{output_file} を出力します。")
 
         line_count = 0
+        plotted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df["first_acceptance_user_id"] == user_id]
             if df_subset.empty:
@@ -1097,12 +1111,13 @@ class AcceptorProductivityPerDate(AbstractPhaseProductivityPerDate):
                         legend_label=username,
                         color=color,
                     )
+            plotted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        self._plot(line_graph_list, output_file)
+        self._plot(line_graph_list, plotted_users, output_file)
 
     def to_csv(self, output_file: Path) -> None:
         """

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -437,6 +437,7 @@ class WorktimePerDate:
         df_cumulative.replace(pandas.NA, numpy.nan, inplace=True)
 
         line_count = 0
+        plotted_users: list[tuple[str, str]] = []
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df_cumulative[df_cumulative["user_id"] == user_id]
             if df_subset.empty:
@@ -457,14 +458,17 @@ class WorktimePerDate:
                     color=color,
                 )
 
+            plotted_users.append((user_id, username))
+
         graph_group_list = []
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
             hide_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=True)
             show_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=False)
             checkbox_group = line_graph.create_checkbox_displaying_markers()
+            multi_choice_widget = line_graph.create_multi_choice_widget_for_searching_user(plotted_users)
 
-            widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group])  # type: ignore[list-item]
+            widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group, multi_choice_widget])  # type: ignore[list-item]
             graph_group = bokeh.layouts.row([line_graph.figure, widgets])  # type: ignore[list-item]
             graph_group_list.append(graph_group)
 


### PR DESCRIPTION
ユーザーごとにプロットする折れ線グラフで、ユーザー数が40人以上だと、特定のユーザーの折れ線を探すのに時間がかかる。
そこで、"MultiChoice" widgetを使って、ユーザー情報を入力できるようにした。該当するユーザーの折れ線グラフは太くなるように変更した。