### PR TITLE
`statistics visualize` : tooltipにuser_countを追加

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -753,12 +753,16 @@ class UserPerformance:
             return None
 
     @staticmethod
-    def _get_quartile_value(df: pandas.DataFrame, column: tuple[str, str]) -> Optional[tuple[float, float, float]]:
-        tmp = df[column].describe()
-        if tmp["count"] > 3:
-            return (tmp["25%"], tmp["50%"], tmp["75%"])
-        else:
-            return None
+    def _get_quartile_value(series: pandas.Series) -> tuple[float, float, float]:
+        """
+        四分位数の値を返します。
+
+        Returns:
+            tuple[0]: 25パーセンタイル
+            tuple[1]: 50パーセンタイル
+            tuple[2]: 75パーセンタイル
+        """
+        return tuple(series.quantile([0.25, 0.5, 0.75]))
 
     @staticmethod
     def _create_div_element() -> Div:
@@ -946,9 +950,8 @@ class UserPerformance:
                 average_minute = average_hour * 60
                 scatter_obj.plot_average_line(average_minute, dimension="width")
 
-            quartile = self._get_quartile_value(df, (f"{worktime_type.value}_worktime_minute/{performance_unit.value}", phase))
-            if quartile is not None:
-                scatter_obj.plot_quartile_line(quartile, dimension="width")
+            quartile = self._get_quartile_value(df[(f"{worktime_type.value}_worktime_minute/{performance_unit.value}", phase)])
+            scatter_obj.plot_quartile_line(quartile, dimension="width")
 
             scatter_obj.add_multi_choice_widget_for_searching_user(list(zip(df[("user_id", "")], df[("username", "")])))
             scatter_obj.process_after_adding_glyphs()
@@ -1044,9 +1047,8 @@ class UserPerformance:
             ["rejected_count/task_count", "pointed_out_inspection_comment_count/annotation_count"],
             scatter_obj_list,
         ):
-            quartile = self._get_quartile_value(df, (column, PHASE))
-            if quartile is not None:
-                scatter_obj.plot_quartile_line(quartile, dimension="width")
+            quartile = self._get_quartile_value(df[(column, PHASE)])
+            scatter_obj.plot_quartile_line(quartile, dimension="width")
 
         for scatter_obj in scatter_obj_list:
             scatter_obj.add_multi_choice_widget_for_searching_user(list(zip(df[("user_id", "")], df[("username", "")])))
@@ -1123,16 +1125,14 @@ class UserPerformance:
                 if y_average is not None:
                     scatter_obj.plot_average_line(y_average, dimension="width")
 
-            x_quartile = self._get_quartile_value(df, (f"{worktime_type.value}_worktime_minute/{performance_unit.value}", PHASE))
+            x_quartile = self._get_quartile_value(df[(f"{worktime_type.value}_worktime_minute/{performance_unit.value}", PHASE)])
             for column, scatter_obj in zip(
                 ["rejected_count/task_count", f"pointed_out_inspection_comment_count/{performance_unit.value}"],
                 scatter_obj_list,
             ):
-                if x_quartile is not None:
-                    scatter_obj.plot_quartile_line(x_quartile, dimension="height")
-                y_quartile = self._get_quartile_value(df, (column, PHASE))
-                if y_quartile is not None:
-                    scatter_obj.plot_quartile_line(y_quartile, dimension="width")
+                scatter_obj.plot_quartile_line(x_quartile, dimension="height")
+                y_quartile = self._get_quartile_value(df[(column, PHASE)])
+                scatter_obj.plot_quartile_line(y_quartile, dimension="width")
 
         if not self._validate_df_for_output(output_file):
             return

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -762,6 +762,8 @@ class UserPerformance:
             tuple[1]: 50パーセンタイル
             tuple[2]: 75パーセンタイル
         """
+        # infinityが含まれていると、四分位数がnanになるときがあるので、infinityをnanに置換する
+        series = series.replace({numpy.inf: numpy.nan})
         return tuple(series.quantile([0.25, 0.5, 0.75]))
 
     @staticmethod

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -316,16 +316,9 @@ class WholeProductivityPerCompletedDate:
             """
         )
 
