### PR TITLE
Ruffの`T20` (flake8-print)を有効にする

### DIFF
--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -239,7 +239,7 @@ class ChangeAttributesOfAnnotation(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -278,17 +278,17 @@ class ChangeAttributesOfAnnotation(CommandLine):
         try:
             annotation_query = self.get_annotation_query_for_api(args.annotation_query, annotation_specs)
         except ValueError as e:
-            print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。 :: {e}", file=sys.stderr)
+            print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。 :: {e}", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         try:
             attributes = self.get_attributes_for_api(args.attributes, annotation_specs, label_id=annotation_query.label_id)
         except ValueError as e:
-            print(f"{self.COMMON_MESSAGE} argument '--attributes' の値が不正です。 :: {e}", file=sys.stderr)
+            print(f"{self.COMMON_MESSAGE} argument '--attributes' の値が不正です。 :: {e}", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         if args.backup is None:
-            print(
+            print(  # noqa: T201
                 "間違えてアノテーションを変更してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。",
                 file=sys.stderr,
             )

--- a/annofabcli/annotation/change_annotation_properties.py
+++ b/annofabcli/annotation/change_annotation_properties.py
@@ -291,7 +291,7 @@ class ChangePropertiesOfAnnotation(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -315,7 +315,7 @@ class ChangePropertiesOfAnnotation(CommandLine):
                 annotation_query_for_cli = AnnotationQueryForCLI.from_dict(dict_annotation_query)
                 annotation_query = annotation_query_for_cli.to_query_for_api(annotation_specs)
             except ValueError as e:
-                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)  # noqa: T201
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
         else:
             annotation_query = None
@@ -324,7 +324,7 @@ class ChangePropertiesOfAnnotation(CommandLine):
         properties_for_cli = AnnotationDetailForCli.from_dict(properties_of_dict)
 
         if args.backup is None:
-            print(
+            print(  # noqa: T201
                 "間違えてアノテーションを変更してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。",
                 file=sys.stderr,
             )

--- a/annofabcli/annotation/change_annotation_properties.py
+++ b/annofabcli/annotation/change_annotation_properties.py
@@ -130,7 +130,7 @@ class ChangePropertiesOfAnnotationMain(CommandLineWithConfirm):
         annotation_list = self.service.wrapper.get_all_annotation_list(self.project_id, query_params={"query": dict_query})
         return annotation_list
 
-    def change_properties_for_task(  # pylint: disable=too-many-return-statements  # noqa: PLR0911, PLR0912
+    def change_properties_for_task(  # pylint: disable=too-many-return-statements  # noqa: PLR0911
         self,
         task_id: str,
         properties: AnnotationDetailForCli,

--- a/annofabcli/annotation/copy_annotation.py
+++ b/annofabcli/annotation/copy_annotation.py
@@ -335,7 +335,7 @@ class CopyAnnotation(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -353,7 +353,7 @@ class CopyAnnotation(CommandLine):
 
         copy_target_list = get_copy_target_list(str_copy_target_list)
         if len(str_copy_target_list) != len(copy_target_list):
-            print(f"{self.COMMON_MESSAGE} argument '--input' の値が不正です。", file=sys.stderr)
+            print(f"{self.COMMON_MESSAGE} argument '--input' の値が不正です。", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         main_obj = CopyAnnotationMain(

--- a/annofabcli/annotation/delete_annotation.py
+++ b/annofabcli/annotation/delete_annotation.py
@@ -181,13 +181,13 @@ class DeleteAnnotation(CommandLine):
                 annotation_query_for_cli = AnnotationQueryForCLI.from_dict(dict_annotation_query)
                 annotation_query = annotation_query_for_cli.to_query_for_api(annotation_specs)
             except ValueError as e:
-                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)  # noqa: T201
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
         else:
             annotation_query = None
 
         if args.backup is None:
-            print(
+            print(  # noqa: T201
                 "間違えてアノテーションを削除してしまっときに復元できるようにするため、'--backup'でバックアップ用のディレクトリを指定することを推奨します。",
                 file=sys.stderr,
             )

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -542,18 +542,18 @@ class ImportAnnotation(CommandLine):
         COMMON_MESSAGE = "annofabcli annotation import: error:"
         annotation_path = Path(args.annotation)
         if not annotation_path.exists():
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリが存在しません。'{annotation_path!s}'",
                 file=sys.stderr,
             )
             return False
 
         elif not (zipfile.is_zipfile(str(annotation_path)) or annotation_path.is_dir()):
-            print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)
+            print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
             return False
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/annotation/list_annotation.py
+++ b/annofabcli/annotation/list_annotation.py
@@ -166,7 +166,7 @@ class ListAnnotation(CommandLine):
                 annotation_query_for_cli = AnnotationQueryForCLI.from_dict(dict_annotation_query)
                 annotation_query = annotation_query_for_cli.to_query_for_api(annotation_specs)
             except ValueError as e:
-                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)  # noqa: T201
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
         else:
             annotation_query = None

--- a/annofabcli/annotation/list_annotation_count.py
+++ b/annofabcli/annotation/list_annotation_count.py
@@ -64,7 +64,7 @@ class ListAnnotationCount(CommandLine):
                 annotation_query_for_cli = AnnotationQueryForCLI.from_dict(dict_annotation_query)
                 annotation_query = annotation_query_for_cli.to_query_for_api(annotation_specs)
             except ValueError as e:
-                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument '--annotation_query' の値が不正です。{e}", file=sys.stderr)  # noqa: T201
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
         else:
             annotation_query = None

--- a/annofabcli/annotation/restore_annotation.py
+++ b/annofabcli/annotation/restore_annotation.py
@@ -266,7 +266,7 @@ class RestoreAnnotation(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/annotation_specs/export_annotation_specs.py
+++ b/annofabcli/annotation_specs/export_annotation_specs.py
@@ -52,7 +52,7 @@ class ListAttributeRestriction(CommandLine):
         if args.before is not None:
             history_id = self.get_history_id_from_before_index(args.project_id, args.before)
             if history_id is None:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --before: 最新より{args.before}個前のアノテーション仕様は見つかりませんでした。",
                     file=sys.stderr,
                 )

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -106,7 +106,7 @@ class PrintAnnotationSpecsLabel(CommandLine):
         if args.before is not None:
             history_id = self.get_history_id_from_before_index(args.project_id, args.before)
             if history_id is None:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --before: 最新より{args.before}個前のアノテーション仕様は見つかりませんでした。",
                     file=sys.stderr,
                 )

--- a/annofabcli/annotation_specs/list_attribute_restriction.py
+++ b/annofabcli/annotation_specs/list_attribute_restriction.py
@@ -239,7 +239,7 @@ class ListAttributeRestriction(CommandLine):
         if args.before is not None:
             history_id = self.get_history_id_from_before_index(args.project_id, args.before)
             if history_id is None:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --before: 最新より{args.before}個前のアノテーション仕様は見つかりませんでした。",
                     file=sys.stderr,
                 )

--- a/annofabcli/comment/delete_comment.py
+++ b/annofabcli/comment/delete_comment.py
@@ -210,7 +210,7 @@ class DeleteComment(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/comment/put_inspection_comment.py
+++ b/annofabcli/comment/put_inspection_comment.py
@@ -27,7 +27,7 @@ class PutInspectionComment(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/comment/put_inspection_comment_simply.py
+++ b/annofabcli/comment/put_inspection_comment_simply.py
@@ -27,7 +27,7 @@ class PutInspectionCommentSimply(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -60,7 +60,7 @@ class PutInspectionCommentSimply(CommandLine):
                         "_type": "Custom",
                     }
                 else:
-                    print(
+                    print(  # noqa: T201
                         f"{self.COMMON_MESSAGE}: カスタムプロジェクト（ビルトインのエディタプラグインを使用していない）に検査コメントを付与する場合は、'--comment_data' または '--custom_project_type'を指定してください。",  # noqa: E501
                         file=sys.stderr,
                     )

--- a/annofabcli/comment/put_onhold_comment.py
+++ b/annofabcli/comment/put_onhold_comment.py
@@ -25,7 +25,7 @@ class PutInspectionComment(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/comment/put_onhold_comment_simply.py
+++ b/annofabcli/comment/put_onhold_comment_simply.py
@@ -25,7 +25,7 @@ class PutOnholdCommentSimply(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/common/utils.py
+++ b/annofabcli/common/utils.py
@@ -59,7 +59,7 @@ def output_string(target: str, output: Optional[Union[str, Path]] = None) -> Non
         output: 出力先。Noneなら標準出力に出力する。
     """
     if output is None:
-        print(target)
+        print(target)  # noqa: T201
     else:
         p_output = output if isinstance(output, Path) else Path(output)
         p_output.parent.mkdir(parents=True, exist_ok=True)

--- a/annofabcli/filesystem/draw_annotation.py
+++ b/annofabcli/filesystem/draw_annotation.py
@@ -298,21 +298,21 @@ class DrawAnnotation(CommandLineWithoutWebapi):
         if args.default_image_size is not None:
             default_image_size = annofabcli.common.cli.get_input_data_size(args.default_image_size)
             if default_image_size is None:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument '--default_image_size': フォーマットが不正です。",
                     file=sys.stderr,
                 )
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         if args.default_image_size is None and args.input_data_id_csv is None:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} '--default_image_size'または'--input_data_id_csv'のいずれかは必須です。",
                 file=sys.stderr,
             )
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         if args.image_dir is None and args.input_data_id_csv is not None:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument '--image_dir': '--input_data_id_csv'を指定したときは必須です。",
                 file=sys.stderr,
             )

--- a/annofabcli/filesystem/filter_annotation.py
+++ b/annofabcli/filesystem/filter_annotation.py
@@ -158,7 +158,7 @@ class FilterAnnotation:
         elif annotation_path.is_dir():
             self.filter_annotation_dir(annotation_path, filter_query=filter_query, output_dir=output_dir)
         else:
-            print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)
+            print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
 

--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -201,7 +201,7 @@ class MergeAnnotation(CommandLineWithoutWebapi):
             annotation_paths: List[Path] = args.annotation
             for path in annotation_paths:
                 if not path.exists():
-                    print(
+                    print(  # noqa: T201
                         f"{COMMON_MESSAGE} argument --annotation: ファイルパス '{path}' が存在しません。",
                         file=sys.stderr,
                     )

--- a/annofabcli/input_data/change_input_data_name.py
+++ b/annofabcli/input_data/change_input_data_name.py
@@ -159,7 +159,7 @@ class ChangeInputDataName(CommandLine):
         COMMON_MESSAGE = "annofabcli input_data change_name: error:"
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず ``--yes`` を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/input_data/list_input_data_merged_task.py
+++ b/annofabcli/input_data/list_input_data_merged_task.py
@@ -116,14 +116,14 @@ class ListInputDataMergedTask(CommandLine):
     def validate(args: argparse.Namespace) -> bool:
         COMMON_MESSAGE = "annofabcli input_data list_merged_task: error:"
         if args.project_id is None and (args.input_data_json is None or args.task_json is None):
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} '--project_id' か、'--task_json'/'--input_data_json'ペアのいずれかを指定する必要があります。",
                 file=sys.stderr,
             )
             return False
 
         if (args.input_data_json is None and args.task_json is not None) or (args.input_data_json is not None and args.task_json is None):
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} '--task_json'と'--input_data_json'の両方を指定する必要があります。",
                 file=sys.stderr,
             )

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -314,12 +314,12 @@ class PutInputData(CommandLine):
     def validate(self, args: argparse.Namespace) -> bool:
         if args.csv is not None:
             if not Path(args.csv).exists():
-                print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
                 return False
 
         if args.csv is not None or args.json is not None:
             if args.parallelism is not None and not args.yes:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                     file=sys.stderr,
                 )
@@ -339,7 +339,7 @@ class PutInputData(CommandLine):
             df = read_input_data_csv(args.csv)
             is_duplicated = is_duplicated_input_data(df)
             if not args.allow_duplicated_input_data and is_duplicated:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --csv: '{args.csv}' に記載されている'input_data_name'または'input_data_path'が重複しているため、入力データを登録しません。"  # noqa: E501
                     f"重複している状態で入力データを登録する際は、'--allow_duplicated_input_data'を指定してください。",
                     file=sys.stderr,
@@ -355,7 +355,7 @@ class PutInputData(CommandLine):
             self.put_input_data_list(project_id, input_data_list=input_data_list, overwrite=args.overwrite, parallelism=args.parallelism)
 
         else:
-            print("引数が不正です。", file=sys.stderr)
+            print("引数が不正です。", file=sys.stderr)  # noqa: T201
 
 
 def main(args: argparse.Namespace) -> None:

--- a/annofabcli/input_data/put_input_data_with_zip.py
+++ b/annofabcli/input_data/put_input_data_with_zip.py
@@ -83,11 +83,11 @@ class PutInputData(CommandLine):
     def validate(self, args: argparse.Namespace) -> bool:
         if args.zip is not None:
             if not Path(args.zip).exists():
-                print(f"{self.COMMON_MESSAGE} argument --zip: ファイルパスが存在しません。 '{args.zip}'", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument --zip: ファイルパスが存在しません。 '{args.zip}'", file=sys.stderr)  # noqa: T201
                 return False
 
             if not zipfile.is_zipfile(args.zip):
-                print(f"{self.COMMON_MESSAGE} argument --zip: zipファイルではありません。 '{args.zip}'", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument --zip: zipファイルではありません。 '{args.zip}'", file=sys.stderr)  # noqa: T201
                 return False
 
         return True
@@ -110,7 +110,7 @@ class PutInputData(CommandLine):
             )
 
         else:
-            print("引数が不正です。", file=sys.stderr)
+            print("引数が不正です。", file=sys.stderr)  # noqa: T201
 
 
 def main(args: argparse.Namespace) -> None:

--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -114,7 +114,7 @@ class UpdateMetadata(CommandLine):
         COMMON_MESSAGE = "annofabcli input_data update_metadata: error:"
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず ``--yes`` を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/instruction/download_instruction.py
+++ b/annofabcli/instruction/download_instruction.py
@@ -133,7 +133,7 @@ class DownloadInstruction(CommandLine):
         if args.before is not None:
             history_id = self.get_history_id_from_before_index(args.project_id, args.before)
             if history_id is None:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --before: 最新より{args.before}個前のアノテーション仕様は見つかりませんでした。",
                     file=sys.stderr,
                 )

--- a/annofabcli/job/list_last_job.py
+++ b/annofabcli/job/list_last_job.py
@@ -117,7 +117,7 @@ class ListLastJob(CommandLine):
             project_id_list = annofabcli.common.cli.get_list_from_args(args.project_id)
 
         else:
-            print("引数に`--project_id` または `--organization` を指定してください。", file=sys.stderr)
+            print("引数に`--project_id` または `--organization` を指定してください。", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         self.print_job_list(project_id_list, job_type=job_type, add_details=args.add_details)

--- a/annofabcli/project/diff_projects.py
+++ b/annofabcli/project/diff_projects.py
@@ -377,7 +377,7 @@ class DiffProjects(CommandLine):
 
         diff_targets = {DiffTarget(e) for e in args.target}
         _, diff_message = self.diff(project_id1, project_id2, diff_targets)
-        print(diff_message)
+        print(diff_message)  # noqa: T201
 
 
 def parse_args(parser: argparse.ArgumentParser) -> None:

--- a/annofabcli/project_member/change_project_members.py
+++ b/annofabcli/project_member/change_project_members.py
@@ -129,11 +129,11 @@ class ChangeProjectMembers(CommandLine):
     def validate(args: argparse.Namespace, member_info: Optional[Dict[str, Any]] = None) -> bool:
         COMMON_MESSAGE = "annofabcli project_member change: error:"
         if args.role is None and args.member_info is None:
-            print(f"{COMMON_MESSAGE} argument `--role`または`--member_info`のどちらかは、必ず指定してください。", file=sys.stderr)
+            print(f"{COMMON_MESSAGE} argument `--role`または`--member_info`のどちらかは、必ず指定してください。", file=sys.stderr)  # noqa: T201
             return False
 
         elif member_info is not None and not ChangeProjectMembers.validate_member_info(member_info):
-            print(f"{COMMON_MESSAGE} argument --member_info: 有効なキーが１つも指定されていません。", file=sys.stderr)
+            print(f"{COMMON_MESSAGE} argument --member_info: 有効なキーが１つも指定されていません。", file=sys.stderr)  # noqa: T201
             return False
 
         else:

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -221,7 +221,7 @@ def merge_visualization_dir(  # pylint: disable=too-many-statements  # noqa: ANN
 def validate(args: argparse.Namespace) -> bool:
     COMMON_MESSAGE = "annofabcli stat_visualization merge:"
     if len(args.dir) < 2:
-        print(f"{COMMON_MESSAGE} argument --dir: マージ対象のディレクトリは2つ以上指定してください。", file=sys.stderr)
+        print(f"{COMMON_MESSAGE} argument --dir: マージ対象のディレクトリは2つ以上指定してください。", file=sys.stderr)  # noqa: T201
         return False
 
     return True

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -1032,7 +1032,7 @@ class ListAnnotationCount(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and args.annotation is None:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -533,7 +533,7 @@ class ListAnnotationDuration(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and args.annotation is None:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/statistics/visualize_annotation_count.py
+++ b/annofabcli/statistics/visualize_annotation_count.py
@@ -319,7 +319,7 @@ class VisualizeAnnotationCount(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and args.annotation is None:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/statistics/visualize_annotation_duration.py
+++ b/annofabcli/statistics/visualize_annotation_duration.py
@@ -281,7 +281,7 @@ class VisualizeAnnotationDuration(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and args.annotation is None:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --project_id: '--annotation'が未指定のときは、'--project_id' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -423,7 +423,7 @@ class VisualizeStatistics(CommandLine):
         COMMON_MESSAGE = "annofabcli statistics visualize: error:"
         if args.start_date is not None and args.end_date is not None:
             if args.start_date > args.end_date:
-                print(
+                print(  # noqa: T201
                     f"{COMMON_MESSAGE} argument `START_DATE <= END_DATE` の関係を満たしていません。",
                     file=sys.stderr,
                 )
@@ -431,7 +431,7 @@ class VisualizeStatistics(CommandLine):
 
         if args.not_download:
             if args.temp_dir is None:
-                print(
+                print(  # noqa: T201
                     f"{COMMON_MESSAGE} argument --not_download: '--not_download'を指定する場合は'--temp_dir'も指定してください。",
                     file=sys.stderr,
                 )

--- a/annofabcli/statistics/visualize_video_duration.py
+++ b/annofabcli/statistics/visualize_video_duration.py
@@ -190,7 +190,7 @@ class VisualizeVideoDuration(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.project_id is None and (args.input_data_json is None or args.task_json is None):
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --project_id: '--input_data_json'または'--task_json'が未指定のときは、'--project_id' を指定してください。",  # noqa: E501
                 file=sys.stderr,
             )
@@ -232,7 +232,7 @@ class VisualizeVideoDuration(CommandLine):
             super().validate_project(project_id, project_member_roles=[ProjectMemberRole.OWNER, ProjectMemberRole.TRAINING_DATA_USER])
             project, _ = self.service.api.get_project(project_id)
             if project["input_data_type"] != InputDataType.MOVIE.value:
-                print(
+                print(  # noqa: T201
                     f"project_id='{project_id}'であるプロジェクトは、動画プロジェクトでないので動画の長さを可視化したファイルを出力できません。終了します。",
                     file=sys.stderr,
                 )

--- a/annofabcli/supplementary/delete_supplementary_data.py
+++ b/annofabcli/supplementary/delete_supplementary_data.py
@@ -215,7 +215,7 @@ class DeleteSupplementaryData(CommandLine):
         COMMON_MESSAGE = "annofabcli supplementary_data put: error:"
         if args.csv is not None:
             if not Path(args.csv).exists():
-                print(f"{COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)
+                print(f"{COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
                 return False
 
         return True

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -314,11 +314,11 @@ class PutSupplementaryData(CommandLine):
     def validate(self, args: argparse.Namespace) -> bool:
         if args.csv is not None:
             if not Path(args.csv).exists():
-                print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)
+                print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
                 return False
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず ``--yes`` を指定してください。",
                 file=sys.stderr,
             )
@@ -339,7 +339,7 @@ class PutSupplementaryData(CommandLine):
         elif args.json is not None:
             supplementary_data_list = self.get_supplementary_data_list_from_dict(get_json_from_args(args.json))
         else:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--csv'または'--json'のいずれかを指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/task/cancel_acceptance.py
+++ b/annofabcli/task/cancel_acceptance.py
@@ -203,7 +203,7 @@ class CancelAcceptance(CommandLine):
     @classmethod
     def validate(cls, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{cls.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -232,7 +232,7 @@ class CancelAcceptance(CommandLine):
             project_member_list = self.service.wrapper.get_all_project_members(args.project_id)
             member = more_itertools.first_true(project_member_list, pred=lambda e: e["user_id"] == assigned_acceptor_user_id)
             if member is None:
-                print(
+                print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --assigned_acceptor_user_id: プロジェクトメンバーに user_id='{assigned_acceptor_user_id}'メンバーは存在しません",  # noqa: E501
                     file=sys.stderr,
                 )

--- a/annofabcli/task/change_operator.py
+++ b/annofabcli/task/change_operator.py
@@ -191,7 +191,7 @@ class ChangeOperator(CommandLine):
         COMMON_MESSAGE = "annofabcli task change_operator: error:"
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず ``--yes`` を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/task/change_status_to_break.py
+++ b/annofabcli/task/change_status_to_break.py
@@ -155,7 +155,7 @@ class ChangeStatusToBreak(CommandLine):
         COMMON_MESSAGE = "annofabcli task change_status_to_break: error:"
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず ``--yes`` を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/task/change_status_to_on_hold.py
+++ b/annofabcli/task/change_status_to_on_hold.py
@@ -243,7 +243,7 @@ class ChangingStatusToOnHold(CommandLine):
         COMMON_MESSAGE = "annofabcli task change_status_to_on_hold: error:"
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、``--yes`` を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/task/complete_tasks.py
+++ b/annofabcli/task/complete_tasks.py
@@ -462,7 +462,7 @@ class CompleteTasks(CommandLine):
                 )
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
                 file=sys.stderr,
             )

--- a/annofabcli/task/copy_tasks.py
+++ b/annofabcli/task/copy_tasks.py
@@ -155,7 +155,7 @@ class CopyTasks(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -172,7 +172,7 @@ class CopyTasks(CommandLine):
         str_copy_target_list = annofabcli.common.cli.get_list_from_args(args.input)
         copy_target_list = get_copy_target_list(str_copy_target_list)
         if len(str_copy_target_list) != len(copy_target_list):
-            print(f"{self.COMMON_MESSAGE} argument '--input' の値が不正です。", file=sys.stderr)
+            print(f"{self.COMMON_MESSAGE} argument '--input' の値が不正です。", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         project_id = args.project_id

--- a/annofabcli/task/list_all_tasks_added_task_history.py
+++ b/annofabcli/task/list_all_tasks_added_task_history.py
@@ -142,7 +142,7 @@ class ListAllTasksAddedTaskHistory(CommandLine):
     def validate(args: argparse.Namespace) -> bool:
         COMMON_MESSAGE = "annofabcli task list_merged_task_history: error:"
         if (args.task_json is None and args.task_history_json is not None) or (args.task_json is not None and args.task_history_json is None):
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} '--task_json'と'--task_history_json'の両方を指定する必要があります。",
                 file=sys.stderr,
             )

--- a/annofabcli/task/reject_tasks.py
+++ b/annofabcli/task/reject_tasks.py
@@ -346,7 +346,7 @@ class RejectTasks(CommandLine):
 
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
                 file=sys.stderr,
             )
@@ -388,7 +388,7 @@ class RejectTasks(CommandLine):
                         "_type": "Custom",
                     }
                 else:
-                    print(
+                    print(  # noqa: T201
                         f"{self.COMMON_MESSAGE}: カスタムプロジェクト（ビルトインのエディタプラグインを使用していない）に検査コメントを付与する場合は、'--comment_data' または '--custom_project_type'を指定してください。",  # noqa: E501
                         file=sys.stderr,
                     )

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -176,7 +176,7 @@ class UpdateMetadataOfTask(CommandLine):
         COMMON_MESSAGE = "annofabcli task update_metadata: error:"
 
         if args.parallelism is not None and not args.yes:
-            print(
+            print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism' を指定するときは、必ず  '--yes'  を指定してください。",
                 file=sys.stderr,
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1906,28 +1906,28 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruff"
-version = "0.4.4"
+version = "0.4.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.4.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:29d44ef5bb6a08e235c8249294fa8d431adc1426bfda99ed493119e6f9ea1bf6"},
-    {file = "ruff-0.4.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c4efe62b5bbb24178c950732ddd40712b878a9b96b1d02b0ff0b08a090cbd891"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c8e2f1e8fc12d07ab521a9005d68a969e167b589cbcaee354cb61e9d9de9c15"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:60ed88b636a463214905c002fa3eaab19795679ed55529f91e488db3fe8976ab"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b90fc5e170fc71c712cc4d9ab0e24ea505c6a9e4ebf346787a67e691dfb72e85"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8e7e6ebc10ef16dcdc77fd5557ee60647512b400e4a60bdc4849468f076f6eef"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9ddb2c494fb79fc208cd15ffe08f32b7682519e067413dbaf5f4b01a6087bcd"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c51c928a14f9f0a871082603e25a1588059b7e08a920f2f9fa7157b5bf08cfe9"},
-    {file = "ruff-0.4.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5eb0a4bfd6400b7d07c09a7725e1a98c3b838be557fee229ac0f84d9aa49c36"},
-    {file = "ruff-0.4.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b1867ee9bf3acc21778dcb293db504692eda5f7a11a6e6cc40890182a9f9e595"},
-    {file = "ruff-0.4.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1aecced1269481ef2894cc495647392a34b0bf3e28ff53ed95a385b13aa45768"},
-    {file = "ruff-0.4.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9da73eb616b3241a307b837f32756dc20a0b07e2bcb694fec73699c93d04a69e"},
-    {file = "ruff-0.4.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:958b4ea5589706a81065e2a776237de2ecc3e763342e5cc8e02a4a4d8a5e6f95"},
-    {file = "ruff-0.4.4-py3-none-win32.whl", hash = "sha256:cb53473849f011bca6e754f2cdf47cafc9c4f4ff4570003a0dad0b9b6890e876"},
-    {file = "ruff-0.4.4-py3-none-win_amd64.whl", hash = "sha256:424e5b72597482543b684c11def82669cc6b395aa8cc69acc1858b5ef3e5daae"},
-    {file = "ruff-0.4.4-py3-none-win_arm64.whl", hash = "sha256:39df0537b47d3b597293edbb95baf54ff5b49589eb7ff41926d8243caa995ea6"},
-    {file = "ruff-0.4.4.tar.gz", hash = "sha256:f87ea42d5cdebdc6a69761a9d0bc83ae9b3b30d0ad78952005ba6568d6c022af"},
+    {file = "ruff-0.4.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ef995583a038cd4a7edf1422c9e19118e2511b8ba0b015861b4abd26ec5367c5"},
+    {file = "ruff-0.4.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:602ebd7ad909eab6e7da65d3c091547781bb06f5f826974a53dbe563d357e53c"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f9ced5cbb7510fd7525448eeb204e0a22cabb6e99a3cb160272262817d49786"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04a80acfc862e0e1630c8b738e70dcca03f350bad9e106968a8108379e12b31f"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be47700ecb004dfa3fd4dcdddf7322d4e632de3c06cd05329d69c45c0280e618"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1ff930d6e05f444090a0139e4e13e1e2e1f02bd51bb4547734823c760c621e79"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f13410aabd3b5776f9c5699f42b37a3a348d65498c4310589bc6e5c548dc8a2f"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0cf5cc02d3ae52dfb0c8a946eb7a1d6ffe4d91846ffc8ce388baa8f627e3bd50"},
+    {file = "ruff-0.4.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea3424793c29906407e3cf417f28fc33f689dacbbadfb52b7e9a809dd535dcef"},
+    {file = "ruff-0.4.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1fa8561489fadf483ffbb091ea94b9c39a00ed63efacd426aae2f197a45e67fc"},
+    {file = "ruff-0.4.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4d5b914818d8047270308fe3e85d9d7f4a31ec86c6475c9f418fbd1624d198e0"},
+    {file = "ruff-0.4.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4f02284335c766678778475e7698b7ab83abaf2f9ff0554a07b6f28df3b5c259"},
+    {file = "ruff-0.4.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3a6a0a4f4b5f54fff7c860010ab3dd81425445e37d35701a965c0248819dde7a"},
+    {file = "ruff-0.4.6-py3-none-win32.whl", hash = "sha256:9018bf59b3aa8ad4fba2b1dc0299a6e4e60a4c3bc62bbeaea222679865453062"},
+    {file = "ruff-0.4.6-py3-none-win_amd64.whl", hash = "sha256:a769ae07ac74ff1a019d6bd529426427c3e30d75bdf1e08bb3d46ac8f417326a"},
+    {file = "ruff-0.4.6-py3-none-win_arm64.whl", hash = "sha256:735a16407a1a8f58e4c5b913ad6102722e80b562dd17acb88887685ff6f20cf6"},
+    {file = "ruff-0.4.6.tar.gz", hash = "sha256:a797a87da50603f71e6d0765282098245aca6e3b94b7c17473115167d8dfb0b7"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ ignore = [
     "RSE", # flake8-raise
     "D", # pydocstyle, Docstringを中途半端にしか書いていないので、除外する
     "C90", # mccabe
-    "T20", # flake8-print
+#    "T20", # flake8-print
     "SLF", #  flake8-self
     "BLE", # flake8-blind-except
     "FBT", # flake8-boolean-trap

--- a/scripts/mask_user_info_for_all_visualization_dir.py
+++ b/scripts/mask_user_info_for_all_visualization_dir.py
@@ -34,7 +34,7 @@ def mask_user_info_for_all_project_dir(project_root_dir: Path, output_dir: Path,
         try:
             execute_mask_user_info_command(project_dir, project_output_dir, remainder_options=remainder_options)
         except Exception:  # pylint: disable=broad-except
-            print(f"'{project_dir}'のユーザのマスク処理に失敗しました。")
+            print(f"'{project_dir}'のユーザのマスク処理に失敗しました。")  # noqa: T201
             traceback.print_exc()
             continue
 

--- a/scripts/mask_user_info_for_rating_performance.py
+++ b/scripts/mask_user_info_for_rating_performance.py
@@ -38,7 +38,7 @@ def mask_user_info_for_dir(root_dir: Path, output_dir: Path, remainder_options: 
             try:
                 execute_mask_user_info_command(root_dir / path, output_dir / path, remainder_options=remainder_options)
             except Exception:  # pylint: disable=broad-except
-                print(f"'{root_dir / path}'のユーザー情報のマスク処理に失敗しました。")
+                print(f"'{root_dir / path}'のユーザー情報のマスク処理に失敗しました。")  # noqa: T201
                 traceback.print_exc()
                 continue
 


### PR DESCRIPTION
デバッグのための`print()`の消し忘れを防ぐため、Ruffの`T20`ルールを有効にした。

https://docs.astral.sh/ruff/rules/#flake8-print-t20