### PR TITLE
Ruffのルール`SIM`(flake8-simplify)を有効にする

### DIFF
--- a/annofabcli/__main__.py
+++ b/annofabcli/__main__.py
@@ -69,7 +69,7 @@ def main(arguments: Optional[list[str]] = None) -> None:
     warn_pandas_copy_on_write()
     parser = create_parser()
 
-    if arguments is None:
+    if arguments is None:  # noqa: SIM108
         args = parser.parse_args()
     else:
         args = parser.parse_args(arguments)

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -142,7 +142,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
             logger.warning(f"task_id={task_id}: タスクが作業中状態のため、スキップします。")
             return False
 
-        if not self.is_force:
+        if not self.is_force:  # noqa: SIM102
             if task.status == TaskStatus.COMPLETE:
                 logger.warning(f"task_id={task_id}: タスクが完了状態のため、スキップします。")
                 return False

--- a/annofabcli/annotation/delete_annotation.py
+++ b/annofabcli/annotation/delete_annotation.py
@@ -118,7 +118,7 @@ class DeleteAnnotationMain(CommandLineWithConfirm):
             logger.warning(f"task_id={task_id}: タスクが作業中状態のため、スキップします。")
             return
 
-        if not self.is_force:
+        if not self.is_force:  # noqa: SIM102
             if task.status == TaskStatus.COMPLETE:
                 logger.warning(f"task_id={task_id}: タスクが完了状態のため、スキップします。")
                 return

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -236,7 +236,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
                 else:
                     return str(uuid.uuid4())
 
-        if detail.attributes is not None:
+        if detail.attributes is not None:  # noqa: SIM108
             additional_data_list = self._to_additional_data_list(detail.attributes, label_info)
         else:
             additional_data_list = []
@@ -372,7 +372,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
             return False
 
         old_annotation, _ = self.service.api.get_editor_annotation(self.project_id, task_id, input_data_id)
-        if len(old_annotation["details"]) > 0:
+        if len(old_annotation["details"]) > 0:  # noqa: SIM102
             if not self.is_overwrite and not self.is_merge:
                 logger.debug(
                     f"task_id={task_id}, input_data_id={input_data_id} : "

--- a/annofabcli/annotation_specs/get_annotation_specs_with_attribute_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_attribute_id_replaced.py
@@ -95,7 +95,7 @@ class ReplacingAttributeId(CommandLineWithConfirm):
             attribute_id = attribute["additional_data_definition_id"]
             attribute_name_en = AnnofabApiFacade.get_additional_data_definition_name_en(attribute)
 
-            if target_attribute_names is not None:
+            if target_attribute_names is not None:  # noqa: SIM102
                 if attribute_name_en not in target_attribute_names:
                     continue
 

--- a/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
@@ -51,7 +51,7 @@ class ReplacingChoiceId(CommandLineWithConfirm):
         for attribute in attribute_list:
             attribute_name_en = AnnofabApiFacade.get_additional_data_definition_name_en(attribute)
 
-            if target_attribute_names is not None:
+            if target_attribute_names is not None:  # noqa: SIM102
                 if attribute_name_en not in target_attribute_names:
                     continue
 

--- a/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
@@ -80,7 +80,7 @@ class ReplacingLabelId(CommandLineWithConfirm):
             label_id = label["label_id"]
             label_name_en = AnnofabApiFacade.get_label_name_en(label)
 
-            if target_label_names is not None:
+            if target_label_names is not None:  # noqa: SIM102
                 if label_name_en not in target_label_names:
                     continue
 

--- a/annofabcli/comment/put_comment.py
+++ b/annofabcli/comment/put_comment.py
@@ -124,7 +124,7 @@ class PutCommentMain(CommandLineWithConfirm):
     ) -> bool:
         task_id = task["task_id"]
 
-        if self.comment_type == CommentType.INSPECTION:
+        if self.comment_type == CommentType.INSPECTION:  # noqa: SIM102
             if task["phase"] == TaskPhase.ANNOTATION.value:
                 logger.warning(f"task_id='{task_id}': 教師付フェーズなので、検査コメントを付与できません。")
                 return False

--- a/annofabcli/comment/put_comment_simply.py
+++ b/annofabcli/comment/put_comment_simply.py
@@ -88,7 +88,7 @@ class PutCommentSimplyMain(CommandLineWithConfirm):
     ) -> bool:
         task_id = task["task_id"]
 
