### PR TITLE
Ruffのルール`ISC` (flake8-implicit-str-concat) を有効にしました。

### DIFF
--- a/annofabcli/annotation/change_annotation_properties.py
+++ b/annofabcli/annotation/change_annotation_properties.py
@@ -365,7 +365,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--annotation_query",
         type=str,
         required=False,
-        help="変更対象のアノテーションを検索する条件をJSON形式で指定します。" f"(ex): ``{EXAMPLE_ANNOTATION_QUERY}``",
+        help=f"変更対象のアノテーションを検索する条件をJSON形式で指定します。(ex): ``{EXAMPLE_ANNOTATION_QUERY}``",
     )
 
     EXAMPLE_PROPERTIES = '{"is_protected": true}'

--- a/annofabcli/annotation/delete_annotation.py
+++ b/annofabcli/annotation/delete_annotation.py
@@ -112,7 +112,7 @@ class DeleteAnnotationMain(CommandLineWithConfirm):
             return
 
         task: Task = Task.from_dict(dict_task)
-        logger.info(f"task_id={task.task_id}, phase={task.phase.value}, status={task.status.value}, " f"updated_datetime={task.updated_datetime}")
+        logger.info(f"task_id={task.task_id}, phase={task.phase.value}, status={task.status.value}, updated_datetime={task.updated_datetime}")
 
         if task.status == TaskStatus.WORKING:
             logger.warning(f"task_id={task_id}: タスクが作業中状態のため、スキップします。")
@@ -241,7 +241,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_name = "delete"
     subcommand_help = "アノテーションを削除します。"
     description = (
-        "タスク配下のアノテーションを削除します。" + "ただし、作業中状態のタスクのアノテーションは削除できません。"
+        "タスク配下のアノテーションを削除します。ただし、作業中状態のタスクのアノテーションは削除できません。"
         "間違えてアノテーションを削除したときに復元できるようにするため、 ``--backup`` でバックアップ用のディレクトリを指定することを推奨します。"
     )
     epilog = "オーナロールを持つユーザで実行してください。"

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -400,7 +400,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
                     success_count += 1
             except Exception:  # pylint: disable=broad-except
                 logger.warning(
-                    f"task_id='{parser.task_id}', input_data_id='{parser.input_data_id}' の" f"アノテーションのインポートに失敗しました。",
+                    f"task_id='{parser.task_id}', input_data_id='{parser.input_data_id}' のアノテーションのインポートに失敗しました。",
                     exc_info=True,
                 )
 

--- a/annofabcli/annotation/list_annotation.py
+++ b/annofabcli/annotation/list_annotation.py
@@ -211,7 +211,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-aq",
         "--annotation_query",
         type=str,
-        help="アノテーションの検索クエリをJSON形式で指定します。" " ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
+        help="アノテーションの検索クエリをJSON形式で指定します。 ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
     )
 
     id_group = parser.add_mutually_exclusive_group()
@@ -220,16 +220,14 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-t",
         "--task_id",
         nargs="+",