-    def plot(self, output_file: Path):  # noqa: ANN201
+    def plot(self, output_file: Path) -> None:
         """
         全体の生産量や生産性をプロットする
-
-
-        Args:
-            df:
-
-        Returns:
-
         """
 
         def add_velocity_columns(df: pandas.DataFrame):  # noqa: ANN202
@@ -377,12 +370,7 @@ class WholeProductivityPerCompletedDate:
             line_graph = create_line_graph(
                 title="日ごとのタスク数と作業時間",
                 y_axis_label="タスク数",
-                tooltip_columns=[
-                    "date",
-                    "task_count",
-                    "actual_worktime_hour",
-                    "monitored_worktime_hour",
-                ],
+                tooltip_columns=["date", "task_count", "actual_worktime_hour", "monitored_worktime_hour", "working_user_count"],
             )
             line_graph.add_secondary_y_axis(
                 "作業時間[hour]",
@@ -429,12 +417,7 @@ class WholeProductivityPerCompletedDate:
             line_graph = create_line_graph(
                 title="日ごとの入力データ数と作業時間",
                 y_axis_label="入力データ数",
-                tooltip_columns=[
-                    "date",
-                    "input_data_count",
-                    "actual_worktime_hour",
-                    "monitored_worktime_hour",
-                ],
+                tooltip_columns=["date", "input_data_count", "actual_worktime_hour", "monitored_worktime_hour", "working_user_count"],
             )
             line_graph.add_secondary_y_axis(
                 "作業時間[hour]",
@@ -511,6 +494,7 @@ class WholeProductivityPerCompletedDate:
                         "monitored_annotation_worktime_hour",
                         "monitored_inspection_worktime_hour",
                         "monitored_acceptance_worktime_hour",
+                        "working_user_count",
                     ],
                 ),
                 "y_info_list": [{"column": f"{e[0]}_hour", "legend": f"{e[1]}"} for e in phase_prefix],
@@ -612,6 +596,7 @@ class WholeProductivityPerCompletedDate:
                     "task_count",
                     "actual_worktime_hour",
                     "monitored_worktime_hour",
+                    "working_user_count",
                     "cumsum_task_count",
                     "cumsum_actual_worktime_hour",
                     "cumsum_monitored_worktime_hour",
@@ -667,6 +652,7 @@ class WholeProductivityPerCompletedDate:
                     "input_data_count",
                     "actual_worktime_hour",
                     "monitored_worktime_hour",
+                    "working_user_count",
                     "cumsum_input_data_count",
                     "cumsum_actual_worktime_hour",
                     "cumsum_monitored_worktime_hour",
@@ -722,6 +708,7 @@ class WholeProductivityPerCompletedDate:
                     "monitored_annotation_worktime_hour",
                     "monitored_inspection_worktime_hour",
                     "monitored_acceptance_worktime_hour",
+                    "working_user_count",
                     "cumsum_actual_worktime_hour",
                     "cumsum_monitored_worktime_hour",
                     "cumsum_monitored_annotation_worktime_hour",


### PR DESCRIPTION
### tooltipに情報を追加
以下の折れ線グラフのtooltipに`working_user_count`を追加しました。
* `折れ線-横軸_日-全体.html`
* `累積折れ線-横軸_日-全体.html`
「X日の作業時間が40時間」だったときに、「何人が作業しているから50時間だった」というざっくりとした情報を把握できるようにするためです。

### 散布図に表示する四分位数の算出方法を変更
生産性などの指標にinfが含まれている場合、四分位数を求める際にnumpyのRuntimeWarningが発生します。

```
RuntimeWarning: invalid value encountered in multiply
  lerp_interpolation = asanyarray(add(a, diff_b_a * t, out=out))
```

infが含まれていてもRuntimeWarningが発生しないようにするため、infを除いて四分位数を求めるようにしました。