-        if self.comment_type == CommentType.INSPECTION:
+        if self.comment_type == CommentType.INSPECTION:  # noqa: SIM102
             if task["phase"] == TaskPhase.ANNOTATION.value:
                 logger.warning(f"task_id='{task_id}': 教師付フェーズなので、検査コメントを付与できません。")
                 return False

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -393,7 +393,7 @@ def prompt_yesnoall(msg: str) -> Tuple[bool, bool]:
     """
     while True:
         choice = input(f"{msg} [y/N/ALL] : ")
-        if choice == "y":
+        if choice == "y":  # noqa: SIM116
             return True, False
 
         elif choice == "N":
@@ -654,10 +654,10 @@ class PrettyHelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaul
         # 不要なデフォルト値（--debug や オプショナルな引数）を表示させないようにする
         # super()._get_help_string の中身を、そのまま持ってきた。
         # https://qiita.com/yuji38kwmt/items/c7c4d487e3188afd781e 参照
-        if "%(default)" not in action.help:
+        if "%(default)" not in action.help:  # noqa: SIM102
             if action.default is not argparse.SUPPRESS:
                 defaulting_nargs = [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
-                if action.option_strings or action.nargs in defaulting_nargs:
+                if action.option_strings or action.nargs in defaulting_nargs:  # noqa: SIM102
                     # 以下の条件だけ、annofabcli独自の設定
                     if action.default is not None and not action.const:
                         help += " (default: %(default)s)"  # noqa: A001

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -122,7 +122,7 @@ def match_annotation_with_task_query(annotation: Dict[str, Any], task_query: Opt
     if task_query.phase is not None and annotation["task_phase"] != task_query.phase.value:
         return False
 
-    if task_query.phase_stage is not None and annotation["task_phase_stage"] != task_query.phase_stage:
+    if task_query.phase_stage is not None and annotation["task_phase_stage"] != task_query.phase_stage:  # noqa: SIM103
         return False
 
     return True
@@ -167,7 +167,7 @@ def match_task_with_query(  # pylint: disable=too-many-return-statements  # noqa
     if task_query.no_user and task.account_id is not None:
         return False
 
-    if task_query.account_id is not None and task.account_id != task_query.account_id:
+    if task_query.account_id is not None and task.account_id != task_query.account_id:  # noqa: SIM103
         return False
 
     return True
@@ -202,7 +202,7 @@ def match_input_data_with_query(  # pylint: disable=too-many-return-statements
     if input_data_query.input_data_name is not None and not match_str(input_data.input_data_name, input_data_query.input_data_name, ignore_case=True):
         return False
 
-    if input_data_query.input_data_path is not None and not match_str(
+    if input_data_query.input_data_path is not None and not match_str(  # noqa: SIM103
         input_data.input_data_path, input_data_query.input_data_path, ignore_case=False
     ):
         return False
@@ -519,7 +519,7 @@ class AnnofabApiFacade:
         project_title = self.get_project_title(project_id)
         logger.info(f"project_title = {project_title}, project_id = {project_id}")
 
-        if project_member_roles is not None:
+        if project_member_roles is not None:  # noqa: SIM102
             if not self.contains_any_project_member_role(project_id, project_member_roles):
                 raise ProjectAuthorizationError(project_title, project_member_roles)
 

--- a/annofabcli/common/utils.py
+++ b/annofabcli/common/utils.py
@@ -223,7 +223,7 @@ def get_cache_dir() -> Path:
 
     """
     cache_home_dir = os.environ.get("XDG_CACHE_HOME")
-    if cache_home_dir is None:
+    if cache_home_dir is None:  # noqa: SIM108
         cache_home_dir_path = Path.home() / ".cache"
     else:
         cache_home_dir_path = Path(cache_home_dir)

--- a/annofabcli/filesystem/draw_annotation.py
+++ b/annofabcli/filesystem/draw_annotation.py
@@ -98,7 +98,7 @@ class DrawingAnnotationForOneImage:
 
         def draw_segmentation(data_uri: str, color: Color):  # noqa: ANN202
             # 外部ファイルを描画する
-            with parser.open_outer_file(data_uri) as f:
+            with parser.open_outer_file(data_uri) as f:  # noqa: SIM117
                 with Image.open(f) as outer_image:
                     draw.bitmap([0, 0], outer_image, fill=color)
 