-        help=("対象のタスクのtask_idを指定します。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
+        help=("対象のタスクのtask_idを指定します。 ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
     )
 
     id_group.add_argument(
         "-i",
         "--input_data_id",
         nargs="+",
-        help=(
-            "対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
-        ),
+        help=("対象の入力データのinput_data_idを指定します。 ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"),
     )
 
     argument_parser.add_format(

--- a/annofabcli/annotation/list_annotation_count.py
+++ b/annofabcli/annotation/list_annotation_count.py
@@ -106,7 +106,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-aq",
         "--annotation_query",
         type=str,
-        help="アノテーションの検索クエリをJSON形式で指定します。" " ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
+        help="アノテーションの検索クエリをJSON形式で指定します。 ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
     )
 
     id_group = parser.add_mutually_exclusive_group()
@@ -115,16 +115,14 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-t",
         "--task_id",
         nargs="+",
-        help=("対象のタスクのtask_idを指定します。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
+        help=("対象のタスクのtask_idを指定します。 ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
     )
 
     id_group.add_argument(
         "-i",
         "--input_data_id",
         nargs="+",
-        help=(
-            "対象の入力データのinput_data_idを指定します。" " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
-        ),
+        help=("対象の入力データのinput_data_idを指定します。 ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"),
     )
 
     parser.add_argument(

--- a/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
@@ -86,7 +86,7 @@ class ReplacingLabelId(CommandLineWithConfirm):
 
             if not self.validate_label_id(label_name_en):
                 logger.warning(
-                    f"label_name_en='{label_name_en}'はlabel_idにできない文字を含むため、" f"label_id='{label_id}'を'{label_name_en}'に変更しません。"
+                    f"label_name_en='{label_name_en}'はlabel_idにできない文字を含むため、label_id='{label_id}'を'{label_name_en}'に変更しません。"
                 )
                 continue
 

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -96,7 +96,7 @@ class PrintAnnotationSpecsLabel(CommandLine):
             return None
         history = histories[-(before + 1)]
         logger.info(
-            f"{history['updated_datetime']}のアノテーション仕様を出力します。" f"history_id={history['history_id']}, comment={history['comment']}"
+            f"{history['updated_datetime']}のアノテーション仕様を出力します。history_id={history['history_id']}, comment={history['comment']}"
         )
         return history["history_id"]
 

--- a/annofabcli/comment/delete_comment.py
+++ b/annofabcli/comment/delete_comment.py
@@ -60,7 +60,7 @@ class DeleteCommentMain(CommandLineWithConfirm):
         for comment_id in comment_ids:
             if comment_id not in old_comment_ids:
                 logger.warning(
-                    f"task_id={task['task_id']}, input_data_id={input_data_id}: " f"comment_id='{comment_id}'のコメントは存在しません。",
+                    f"task_id={task['task_id']}, input_data_id={input_data_id}: comment_id='{comment_id}'のコメントは存在しません。",
                 )
                 continue
             request_body.append(_convert(comment_id))
@@ -127,7 +127,7 @@ class DeleteCommentMain(CommandLineWithConfirm):
             logger.warning(f"{logging_prefix} : task_id='{task_id}' のタスクは存在しないので、スキップします。")
             return 0
 
-        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, status = {task['status']}, phase = {task['phase']}, ")
 
         if not self._can_delete_comment(
             task=task,
@@ -151,12 +151,10 @@ class DeleteCommentMain(CommandLineWithConfirm):
                     self.service.api.batch_update_comments(self.project_id, task_id, input_data_id, request_body=request_body)
                     added_comments_count += 1
                     logger.debug(
-                        f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: " f"{len(request_body)}件のコメントを削除しました。"
+                        f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: {len(request_body)}件のコメントを削除しました。"
                     )
                 else:
-                    logger.warning(
-                        f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: " f"削除できるコメントは存在しませんでした。"
-                    )
+                    logger.warning(f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: 削除できるコメントは存在しませんでした。")
 
             except Exception:  # pylint: disable=broad-except
                 logger.warning(
@@ -249,7 +247,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--json",
         type=str,
         required=True,
-        help=("削除するコメントのcomment_idをJSON形式で指定してください。\n\n" f"(ex) ``{json.dumps(JSON_SAMPLE)}``"),
+        help=(f"削除するコメントのcomment_idをJSON形式で指定してください。\n\n(ex) ``{json.dumps(JSON_SAMPLE)}``"),
     )
 
     parser.add_argument(

--- a/annofabcli/comment/list_all_comment.py
+++ b/annofabcli/comment/list_all_comment.py
@@ -104,15 +104,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_project_id()
     argument_parser.add_task_id(
         required=False,
-        help_message=("対象のタスクのtask_idを指定します。 \n" "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
+        help_message=("対象のタスクのtask_idを指定します。 \n``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。"),
     )
 
     parser.add_argument(
         "--comment_type",
         choices=[CommentType.INSPECTION.value, CommentType.ONHOLD.value],
-        help=(
-            "コメントの種類で絞り込みます。\n\n" f" * {CommentType.INSPECTION.value}: 検査コメント\n" f" * {CommentType.ONHOLD.value}: 保留コメント\n"
-        ),
+        help=(f"コメントの種類で絞り込みます。\n\n * {CommentType.INSPECTION.value}: 検査コメント\n * {CommentType.ONHOLD.value}: 保留コメント\n"),
     )
 
     parser.add_argument(

--- a/annofabcli/comment/list_comment.py
+++ b/annofabcli/comment/list_comment.py
@@ -86,15 +86,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_project_id()
     argument_parser.add_task_id(
         required=True,
-        help_message="対象のタスクのtask_idを指定します。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
+        help_message="対象のタスクのtask_idを指定します。 ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(
         "--comment_type",
         choices=[CommentType.INSPECTION.value, CommentType.ONHOLD.value],
-        help=(
-            "コメントの種類で絞り込みます。\n\n" f" * {CommentType.INSPECTION.value}: 検査コメント\n" f" * {CommentType.ONHOLD.value}: 保留コメント\n"
-        ),
+        help=(f"コメントの種類で絞り込みます。\n\n * {CommentType.INSPECTION.value}: 検査コメント\n * {CommentType.ONHOLD.value}: 保留コメント\n"),
     )
 
     parser.add_argument("--exclude_reply", action="store_true", help="返信コメントを除外します。")

--- a/annofabcli/comment/put_comment.py
+++ b/annofabcli/comment/put_comment.py
@@ -160,7 +160,7 @@ class PutCommentMain(CommandLineWithConfirm):
             logger.warning(f"{logging_prefix} : task_id='{task_id}' のタスクは存在しないので、スキップします。")
             return 0
 
-        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, status = {task['status']}, phase = {task['phase']}, ")
 
         if not self._can_add_comment(
             task=task,
@@ -182,7 +182,7 @@ class PutCommentMain(CommandLineWithConfirm):
                 request_body = self._create_request_body(task=changed_task, input_data_id=input_data_id, comments=comments)
                 self.service.api.batch_update_comments(self.project_id, task_id, input_data_id, request_body=request_body)
                 added_comments_count += 1
-                logger.debug(f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: " f"{len(comments)}件のコメントを付与しました。")
+                logger.debug(f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: {len(comments)}件のコメントを付与しました。")
             except Exception:  # pylint: disable=broad-except
                 logger.warning(
                     f"{logging_prefix} : task_id={task_id}, input_data_id={input_data_id}: コメントの付与に失敗しました。",

--- a/annofabcli/comment/put_comment_simply.py
+++ b/annofabcli/comment/put_comment_simply.py
@@ -124,7 +124,7 @@ class PutCommentSimplyMain(CommandLineWithConfirm):
             logger.warning(f"{logging_prefix} : task_id='{task_id}' のタスクは存在しないので、スキップします。")
             return False
 
-        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, status = {task['status']}, phase = {task['phase']}, ")
 
         if not self._can_add_comment(
             task=task,

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -436,7 +436,7 @@ class ArgumentParser:
         if help_message is None:
             help_message = (
                 "対象の入力データのinput_data_idを指定します。"
-                + " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
+                " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"
             )
 
         self.parser.add_argument("-i", "--input_data_id", type=str, required=required, nargs="+", help=help_message)

--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -85,7 +85,7 @@ def fill_annotation(
         if outer_image is not None:
             draw.bitmap([0, 0], outer_image, fill=color)
         else:
-            logger.warning(f"アノテーション種類が`{data_type}`ですが、`outer_image`がNoneです。 " f"annotation_id={annotation.annotation_id}")
+            logger.warning(f"アノテーション種類が`{data_type}`ですが、`outer_image`がNoneです。 annotation_id={annotation.annotation_id}")
 
     return draw
 
@@ -306,9 +306,7 @@ def write_annotation_images_from_path(
             if original_resolution is not None and (original_resolution.get("width") is not None and original_resolution.get("height") is not None):
                 return original_resolution.get("width"), original_resolution.get("height")
             else:
-                logger.warning(
-                    f"input_data_id={input_data_id}のプロパティ" f"`system_metadata.original_resolution`には画像サイズが設定されていません。"
-                )
+                logger.warning(f"input_data_id={input_data_id}のプロパティ`system_metadata.original_resolution`には画像サイズが設定されていません。")
                 return None
 
         if image_size is not None:

--- a/annofabcli/filesystem/draw_annotation.py
+++ b/annofabcli/filesystem/draw_annotation.py
@@ -266,7 +266,7 @@ def draw_annotation_all(  # noqa: ANN201, PLR0913
         try:
             drawing.main(parser, image_file=image_file, output_file=output_file, image_size=default_image_size)
             logger.debug(
-                f"{success_count+1}件目: {output_file!s} を出力しました。image_file={image_file}, " f"アノテーションJSON={parser.json_file_path}"
+                f"{success_count+1}件目: {output_file!s} を出力しました。image_file={image_file}, アノテーションJSON={parser.json_file_path}"
             )
             success_count += 1
         except Exception:  # pylint: disable=broad-except
@@ -367,7 +367,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--image_dir", type=Path, help="画像が存在するディレクトリを指定してください。\n" "'--input_data_id_csv'を指定したときは必須です。"
+        "--image_dir", type=Path, help="画像が存在するディレクトリを指定してください。\n'--input_data_id_csv'を指定したときは必須です。"
     )
 
     parser.add_argument(
@@ -380,7 +380,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--default_image_size", type=str, help="デフォルトの画像サイズ。 ``--input_data_id_csv`` を指定しないときは必須です。\n" "(例) 1280x720"
+        "--default_image_size", type=str, help="デフォルトの画像サイズ。 ``--input_data_id_csv`` を指定しないときは必須です。\n(例) 1280x720"
     )
 
     LABEL_COLOR_SAMPLE = {"dog": [255, 128, 64], "cat": "blue"}

--- a/annofabcli/filesystem/filter_annotation.py
+++ b/annofabcli/filesystem/filter_annotation.py
@@ -198,30 +198,38 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--input_data_id",
         type=str,
         nargs="+",
-        help="抽出する入力データのinput_data_idを指定してください。"
-        + " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。",
+        help=(
+            "抽出する入力データのinput_data_idを指定してください。"
+            " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。"
+        ),
     )
     id_name_list_group.add_argument(
         "--exclude_input_data_id",
         type=str,
         nargs="+",
-        help="除外する入力データのinput_data_idを指定してください。"
-        + " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。",
+        help=(
+            "除外する入力データのinput_data_idを指定してください。"
+            " ``file://`` を先頭に付けると、input_data_id の一覧が記載されたファイルを指定できます。"
+        ),
     )
 
     id_name_list_group.add_argument(
         "--input_data_name",
         type=str,
         nargs="+",
-        help="抽出する入力データのinput_data_nameを指定してください。"
-        + " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。",
+        help=(
+            "抽出する入力データのinput_data_nameを指定してください。"
+            " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。"
+        ),
     )
     id_name_list_group.add_argument(
         "--exclude_input_data_name",
         type=str,
         nargs="+",
-        help="除外する入力データのinput_data_nameを指定してください。"
-        + " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。",
+        help=(
+            "除外する入力データのinput_data_nameを指定してください。"
+            " ``file://`` を先頭に付けると、input_data_name の一覧が記載されたファイルを指定できます。"
+        ),
     )
 
     parser.add_argument("-o", "--output_dir", type=Path, required=True, help="出力先ディレクトリのパス")

--- a/annofabcli/input_data/change_input_data_name.py
+++ b/annofabcli/input_data/change_input_data_name.py
@@ -55,7 +55,7 @@ class ChangeInputDataNameMain(CommandLineWithConfirm):
             return False
 
         if not self.confirm_processing(
-            f"input_data_id='{input_data_id}' :: " f"input_data_name='{old_input_data['input_data_name']}'を'{new_input_data_name}'に変更しますか？"
+            f"input_data_id='{input_data_id}' :: input_data_name='{old_input_data['input_data_name']}'を'{new_input_data_name}'に変更しますか？"
         ):
             return False
 

--- a/annofabcli/input_data/delete_input_data.py
+++ b/annofabcli/input_data/delete_input_data.py
@@ -53,7 +53,7 @@ class DeleteInputData(CommandLine):
         return deleted_count
 
     def confirm_delete_input_data(self, input_data_id: str, input_data_name: str, used_task_id_list: List[str]) -> bool:
-        message_for_confirm = f"入力データ(input_data_id='{input_data_id}', " f"input_data_name='{input_data_name}') を削除しますか？"
+        message_for_confirm = f"入力データ(input_data_id='{input_data_id}', input_data_name='{input_data_name}') を削除しますか？"
         if len(used_task_id_list) > 0:
             message_for_confirm += f"タスク{used_task_id_list}に使われています。"
         return self.confirm_processing(message_for_confirm)
@@ -97,7 +97,7 @@ class DeleteInputData(CommandLine):
 
         self.service.api.delete_input_data(project_id, input_data_id)
         logger.debug(
-            f"{input_data_index+1!s} 件目: 入力データ(input_data_id='{input_data_id}', " f"input_data_name='{input_data_name}') を削除しました。"
+            f"{input_data_index+1!s} 件目: 入力データ(input_data_id='{input_data_id}', input_data_name='{input_data_name}') を削除しました。"
         )
 
         if delete_supplementary:

--- a/annofabcli/input_data/list_all_input_data.py
+++ b/annofabcli/input_data/list_all_input_data.py
@@ -133,7 +133,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--input_data_id",
         type=str,
         nargs="+",
-        help="対象のinput_data_idを指定します。\n" "``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
+        help="対象のinput_data_idを指定します。\n``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(

--- a/annofabcli/input_data/list_input_data.py
+++ b/annofabcli/input_data/list_input_data.py
@@ -212,7 +212,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--add_details", action="store_true", help="入力データの詳細情報を表示します。以下の列を追加します。\n" "\n" " * parent_task_id_list"
+        "--add_details", action="store_true", help="入力データの詳細情報を表示します。以下の列を追加します。\n\n * parent_task_id_list"
     )
 
     parser.add_argument(

--- a/annofabcli/input_data/list_input_data_merged_task.py
+++ b/annofabcli/input_data/list_input_data_merged_task.py
@@ -210,7 +210,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "-p",
         "--project_id",
         type=str,
-        help="対象のプロジェクトのproject_idを指定してください。" "指定すると、入力データ一覧ファイル、タスク一覧ファイルをダウンロードします。",
+        help="対象のプロジェクトのproject_idを指定してください。指定すると、入力データ一覧ファイル、タスク一覧ファイルをダウンロードします。",
     )
 
     parser.add_argument("-i", "--input_data_id", type=str, nargs="+", help="指定したinput_data_idに完全一致する入力データを絞り込みます。")

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -94,12 +94,12 @@ def is_duplicated_input_data(df: pandas.DataFrame) -> bool:
     df_duplicated_input_data_name = df[df["input_data_name"].duplicated()]
     result = False
     if len(df_duplicated_input_data_name) > 0:
-        logger.warning(f"'input_data_name'が重複しています。\n" f"{df_duplicated_input_data_name['input_data_name'].unique()}")
+        logger.warning(f"'input_data_name'が重複しています。\n{df_duplicated_input_data_name['input_data_name'].unique()}")
         result = True
 
     df_duplicated_input_data_path = df[df["input_data_path"].duplicated()]
     if len(df_duplicated_input_data_path) > 0:
-        logger.warning(f"'input_data_path'が重複しています。\n" f"{df_duplicated_input_data_path['input_data_path'].unique()}")
+        logger.warning(f"'input_data_path'が重複しています。\n{df_duplicated_input_data_path['input_data_path'].unique()}")
         result = True
 
     return result
@@ -211,14 +211,12 @@ class SubPutInputData:
         # 入力データを登録
         try:
             self.put_input_data(project_id, input_data, last_updated_datetime=last_updated_datetime)
-            logger.debug(
-                f"入力データを登録しました。 :: " f"input_data_id='{input_data.input_data_id}', " f"input_data_name='{input_data.input_data_name}'"
-            )
+            logger.debug(f"入力データを登録しました。 :: input_data_id='{input_data.input_data_id}', input_data_name='{input_data.input_data_name}'")
             return True
 
         except requests.exceptions.HTTPError:
             logger.warning(
-                f"入力データの登録に失敗しました。" f"input_data_id='{input_data.input_data_id}', " f"input_data_name='{input_data.input_data_name}'",
+                f"入力データの登録に失敗しました。input_data_id='{input_data.input_data_id}', input_data_name='{input_data.input_data_name}'",
                 exc_info=True,
             )
             return False
@@ -299,13 +297,13 @@ class PutInputData(CommandLine):
         df = pandas.DataFrame(input_data_dict_list)
         df_duplicated_input_data_name = df[df["input_data_name"].duplicated()]
         if len(df_duplicated_input_data_name) > 0:
-            logger.warning(f"`input_data_name`が重複しています。\n" f"{df_duplicated_input_data_name['input_data_name'].unique()}")
+            logger.warning(f"`input_data_name`が重複しています。\n{df_duplicated_input_data_name['input_data_name'].unique()}")
             if not allow_duplicated_input_data:
                 raise RuntimeError("`input_data_name`が重複しています。")
 
         df_duplicated_input_data_path = df[df["input_data_path"].duplicated()]
         if len(df_duplicated_input_data_path) > 0:
-            logger.warning(f"`input_data_path`が重複しています。\n" f"{df_duplicated_input_data_path['input_data_path'].unique()}")
+            logger.warning(f"`input_data_path`が重複しています。\n{df_duplicated_input_data_path['input_data_path'].unique()}")
             if not allow_duplicated_input_data:
                 raise RuntimeError("`input_data_path`が重複しています。")
 

--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -42,7 +42,7 @@ class UpdateMetadataMain(CommandLineWithConfirm):
             logger.warning(f"{logging_prefix} 入力データは存在しないのでスキップします。input_data_id={input_data_id}")
             return False
 
-        logger.debug(f"{logging_prefix} input_data_id={input_data['input_data_id']}, " f"input_data_name={input_data['input_data_name']}")
+        logger.debug(f"{logging_prefix} input_data_id={input_data['input_data_id']}, input_data_name={input_data['input_data_name']}")
         if not self.confirm_processing(f"入力データのメタデータを更新しますか？ input_data_id={input_data['input_data_id']}"):
             return False
 

--- a/annofabcli/instruction/upload_instruction.py
+++ b/annofabcli/instruction/upload_instruction.py
@@ -146,8 +146,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_help = "HTMLファイルを作業ガイドとして登録します。"
     description = (
         "HTMLファイルを作業ガイドとして登録します。"
-        + "img要素のsrc属性がローカルの画像を参照している場合（http, https, dataスキーマが付与されていない）、"
-        "画像もアップロードします。"
+        "img要素のsrc属性がローカルの画像を参照している場合（http, https, dataスキーマが付与されていない）、画像もアップロードします。"
     )
     epilog = "チェッカーまたはオーナロールを持つユーザで実行してください。"
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/job/list_last_job.py
+++ b/annofabcli/job/list_last_job.py
@@ -155,7 +155,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--add_details",
         action="store_true",
-        help="プロジェクトに関する詳細情報を表示します" "（ ``task_last_updated_datetime, annotation_specs_last_updated_datetime`` ）",
+        help="プロジェクトに関する詳細情報を表示します（ ``task_last_updated_datetime, annotation_specs_last_updated_datetime`` ）",
     )
 
     argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)

--- a/annofabcli/project/diff_projects.py
+++ b/annofabcli/project/diff_projects.py
@@ -119,7 +119,7 @@ class DiffProjects(CommandLine):
             diff_result = list(dictdiffer.diff(member1, member2, ignore=ignored_key))
             if len(diff_result) > 0:
                 is_different = True
-                diff_message += f"差分のあるuser_id: {member1['user_id']}\n" f"{pprint.pformat(diff_result)}\n"
+                diff_message += f"差分のあるuser_id: {member1['user_id']}\n{pprint.pformat(diff_result)}\n"
 
         if not is_different:
             logger.info("プロジェクトメンバは同じ")
@@ -184,7 +184,7 @@ class DiffProjects(CommandLine):
             diff_message += "ラベル名(en)が重複しているので、アノテーションラベル情報の差分は確認しません。\n"
 
         if label_names1 != label_names2:
-            diff_message += f"### ラベル名(en)のListに差分あり\n" f"label_names1: {label_names1}\n" f"label_names2: {label_names2}\n"
+            diff_message += f"### ラベル名(en)のListに差分あり\nlabel_names1: {label_names1}\nlabel_names2: {label_names2}\n"
 
             # 両方に存在するlabel_nameのみ確認する
             is_different = True
@@ -206,7 +206,7 @@ class DiffProjects(CommandLine):
             diff_result = list(dictdiffer.diff(create_ignored_label(label1), create_ignored_label(label2)))
             if len(diff_result) > 0:
                 is_different = True
-                diff_message += f"ラベル名(en): {label_name} は差分あり\n" f"{pprint.pformat(diff_result)}\n"
+                diff_message += f"ラベル名(en): {label_name} は差分あり\n{pprint.pformat(diff_result)}\n"
 
             else:
                 logger.debug(f"ラベル名(en): {label_name} は同じ")
@@ -253,7 +253,7 @@ class DiffProjects(CommandLine):
             diff_result = list(dictdiffer.diff(phrase1, phrase2))
             if len(diff_result) > 0:
                 is_different = True
-                diff_message += f"定型指摘に: {phrase1['id']} は差分あり\n" f"{pprint.pformat(diff_result)}\n"
+                diff_message += f"定型指摘に: {phrase1['id']} は差分あり\n{pprint.pformat(diff_result)}\n"
 
         if not is_different:
             logger.info("定型指摘は同じ")
@@ -320,7 +320,7 @@ class DiffProjects(CommandLine):
 
         diff_result = list(dictdiffer.diff(config1, config2))
         if len(diff_result) > 0:
-            diff_message += f"### プロジェクト設定に差分あり\n" f"{pprint.pformat(diff_result)}\n"
+            diff_message += f"### プロジェクト設定に差分あり\n{pprint.pformat(diff_result)}\n"
             return True, diff_message
         else:
             logger.info("プロジェクト設定は同じ")
@@ -367,7 +367,7 @@ class DiffProjects(CommandLine):
             diff_message += message
 
         if is_different:
-            diff_message = f"!!! {self.project_title1}({project_id1}) と " f"{self.project_title2}({project_id2}) に差分あり\n" + diff_message
+            diff_message = f"!!! {self.project_title1}({project_id1}) と {self.project_title2}({project_id2}) に差分あり\n" + diff_message
         return is_different, diff_message
 
     def main(self) -> None:

--- a/annofabcli/project_member/change_project_members.py
+++ b/annofabcli/project_member/change_project_members.py
@@ -179,7 +179,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--user_id",
         type=str,
         nargs="+",
-        help="変更するプロジェクトメンバのuser_idを指定してください。" " ``file://`` を先頭に付けると、一覧が記載されたファイルを指定できます。",
+        help="変更するプロジェクトメンバのuser_idを指定してください。 ``file://`` を先頭に付けると、一覧が記載されたファイルを指定できます。",
     )
     user_group.add_argument("--all_user", action="store_true", help="自分以外のすべてのプロジェクトメンバを変更します。")
 

--- a/annofabcli/project_member/drop_project_members.py
+++ b/annofabcli/project_member/drop_project_members.py
@@ -64,7 +64,7 @@ class DropProjectMembersMain:
         for project_id in project_id_list:
             try:
                 if not self.facade.my_role_is_owner(project_id):
-                    logger.warning(f"オーナではないため、プロジェクトメンバを脱退させられません。" f"project_id = {project_id}")
+                    logger.warning(f"オーナではないため、プロジェクトメンバを脱退させられません。project_id = {project_id}")
                     continue
 
                 self.drop_project_members(project_id, user_id_list)

--- a/annofabcli/project_member/invite_project_members.py
+++ b/annofabcli/project_member/invite_project_members.py
@@ -70,7 +70,7 @@ class InviteProjectMemberMain:
         for project_id in project_id_list:
             try:
                 if not self.facade.my_role_is_owner(project_id):
-                    logger.warning(f"オーナではないため、プロジェクトメンバを招待できません。" f"project_id = {project_id}")
+                    logger.warning(f"オーナではないため、プロジェクトメンバを招待できません。project_id = {project_id}")
                     continue
 
                 self.invite_project_members(project_id, user_id_list, member_role)

--- a/annofabcli/project_member/put_project_members.py
+++ b/annofabcli/project_member/put_project_members.py
@@ -95,11 +95,11 @@ class PutProjectMembers(CommandLine):
                 continue
 
             if not self.member_exists(organization_members, member.user_id):
-                logger.warning(f"ユーザ '{member.user_id}' は、" f"'{organization_name}' 組織の組織メンバでないため、登録できませんでした。")
+                logger.warning(f"ユーザ '{member.user_id}' は、'{organization_name}' 組織の組織メンバでないため、登録できませんでした。")
                 continue
 
             message_for_confirm = (
-                f"ユーザ '{member.user_id}'を、{project_title} プロジェクトのメンバに登録しますか？" f"member_role={member.member_role.value}"
+                f"ユーザ '{member.user_id}'を、{project_title} プロジェクトのメンバに登録しますか？member_role={member.member_role.value}"
             )
             if not self.confirm_processing(message_for_confirm):
                 continue
@@ -107,12 +107,12 @@ class PutProjectMembers(CommandLine):
             # メンバを登録
             try:
                 self.invite_project_member(project_id, member, old_project_members)
-                logger.debug(f"user_id = {member.user_id}, member_role = {member.member_role.value} のユーザをプ" f"ロジェクトメンバに登録しました。")
+                logger.debug(f"user_id = {member.user_id}, member_role = {member.member_role.value} のユーザをプロジェクトメンバに登録しました。")
                 count_invite_members += 1
 
             except requests.exceptions.HTTPError as e:
                 logger.warning(e)
-                logger.warning(f"プロジェクトメンバの登録に失敗しました。" f"user_id = {member.user_id}, member_role = {member.member_role.value}")
+                logger.warning(f"プロジェクトメンバの登録に失敗しました。user_id = {member.user_id}, member_role = {member.member_role.value}")
 
         logger.info(f"{project_title} に、{count_invite_members} / {len(members)} 件のプロジェクトメンバを登録しました。")
 
@@ -127,7 +127,7 @@ class PutProjectMembers(CommandLine):
             count_delete_members = 0
             logger.info(f"{project_title} から、{len(deleted_members)} 件のプロジェクトメンバを削除します。")
             for deleted_member in deleted_members:
-                message_for_confirm = f"ユーザ '{deleted_member['user_id']}'を、" f"{project_title} のプロジェクトメンバから削除しますか？"
+                message_for_confirm = f"ユーザ '{deleted_member['user_id']}'を、{project_title} のプロジェクトメンバから削除しますか？"
                 if not self.confirm_processing(message_for_confirm):
                     continue
 
@@ -139,7 +139,7 @@ class PutProjectMembers(CommandLine):
                     logger.warning(e)
                     logger.warning(f"プロジェクトメンバの削除に失敗しました。user_id = '{deleted_member['user_id']}' ")
 
-            logger.info(f"{project_title} から {count_delete_members} / {len(deleted_members)} 件の" f"プロジェクトメンバを削除しました。")
+            logger.info(f"{project_title} から {count_delete_members} / {len(deleted_members)} 件のプロジェクトメンバを削除しました。")
 
     @staticmethod
     def get_members_from_csv(csv_path: Path) -> List[Member]:

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -594,7 +594,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--user_id",
         type=str,
         nargs="+",
-        help="評価対象のユーザのuser_idを指定してください。" " ``file://`` を先頭に付けると、user_idの一覧が記載されたファイルを指定できます。",
+        help="評価対象のユーザのuser_idを指定してください。 ``file://`` を先頭に付けると、user_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(
@@ -659,7 +659,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--threshold_settings",
         type=str,
-        help="JSON形式で、ディレクトリ名ごとに閾値を指定してください。\n" f"(ex) ``{json.dumps(THRESHOLD_SETTINGS_SAMPLE)}``",
+        help=f"JSON形式で、ディレクトリ名ごとに閾値を指定してください。\n(ex) ``{json.dumps(THRESHOLD_SETTINGS_SAMPLE)}``",
     )
 
     parser.add_argument("-o", "--output_dir", required=True, type=Path, help="出力ディレクトリ")

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -1107,7 +1107,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--annotation",
         type=str,
-        help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。",
+        help="アノテーションzip、またはzipを展開したディレクトリを指定します。指定しない場合はAnnofabからダウンロードします。",
     )
 
     parser.add_argument(

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -611,7 +611,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--annotation",
         type=str,
-        help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。",
+        help="アノテーションzip、またはzipを展開したディレクトリを指定します。指定しない場合はAnnofabからダウンロードします。",
     )
 
     parser.add_argument(

--- a/annofabcli/statistics/visualize_annotation_count.py
+++ b/annofabcli/statistics/visualize_annotation_count.py
@@ -93,7 +93,7 @@ def get_only_selective_attribute(columns: list[AttributeValueKey]) -> list[Attri
 
     if len(non_selective_attribute_names) > 0:
         logger.debug(
-            f"以下の属性は値の個数が{SELECTIVE_ATTRIBUTE_VALUE_MAX_COUNT}を超えていたため、集計しません。 :: " f"{non_selective_attribute_names}"
+            f"以下の属性は値の個数が{SELECTIVE_ATTRIBUTE_VALUE_MAX_COUNT}を超えていたため、集計しません。 :: {non_selective_attribute_names}"
         )
 
     return [
@@ -478,7 +478,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--annotation",
         type=str,
         required=False,
-        help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。",
+        help="アノテーションzip、またはzipを展開したディレクトリを指定します。指定しない場合はAnnofabからダウンロードします。",
     )
 
     parser.add_argument(

--- a/annofabcli/statistics/visualize_annotation_duration.py
+++ b/annofabcli/statistics/visualize_annotation_duration.py
@@ -427,7 +427,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--annotation",
         type=str,
         required=False,
-        help="アノテーションzip、またはzipを展開したディレクトリを指定します。" "指定しない場合はAnnofabからダウンロードします。",
+        help="アノテーションzip、またはzipを展開したディレクトリを指定します。指定しない場合はAnnofabからダウンロードします。",
     )
 
     parser.add_argument(

--- a/annofabcli/statistics/visualize_video_duration.py
+++ b/annofabcli/statistics/visualize_video_duration.py
@@ -116,7 +116,7 @@ def plot_video_duration(
 
     layout_list: list[LayoutDOM] = [
         Div(text="<h3>動画の長さの分布</h3>"),
-        PreText(text=f"project_id='{project_id}'\n" f"project_title='{project_title}'"),
+        PreText(text=f"project_id='{project_id}'\nproject_title='{project_title}'"),
         create_figure(
             durations_for_input_data,
             bins=bins,
@@ -298,7 +298,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--task_json",
         type=Path,
         required=False,
-        help="タスク情報が記載されたJSONファイルのパスを指定します。\n" "JSONファイルは ``$ annofabcli task download`` コマンドで取得できます。",
+        help="タスク情報が記載されたJSONファイルのパスを指定します。\nJSONファイルは ``$ annofabcli task download`` コマンドで取得できます。",
     )
 
     parser.add_argument(

--- a/annofabcli/supplementary/list_supplementary_data.py
+++ b/annofabcli/supplementary/list_supplementary_data.py
@@ -93,8 +93,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--input_data_id",
         type=str,
         nargs="+",
-        help="対象の入力データのinput_data_idを指定します。"
-        + " ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。",
+        help=("対象の入力データのinput_data_idを指定します。 ``file://`` を先頭に付けると、input_data_idの一覧が記載されたファイルを指定できます。"),
     )
 
     argument_parser.add_format(choices=[FormatArgument.CSV, FormatArgument.JSON, FormatArgument.PRETTY_JSON], default=FormatArgument.CSV)

--- a/annofabcli/task/cancel_acceptance.py
+++ b/annofabcli/task/cancel_acceptance.py
@@ -73,7 +73,7 @@ class CancelAcceptanceMain(CommandLineWithConfirm):
                 return False
 
             if task["phase"] != TaskPhase.ACCEPTANCE.value or task["status"] != TaskStatus.COMPLETE.value:
-                logger.warning(f"{logging_prefix}: task_id = {task_id} は受入完了でありません。" f"status = {task['status']}, phase={task['phase']}")
+                logger.warning(f"{logging_prefix}: task_id = {task_id} は受入完了でありません。status = {task['status']}, phase={task['phase']}")
                 return False
 
             actual_acceptor: Optional[User] = None
@@ -281,13 +281,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     assign_group.add_argument(
         "--not_assign",
         action="store_true",
-        help="受入を取り消した後のタスクの担当者を未割り当てにします。" "指定しない場合は、最後の受入phaseの担当者が割り当てます。",
+        help="受入を取り消した後のタスクの担当者を未割り当てにします。指定しない場合は、最後の受入phaseの担当者が割り当てます。",
     )
 
     assign_group.add_argument(
         "--assigned_acceptor_user_id",
         type=str,
-        help="受入を取り消した後に割り当てる受入作業者のuser_idを指定します。" "指定しない場合は、最後の受入phaseの担当者が割り当てます。",
+        help="受入を取り消した後に割り当てる受入作業者のuser_idを指定します。指定しない場合は、最後の受入phaseの担当者が割り当てます。",
     )
 
     argument_parser.add_task_query()

--- a/annofabcli/task/complete_tasks.py
+++ b/annofabcli/task/complete_tasks.py
@@ -453,7 +453,7 @@ class CompleteTasks(CommandLine):
         COMMON_MESSAGE = "annofabcli task complete: error:"
         if args.phase == TaskPhase.ANNOTATION.value:
             if args.inspection_status is not None:
-                logger.warning(f"'--phase'に'{TaskPhase.ANNOTATION.value}'を指定しているとき、" f"'--inspection_status'の値は無視されます。")
+                logger.warning(f"'--phase'に'{TaskPhase.ANNOTATION.value}'を指定しているとき、'--inspection_status'の値は無視されます。")
         elif args.phase in [TaskPhase.INSPECTION.value, TaskPhase.ACCEPTANCE.value]:
             if args.reply_comment is not None:
                 logger.warning(

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -182,7 +182,7 @@ class DeleteTaskMain(CommandLineWithConfirm):
             logger.warning(f"{log_prefix} :: タスクは存在しません。")
             return False
 
-        logger.debug(f"{log_prefix} :: status={task['status']}, " f"phase={task['phase']}, updated_datetime={task['updated_datetime']}")
+        logger.debug(f"{log_prefix} :: status={task['status']}, phase={task['phase']}, updated_datetime={task['updated_datetime']}")
 
         if not self._should_delete_task(task, log_prefix, task_query=task_query):
             return False

--- a/annofabcli/task/list_tasks.py
+++ b/annofabcli/task/list_tasks.py
@@ -245,7 +245,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--user_id",
         type=str,
         nargs="+",
-        help="絞り込み対象である担当者のuser_idを指定します。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
+        help="絞り込み対象である担当者のuser_idを指定します。 ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
     )
 
     argument_parser.add_format(

--- a/annofabcli/task/reject_tasks.py
+++ b/annofabcli/task/reject_tasks.py
@@ -213,7 +213,7 @@ class RejectTasksMain(CommandLineWithConfirm):
             logger.warning(f"{logging_prefix} : task_id='{task_id}'のタスクをは存在しないので、スキップします。")
             return False
 
-        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, " f"status = {task['status']}, " f"phase = {task['phase']}, ")
+        logger.debug(f"{logging_prefix} : task_id = {task['task_id']}, status = {task['status']}, phase = {task['phase']}, ")
 
         if not self._can_reject_task(
             task=task,
@@ -454,13 +454,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     assign_group.add_argument(
         "--not_assign",
         action="store_true",
-        help="差し戻したタスクに担当者を割り当てません。" "指定しない場合は、最後のannotation phaseの担当者が割り当てられます。",
+        help="差し戻したタスクに担当者を割り当てません。指定しない場合は、最後のannotation phaseの担当者が割り当てられます。",
     )
 
     assign_group.add_argument(
         "--assigned_annotator_user_id",
         type=str,
-        help="差し戻したタスクに割り当てるユーザのuser_idを指定します。" "指定しない場合は、最後の教師付フェーズの担当者が割り当てられます。",
+        help="差し戻したタスクに割り当てるユーザのuser_idを指定します。指定しない場合は、最後の教師付フェーズの担当者が割り当てられます。",
     )
 
     parser.add_argument("--cancel_acceptance", action="store_true", help="受入完了状態を取り消して、タスクを差し戻します。")

--- a/annofabcli/task_history/list_all_task_history.py
+++ b/annofabcli/task_history/list_all_task_history.py
@@ -134,7 +134,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--task_id",
         type=str,
         nargs="+",
-        help="対象のタスクのtask_idを指定します。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
+        help="対象のタスクのtask_idを指定します。 ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(

--- a/annofabcli/task_history/list_task_history.py
+++ b/annofabcli/task_history/list_task_history.py
@@ -131,7 +131,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--task_id",
         type=str,
         nargs="+",
-        help="対象のタスクのtask_idを指定します。" " ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
+        help="対象のタスクのtask_idを指定します。 ``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
     )
 
     argument_parser.add_format(

--- a/annofabcli/task_history_event/list_all_task_history_event.py
+++ b/annofabcli/task_history_event/list_all_task_history_event.py
@@ -135,7 +135,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--task_id",
         type=str,
         nargs="+",
-        help="対象のタスクのtask_idを指定します。\n" "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
+        help="対象のタスクのtask_idを指定します。\n``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(

--- a/annofabcli/task_history_event/list_worktime.py
+++ b/annofabcli/task_history_event/list_worktime.py
@@ -289,7 +289,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--task_id",
         type=str,
         nargs="+",
-        help="対象のタスクのuser_idを指定します。\n" "``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
+        help="対象のタスクのuser_idを指定します。\n``file://`` を先頭に付けると、task_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(
@@ -297,7 +297,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--user_id",
         type=str,
         nargs="+",
-        help="絞り込み対象のユーザのuser_idを指定します。\n" "``file://`` を先頭に付けると、user_idの一覧が記載されたファイルを指定できます。",
+        help="絞り込み対象のユーザのuser_idを指定します。\n``file://`` を先頭に付けると、user_idの一覧が記載されたファイルを指定できます。",
     )
 
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ ignore = [
     "SIM",#flake8-simplify
     "TCH", # flake8-type-checking
     "PTH", #pathlibを使わないコードが多いので、除外する
-    "ISC", #flake8-implicit-str-concat
+    # "ISC", #flake8-implicit-str-concat
     "N", # pep8-naming
     "PT", # flake8-pytest-style
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,16 +128,17 @@ ignore = [
     "RUF002",# 全角記号など`ambiguous unicode character`も使いたいため
     "RUF003",# 全角記号など`ambiguous unicode character`も使いたいため
     "PLR2004", # magic-value-comparison: listのサイズで判定するときがよくあるため
+    "ISC001", # single-line-implicit-string-concatenation: formatterと競合するので無視する https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
     "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。
     "FIX", # TODOやFIXMEを使うため無視する
     "TD", # TODOコメントの書き方に気にしていないので無視する
+    
 
     # 以下のルールはannofabcliのコードに合っていないので無効化した
     "RSE", # flake8-raise
     "D", # pydocstyle, Docstringを中途半端にしか書いていないので、除外する
     "C90", # mccabe
-#    "T20", # flake8-print
     "SLF", #  flake8-self
     "BLE", # flake8-blind-except
     "FBT", # flake8-boolean-trap
@@ -151,7 +152,6 @@ ignore = [
     "SIM",#flake8-simplify
     "TCH", # flake8-type-checking
     "PTH", #pathlibを使わないコードが多いので、除外する
-    # "ISC", #flake8-implicit-str-concat
     "N", # pep8-naming
     "PT", # flake8-pytest-style
 ]


### PR DESCRIPTION
文字列の連結を見やすくするため、`ISC`ルールを有効にしました。

ただし、以下の警告が出るため、フォーマット後に`ISC001`は無視する設定にしました。

```
warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
```