@@ -198,7 +198,7 @@ def create_is_target_parser_func(
     task_id_set = set(task_ids) if task_ids is not None else None
 
     def is_target_parser(parser: SimpleAnnotationParser) -> bool:
-        if task_id_set is not None and len(task_id_set) > 0:
+        if task_id_set is not None and len(task_id_set) > 0:  # noqa: SIM102
             if parser.task_id not in task_id_set:
                 return False
 
@@ -245,7 +245,7 @@ def draw_annotation_all(  # noqa: ANN201, PLR0913
 
         total_count += 1
         input_data_id = parser.input_data_id
-        if input_data_id_relation_dict is not None:
+        if input_data_id_relation_dict is not None:  # noqa: SIM102
             if input_data_id not in input_data_id_relation_dict:
                 logger.warning(f"input_data_id='{input_data_id}'に対応する画像ファイルのパスが見つかりませんでした。")
                 continue

--- a/annofabcli/filesystem/filter_annotation.py
+++ b/annofabcli/filesystem/filter_annotation.py
@@ -37,15 +37,15 @@ def match_query(  # pylint: disable=too-many-return-statements  # noqa: PLR0911
         return False
 
     # xxx_set は1個のみ指定されていること前提なので、elif を羅列する
-    if filter_query.task_id_set is not None and annotation["task_id"] not in filter_query.task_id_set:
+    if filter_query.task_id_set is not None and annotation["task_id"] not in filter_query.task_id_set:  # noqa: SIM114
         return False
-    elif filter_query.exclude_task_id_set is not None and annotation["task_id"] in filter_query.exclude_task_id_set:
+    elif filter_query.exclude_task_id_set is not None and annotation["task_id"] in filter_query.exclude_task_id_set:  # noqa: SIM114
         return False
-    elif filter_query.input_data_id_set is not None and annotation["input_data_id"] not in filter_query.input_data_id_set:
+    elif filter_query.input_data_id_set is not None and annotation["input_data_id"] not in filter_query.input_data_id_set:  # noqa: SIM114
         return False
-    elif filter_query.exclude_input_data_id_set is not None and annotation["input_data_id"] in filter_query.exclude_input_data_id_set:
+    elif filter_query.exclude_input_data_id_set is not None and annotation["input_data_id"] in filter_query.exclude_input_data_id_set:  # noqa: SIM114
         return False
-    elif filter_query.input_data_name_set is not None and annotation["input_data_name"] not in filter_query.input_data_name_set:
+    elif filter_query.input_data_name_set is not None and annotation["input_data_name"] not in filter_query.input_data_name_set:  # noqa: SIM114
         return False
     elif filter_query.exclude_input_data_name_set is not None and annotation["input_data_name"] in filter_query.exclude_input_data_name_set:
         return False

--- a/annofabcli/filesystem/mask_user_info.py
+++ b/annofabcli/filesystem/mask_user_info.py
@@ -99,7 +99,7 @@ def create_masked_name(name: str) -> str:
 
 
 def get_replaced_user_id_set_from_biography(df: pandas.DataFrame, not_masked_location_set: Optional[Set[str]] = None) -> Set[str]:
-    if not_masked_location_set is None:
+    if not_masked_location_set is None:  # noqa: SIM108
         filtered_df = df
     else:
         filtered_df = df[df["biography"].map(lambda e: e not in not_masked_location_set)]

--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -133,7 +133,7 @@ class MergeAnnotationMain:
         task_id_set = set(task_ids) if task_ids is not None else None
 
         def is_target_parser(parser: SimpleAnnotationParser) -> bool:
-            if task_id_set is not None and len(task_id_set) > 0:
+            if task_id_set is not None and len(task_id_set) > 0:  # noqa: SIM102
                 if parser.task_id not in task_id_set:
                     return False
 

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -200,7 +200,7 @@ class SubPutInputData:
                 return False
 
         file_path = get_file_scheme_path(input_data.input_data_path)
-        if file_path is not None:
+        if file_path is not None:  # noqa: SIM102
             if not Path(file_path).exists():
                 logger.warning(f"{input_data.input_data_path} は存在しません。")
                 return False
@@ -310,12 +310,12 @@ class PutInputData(CommandLine):
         return [CsvInputData.from_dict(e) for e in input_data_dict_list]
 
     def validate(self, args: argparse.Namespace) -> bool:
-        if args.csv is not None:
+        if args.csv is not None:  # noqa: SIM102
             if not Path(args.csv).exists():
                 print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
                 return False
 
-        if args.csv is not None or args.json is not None:
+        if args.csv is not None or args.json is not None:  # noqa: SIM102
             if args.parallelism is not None and not args.yes:
                 print(  # noqa: T201
                     f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",

--- a/annofabcli/instruction/upload_instruction.py
+++ b/annofabcli/instruction/upload_instruction.py
@@ -67,7 +67,7 @@ class UploadInstruction(CommandLine):
             if src_value.startswith("data:"):
                 img_path = save_image_from_data_uri_scheme(src_value, temp_dir=temp_dir)
             else:  # noqa: PLR5501
-                if src_value[0] == "/":
+                if src_value[0] == "/":  # noqa: SIM108
                     img_path = Path(src_value)
                 else:
                     img_path = html_path.parent / src_value
@@ -95,7 +95,7 @@ class UploadInstruction(CommandLine):
                 continue
 
         # body要素があればその中身、なければhtmlファイルの中身をアップロードする
-        if len(pq_html("body")) > 0:
+        if len(pq_html("body")) > 0:  # noqa: SIM108
             html_data = pq_html("body").html()
         else:
             html_data = pq_html.html()
@@ -105,7 +105,7 @@ class UploadInstruction(CommandLine):
 
     def update_instruction(self, project_id: str, html_data: str):  # noqa: ANN201
         histories, _ = self.service.api.get_instruction_history(project_id)
-        if len(histories) > 0:
+        if len(histories) > 0:  # noqa: SIM108
             last_updated_datetime = histories[0]["updated_datetime"]
         else:
             last_updated_datetime = None

--- a/annofabcli/job/list_job.py
+++ b/annofabcli/job/list_job.py
@@ -23,7 +23,7 @@ class ListJob(CommandLine):
         ジョブ一覧を取得する。
         """
 
-        if job_query is not None:
+        if job_query is not None:  # noqa: SIM108
             query_params = copy.deepcopy(job_query)
         else:
             query_params = {}

--- a/annofabcli/project/update_annotation_zip.py
+++ b/annofabcli/project/update_annotation_zip.py
@@ -69,7 +69,7 @@ class SubUpdateAnnotationZip:
         )
         job_status = JobStatus(job["job_status"])
         if job_status == JobStatus.SUCCEEDED:
-            if dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(last_tasks_updated_datetime):
+            if dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(last_tasks_updated_datetime):  # noqa: SIM114
                 return True
 
             elif dateutil.parser.parse(job["updated_datetime"]) < dateutil.parser.parse(annotation_specs_updated_datetime):
@@ -130,7 +130,7 @@ class SubUpdateAnnotationZip:
             logger.warning(f"project_id={project_id}: オーナロールまたはアノテーションユーザロールでないため、アノテーションzipを更新できません。")
             return
 
-        if not force:
+        if not force:  # noqa: SIM108
             should_update = self._should_update_annotation_zip(project_id)
         else:
             should_update = True

--- a/annofabcli/project_member/invite_project_members.py
+++ b/annofabcli/project_member/invite_project_members.py
@@ -42,7 +42,7 @@ class InviteProjectMemberMain:
         # プロジェクトメンバを追加/更新する
         for user_id in user_id_list:
             dest_member = get_project_member(user_id)
-            if dest_member is not None:
+            if dest_member is not None:  # noqa: SIM108
                 last_updated_datetime = dest_member["updated_datetime"]
             else:
                 last_updated_datetime = None

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -146,7 +146,7 @@ class MergingVisualizationFile:
         for project_dir in self.project_dir_list:
             tmp_obj = project_dir.read_worktime_per_date_user()
 
-            if merged_obj is None:
+            if merged_obj is None:  # noqa: SIM108
                 merged_obj = tmp_obj
             else:
                 merged_obj = WorktimePerDate.merge(merged_obj, tmp_obj)

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -295,7 +295,7 @@ class ListAnnotationCounterByInputData:
                 continue
 
             simple_annotation_dict = parser.load_json()
-            if task_query is not None:
+            if task_query is not None:  # noqa: SIM102
                 if not match_annotation_with_task_query(simple_annotation_dict, task_query):
                     continue
 

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -275,7 +275,7 @@ class ListAnnotationDurationByInputData:
                 continue
 
             simple_annotation_dict = parser.load_json()
-            if task_query is not None:
+            if task_query is not None:  # noqa: SIM102
                 if not match_annotation_with_task_query(simple_annotation_dict, task_query):
                     continue
 
@@ -405,7 +405,7 @@ class AnnotationDurationCsvByLabel:
     """
 
     def _value_columns(self, annotation_duration_list: list[AnnotationDuration], prior_label_columns: Optional[list[str]]) -> list[str]:
-        all_attr_key_set = {attr_key for elm in annotation_duration_list for attr_key in elm.annotation_duration_second_by_label.keys()}
+        all_attr_key_set = {attr_key for elm in annotation_duration_list for attr_key in elm.annotation_duration_second_by_label.keys()}  # noqa: SIM118
         if prior_label_columns is not None:
             remaining_columns = sorted(all_attr_key_set - set(prior_label_columns))
             value_columns = prior_label_columns + remaining_columns

--- a/annofabcli/statistics/summarize_task_count.py
+++ b/annofabcli/statistics/summarize_task_count.py
@@ -98,7 +98,7 @@ def create_task_count_summary(task_list: List[Task], number_of_inspections: int)
     """
     for task in task_list:
         status = TaskStatus(task["status"])
-        if status == TaskStatus.COMPLETE:
+        if status == TaskStatus.COMPLETE:  # noqa: SIM108
             step_for_current_phase = sys.maxsize
         else:
             step_for_current_phase = get_step_for_current_phase(task, number_of_inspections)

--- a/annofabcli/statistics/visualization/dataframe/annotation_count.py
+++ b/annofabcli/statistics/visualization/dataframe/annotation_count.py
@@ -61,7 +61,7 @@ class AnnotationCount:
         def get_annotation_count_default(simple_annotation: dict[str, Any]) -> int:
             return len(simple_annotation["details"])
 
-        if get_annotation_count_func is not None:
+        if get_annotation_count_func is not None:  # noqa: SIM108
             get_annotation_count = get_annotation_count_func
         else:
             get_annotation_count = get_annotation_count_default

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -236,7 +236,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -297,7 +297,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -360,7 +360,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -477,7 +477,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -525,7 +525,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -573,7 +573,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -668,7 +668,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -716,7 +716,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list
@@ -762,7 +762,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self.default_user_id_list

--- a/annofabcli/statistics/visualization/dataframe/inspection_comment_count.py
+++ b/annofabcli/statistics/visualization/dataframe/inspection_comment_count.py
@@ -66,7 +66,7 @@ class InspectionCommentCount:
             if comment_node["_type"] != "Root":
                 return False
 
-            if comment_node["status"] != CommentStatus.RESOLVED.value:
+            if comment_node["status"] != CommentStatus.RESOLVED.value:  # noqa: SIM103
                 return False
             return True
 

--- a/annofabcli/statistics/visualization/dataframe/task_history.py
+++ b/annofabcli/statistics/visualization/dataframe/task_history.py
@@ -67,7 +67,7 @@ class TaskHistory:
                 new_task_history["worktime_hour"] = isoduration_to_hour(task_history["accumulated_labor_time_milliseconds"])
                 all_task_history_list.append(new_task_history)
 
-        if len(all_task_history_list) > 0:
+        if len(all_task_history_list) > 0:  # noqa: SIM108
             df = pandas.DataFrame(all_task_history_list)
         else:
             df = cls.empty()

--- a/annofabcli/statistics/visualization/dataframe/whole_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_performance.py
@@ -191,12 +191,12 @@ class WholePerformance:
         # CSVファイル読み込み直後では、数値も文字列として格納されているので、文字列情報以外は数値に変換する
         for key, value in series.items():
             # `first_working_date`など2列目が空欄の場合は、key[1]がnumpy.nanになるため、keyを変換する
-            if isinstance(key[1], float) and numpy.isnan(key[1]):
+            if isinstance(key[1], float) and numpy.isnan(key[1]):  # noqa: SIM108
                 key2 = (key[0], "")
             else:
                 key2 = key
 
-            if key2 in cls.STRING_KEYS:
+            if key2 in cls.STRING_KEYS:  # noqa: SIM108
                 value2 = value
             else:
                 value2 = float(value)

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -288,11 +288,11 @@ class WholeProductivityPerCompletedDate:
         row_list: list[pandas.Series] = []
         for dt in date_range():
             str_date = str(dt.date())
-            if str_date in tmp_df1.index:
+            if str_date in tmp_df1.index:  # noqa: SIM108
                 row1 = tmp_df1.loc[str_date]
             else:
                 row1 = None
-            if str_date in tmp_df2.index:
+            if str_date in tmp_df2.index:  # noqa: SIM108
                 row2 = tmp_df2.loc[str_date]
             else:
                 row2 = None
@@ -1005,11 +1005,11 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         row_list: list[pandas.Series] = []
         for dt in date_range():
             str_date = str(dt.date())
-            if str_date in tmp_df1.index:
+            if str_date in tmp_df1.index:  # noqa: SIM108
                 row1 = tmp_df1.loc[str_date]
             else:
                 row1 = None
-            if str_date in tmp_df2.index:
+            if str_date in tmp_df2.index:  # noqa: SIM108
                 row2 = tmp_df2.loc[str_date]
             else:
                 row2 = None

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -355,7 +355,7 @@ class WorktimePerDate:
 
         logger.debug(f"{output_file} を出力します。")
 
-        if target_user_id_list is not None:
+        if target_user_id_list is not None:  # noqa: SIM108
             user_id_list = target_user_id_list
         else:
             user_id_list = self._get_default_user_id_list()

--- a/annofabcli/statistics/visualization/visualization_source_files.py
+++ b/annofabcli/statistics/visualization/visualization_source_files.py
@@ -172,7 +172,7 @@ class VisualizationSourceFiles:
                 logger.debug(f"{self.logging_prefix}: タスク履歴一覧取得中 {task_index} / {len(task_ids)} 件目")
             sub_task_histories, _ = self.annofab_service.api.get_task_histories(self.project_id, task_id)
             result[task_id] = sub_task_histories
-            task_index += 1
+            task_index += 1  # noqa: SIM113
 
         with self.task_history_json_path.open(mode="w", encoding="utf-8") as f:
             json.dump(result, f)

--- a/annofabcli/statistics/visualize_annotation_count.py
+++ b/annofabcli/statistics/visualize_annotation_count.py
@@ -139,7 +139,7 @@ def plot_label_histogram(
 
     df = create_df()
 
-    if arrange_bin_edge:
+    if arrange_bin_edge:  # noqa: SIM108
         histogram_range = (
             df.min(numeric_only=True).min(),
             df.max(numeric_only=True).max(),
@@ -247,7 +247,7 @@ def plot_attribute_histogram(  # noqa: PLR0915
     df = create_df()
     y_axis_label = _get_y_axis_label(group_by)
 
-    if arrange_bin_edge:
+    if arrange_bin_edge:  # noqa: SIM108
         histogram_range = (
             df.min(numeric_only=True).min(),
             df.max(numeric_only=True).max(),

--- a/annofabcli/statistics/visualize_annotation_duration.py
+++ b/annofabcli/statistics/visualize_annotation_duration.py
@@ -74,7 +74,7 @@ def plot_annotation_duration_histogram_by_label(  # noqa: PLR0915
     """
 
     def create_df() -> pandas.DataFrame:
-        all_label_key_set = {key for c in annotation_duration_list for key in c.annotation_duration_second_by_label.keys()}
+        all_label_key_set = {key for c in annotation_duration_list for key in c.annotation_duration_second_by_label.keys()}  # noqa: SIM118
         if prior_keys is not None:
             remaining_columns = sorted(all_label_key_set - set(prior_keys))
             columns = prior_keys + remaining_columns
@@ -119,7 +119,7 @@ def plot_annotation_duration_histogram_by_label(  # noqa: PLR0915
             )
         df = df[columns]
 
-    if bin_width is not None:
+    if bin_width is not None:  # noqa: SIM102
         if time_unit == TimeUnit.MINUTE:
             bin_width = bin_width / 60
 
@@ -185,7 +185,7 @@ def plot_annotation_duration_histogram_by_attribute(  # noqa: PLR0915
     """
 
     def create_df() -> pandas.DataFrame:
-        all_key_set = {key for c in annotation_duration_list for key in c.annotation_duration_second_by_attribute.keys()}
+        all_key_set = {key for c in annotation_duration_list for key in c.annotation_duration_second_by_attribute.keys()}  # noqa: SIM118
         if prior_keys is not None:
             remaining_columns = list(all_key_set - set(prior_keys))
             remaining_columns_selective_attribute = sorted(get_only_selective_attribute(remaining_columns))
@@ -211,7 +211,7 @@ def plot_annotation_duration_histogram_by_attribute(  # noqa: PLR0915
     df = create_df()
     logger.debug(f"{len(df.columns)}個の属性値ごとのヒストグラムで出力します。")
 
-    if bin_width is not None:
+    if bin_width is not None:  # noqa: SIM102
         if time_unit == TimeUnit.MINUTE:
             bin_width = bin_width / 60
 

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -333,7 +333,7 @@ class VisualizingStatisticsMain:
             df_annotation_count = self.annotation_count.df
             df_annotation_count = df_annotation_count[df_annotation_count["project_id"] == project_id]
             # `annotation_count = None`にする理由：後続の処理でアノテーションZIPからアノテーション数を算出するようにするため
-            if len(df_annotation_count) == 0:
+            if len(df_annotation_count) == 0:  # noqa: SIM108
                 annotation_count = None
             else:
                 annotation_count = AnnotationCount(df_annotation_count)
@@ -421,7 +421,7 @@ class VisualizeStatistics(CommandLine):
     @staticmethod
     def validate(args: argparse.Namespace) -> bool:
         COMMON_MESSAGE = "annofabcli statistics visualize: error:"
-        if args.start_date is not None and args.end_date is not None:
+        if args.start_date is not None and args.end_date is not None:  # noqa: SIM102
             if args.start_date > args.end_date:
                 print(  # noqa: T201
                     f"{COMMON_MESSAGE} argument `START_DATE <= END_DATE` の関係を満たしていません。",
@@ -429,7 +429,7 @@ class VisualizeStatistics(CommandLine):
                 )
                 return False
 
-        if args.not_download:
+        if args.not_download:  # noqa: SIM102
             if args.temp_dir is None:
                 print(  # noqa: T201
                     f"{COMMON_MESSAGE} argument --not_download: '--not_download'を指定する場合は'--temp_dir'も指定してください。",

--- a/annofabcli/supplementary/delete_supplementary_data.py
+++ b/annofabcli/supplementary/delete_supplementary_data.py
@@ -213,7 +213,7 @@ class DeleteSupplementaryData(CommandLine):
     @staticmethod
     def validate(args: argparse.Namespace) -> bool:
         COMMON_MESSAGE = "annofabcli supplementary_data put: error:"
-        if args.csv is not None:
+        if args.csv is not None:  # noqa: SIM102
             if not Path(args.csv).exists():
                 print(f"{COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
                 return False

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -191,7 +191,7 @@ class SubPutSupplementaryData:
 
         file_path = get_file_scheme_path(supplementary_data_path)
         logger.debug(f"csv_supplementary_data='{csv_supplementary_data}'")
-        if file_path is not None:
+        if file_path is not None:  # noqa: SIM102
             if not Path(file_path).exists():
                 logger.warning(f"'{supplementary_data_path}' は存在しません。")
                 return False
@@ -312,7 +312,7 @@ class PutSupplementaryData(CommandLine):
     COMMON_MESSAGE = "annofabcli supplementary_data put: error:"
 
     def validate(self, args: argparse.Namespace) -> bool:
-        if args.csv is not None:
+        if args.csv is not None:  # noqa: SIM102
             if not Path(args.csv).exists():
                 print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
                 return False

--- a/annofabcli/task/change_status_to_on_hold.py
+++ b/annofabcli/task/change_status_to_on_hold.py
@@ -95,7 +95,7 @@ class ChangingStatusToOnHoldMain(CommandLineWithConfirm):
                 )
                 return False
 
-            if not self.confirm_change_status_to_on_hold(task):
+            if not self.confirm_change_status_to_on_hold(task):  # noqa: SIM103
                 return False
 
             return True

--- a/annofabcli/task/complete_tasks.py
+++ b/annofabcli/task/complete_tasks.py
@@ -225,7 +225,7 @@ class CompleteTasksMain(CommandLineWithConfirm):
         unanswered_comment_count_for_task = sum(len(e) for e in unanswered_comment_list_dict.values())
 
         logger.debug(f"{task.task_id}: 未回答の検査コメントが {unanswered_comment_count_for_task} 件あります。")
-        if unanswered_comment_count_for_task > 0:
+        if unanswered_comment_count_for_task > 0:  # noqa: SIM102
             if reply_comment is None:
                 logger.warning(
                     f"{task.task_id}: 未回答の検査コメントに対する返信コメント（'--reply_comment'）が指定されていないので、スキップします。"
@@ -266,7 +266,7 @@ class CompleteTasksMain(CommandLineWithConfirm):
         unprocessed_inspection_count = sum(len(e) for e in unprocessed_inspection_list_dict.values())
 
         logger.debug(f"{task.task_id}: 未処置の検査コメントが {unprocessed_inspection_count} 件あります。")
-        if unprocessed_inspection_count > 0:
+        if unprocessed_inspection_count > 0:  # noqa: SIM102
             if inspection_status is None:
                 logger.warning(
                     f"{task.task_id}: 未処置の検査コメントに対する対応方法（'--inspection_status'）が指定されていないので、スキップします。"
@@ -454,7 +454,7 @@ class CompleteTasks(CommandLine):
         if args.phase == TaskPhase.ANNOTATION.value:
             if args.inspection_status is not None:
                 logger.warning(f"'--phase'に'{TaskPhase.ANNOTATION.value}'を指定しているとき、'--inspection_status'の値は無視されます。")
-        elif args.phase in [TaskPhase.INSPECTION.value, TaskPhase.ACCEPTANCE.value]:
+        elif args.phase in [TaskPhase.INSPECTION.value, TaskPhase.ACCEPTANCE.value]:  # noqa: SIM102
             if args.reply_comment is not None:
                 logger.warning(
                     f"'--phase'に'{TaskPhase.INSPECTION.value}'または'{TaskPhase.ACCEPTANCE.value}'を指定しているとき、"

--- a/annofabcli/task/delete_tasks.py
+++ b/annofabcli/task/delete_tasks.py
@@ -138,7 +138,7 @@ class DeleteTaskMain(CommandLineWithConfirm):
 
         annotation_list = self.get_annotation_list(task_id)
         logger.debug(f"{log_prefix} :: アノテーションが{len(annotation_list)}個付与されています。")
-        if not self.force:
+        if not self.force:  # noqa: SIM102
             if len(annotation_list) > 0:
                 logger.info(
                     f"{log_prefix} :: アノテーションが付与されているため（{len(annotation_list)}個）、タスクの削除をスキップします。"
@@ -150,7 +150,7 @@ class DeleteTaskMain(CommandLineWithConfirm):
             logger.debug(f"{log_prefix} :: `--task_query`の条件にマッチしないため、スキップします。task_query={task_query}")
             return False
 
-        if not self.confirm_delete_task(task_id):
+        if not self.confirm_delete_task(task_id):  # noqa: SIM103
             return False
 
         return True
@@ -172,7 +172,7 @@ class DeleteTaskMain(CommandLineWithConfirm):
             True: タスクを削除した。False: タスクを削除しなかった。
 
         """
-        if task_index is not None:
+        if task_index is not None:  # noqa: SIM108
             log_prefix = f"{task_index+1} 件目, task_id='{task_id}'"
         else:
             log_prefix = f"task_id='{task_id}'"

--- a/annofabcli/task/list_tasks.py
+++ b/annofabcli/task/list_tasks.py
@@ -92,7 +92,7 @@ class ListTasksMain:
         Returns:
             対象の検査コメント一覧
         """
-        if task_query is not None:
+        if task_query is not None:  # noqa: SIM108
             task_query = self._modify_task_query(project_id, task_query)
         else:
             task_query = {}

--- a/annofabcli/task/reject_tasks.py
+++ b/annofabcli/task/reject_tasks.py
@@ -144,7 +144,7 @@ class RejectTasksMain(CommandLineWithConfirm):
             logger.debug(f"task_id = {task_id} : `--task_query`の条件にマッチしないため、スキップします。task_query={task_query}")
             return False
 
-        if not self.confirm_reject_task(task_id, assign_last_annotator=assign_last_annotator, assigned_annotator_user_id=assigned_annotator_user_id):
+        if not self.confirm_reject_task(task_id, assign_last_annotator=assign_last_annotator, assigned_annotator_user_id=assigned_annotator_user_id):  # noqa: SIM103
             return False
 
         return True

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -63,7 +63,7 @@ class UpdateMetadataOfTaskMain(CommandLineWithConfirm):
         if not self.confirm_processing(self.get_confirm_message(task_id, metadata)):
             return False
 
-        if self.is_overwrite_metadata:
+        if self.is_overwrite_metadata:  # noqa: SIM108
             new_metadata = metadata
         else:
             new_metadata = {**task["metadata"], **metadata}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ ignore = [
     "EXE", # flake8-executable
     "ICN", # flake8-import-conventions
     "RET",#flake8-return
-    "SIM",#flake8-simplify
     "TCH", # flake8-type-checking
     "PTH", #pathlibを使わないコードが多いので、除外する
     "N", # pep8-naming
@@ -180,7 +179,8 @@ select = [
     "DTZ",  # flake8-datetimez
     "ANN",  # flake8-annotations
     "E501",  # line-too-long
-    "RUF100"  # unused-noqa
+    "RUF100",  # unused-noqa
+    "SIM",#flake8-simplify
 ]
 
 


### PR DESCRIPTION
分かりやすい記述に気づけるようにするため、Ruffの"flake8-simplify"を有効にしました。

また、以下のルールはバグの発見にもつながるので、有効にしました。
* open-file-with-context-handler 
* return-in-try-except-finally