### PR TITLE
MFAコードを間違えて入力したときに、再度MFAコードを入力できるようにしました。

### DIFF
--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -19,13 +19,12 @@ import requests
 import yaml
 from annofabapi.api import DEFAULT_ENDPOINT_URL
 from annofabapi.exceptions import AnnofabApiException
-from annofabapi.exceptions import MfaEnabledUserExecutionError as AnnofabApiMfaEnabledUserExecutionError
 from annofabapi.models import OrganizationMemberRole, ProjectMemberRole
 from more_itertools import first_true
 
 from annofabcli.common.dataclasses import WaitOptions
 from annofabcli.common.enums import FormatArgument
-from annofabcli.common.exceptions import AnnofabCliException, AuthenticationError, MfaEnabledUserExecutionError
+from annofabcli.common.exceptions import AnnofabCliException, AuthenticationError
 from annofabcli.common.facade import AnnofabApiFacade
 from annofabcli.common.typing import InputDataSize
 from annofabcli.common.utils import (
@@ -68,18 +67,6 @@ def build_annofabapi_resource_and_login(args: argparse.Namespace) -> annofabapi.
         if e.response.status_code == requests.codes.unauthorized:
             raise AuthenticationError(service.api.login_user_id) from e
         raise e  # noqa: TRY201
-
-    except AnnofabApiMfaEnabledUserExecutionError:
-        # 標準入力からMFAコードを入力させる
-        inputted_mfa_code = ""
-        while inputted_mfa_code == "":
-            inputted_mfa_code = input("Enter MFA Code: ")
-
-        try:
-            service.api.login(mfa_code=inputted_mfa_code)
-            return service  # noqa: TRY300
-        except AnnofabApiMfaEnabledUserExecutionError as e:
-            raise MfaEnabledUserExecutionError(service.api.login_user_id) from e
 
 
 def add_parser(

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -318,23 +318,23 @@ def build_annofabapi_resource(args: argparse.Namespace) -> annofabapi.Resource:
     if args.annofab_user_id is not None:
         login_user_id: str = args.annofab_user_id
         if args.annofab_password is not None:
-            return annofabapi.build(login_user_id, args.annofab_password, **kwargs)
+            return annofabapi.build(login_user_id, args.annofab_password, **kwargs)  # type: ignore[arg-type]
         else:
             # コマンドライン引数にパスワードが指定されなければ、標準入力からパスワードを取得する
             login_password = ""
             while login_password == "":
                 login_password = getpass.getpass("Enter Annofab Password: ")
-            return annofabapi.build(login_user_id, login_password, **kwargs)
+            return annofabapi.build(login_user_id, login_password, **kwargs)  # type: ignore[arg-type]
 
     # 環境変数から認証情報を取得する
     try:
-        return annofabapi.build_from_env(**kwargs)
+        return annofabapi.build_from_env(**kwargs)  # type: ignore[arg-type]
     except AnnofabApiException:
         pass
 
     # .netrcファイルから認証情報を取得する
     try:
-        return annofabapi.build_from_netrc(**kwargs)
+        return annofabapi.build_from_netrc(**kwargs)  # type: ignore[arg-type]
     except AnnofabApiException:
         pass
 
@@ -347,7 +347,7 @@ def build_annofabapi_resource(args: argparse.Namespace) -> annofabapi.Resource:
     while login_password == "":
         login_password = getpass.getpass("Enter Annofab Password: ")
 
-    return annofabapi.build(login_user_id, login_password, **kwargs)
+    return annofabapi.build(login_user_id, login_password, **kwargs)  # type: ignore[arg-type]
 
 
 def prompt_yesno(msg: str) -> bool:

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -326,27 +326,28 @@ def build_annofabapi_resource(args: argparse.Namespace) -> annofabapi.Resource:
     if endpoint_url != DEFAULT_ENDPOINT_URL:
         logger.info(f"Annofab WebAPIのエンドポイントURL: {endpoint_url}")
 
+    kwargs = {"endpoint_url": endpoint_url, "input_mfa_code_via_stdin": True}
     # コマンドライン引数からユーザーIDが指定された場合
     if args.annofab_user_id is not None:
         login_user_id: str = args.annofab_user_id
         if args.annofab_password is not None:
-            return annofabapi.build(login_user_id, args.annofab_password, endpoint_url=endpoint_url)
+            return annofabapi.build(login_user_id, args.annofab_password, **kwargs)
         else:
             # コマンドライン引数にパスワードが指定されなければ、標準入力からパスワードを取得する
             login_password = ""
             while login_password == "":
                 login_password = getpass.getpass("Enter Annofab Password: ")
-            return annofabapi.build(login_user_id, login_password, endpoint_url=endpoint_url)
+            return annofabapi.build(login_user_id, login_password, **kwargs)
 
     # 環境変数から認証情報を取得する
     try:
-        return annofabapi.build_from_env(endpoint_url)
+        return annofabapi.build_from_env(**kwargs)
     except AnnofabApiException:
         pass
 
     # .netrcファイルから認証情報を取得する
     try:
-        return annofabapi.build_from_netrc(endpoint_url)
+        return annofabapi.build_from_netrc(**kwargs)
     except AnnofabApiException:
         pass
 
@@ -359,7 +360,7 @@ def build_annofabapi_resource(args: argparse.Namespace) -> annofabapi.Resource:
     while login_password == "":
         login_password = getpass.getpass("Enter Annofab Password: ")
 
-    return annofabapi.build(login_user_id, login_password, endpoint_url=endpoint_url)
+    return annofabapi.build(login_user_id, login_password, **kwargs)
 
 
 def prompt_yesno(msg: str) -> bool:

--- a/annofabcli/common/download.py
+++ b/annofabcli/common/download.py
@@ -61,7 +61,11 @@ class DownloadingFile:
             raise UpdatedFileForDownloadingError(f"{filetype}の更新処理が{max_wait_minutes}分以内に完了しない、または更新処理に失敗しました。")
 
     async def download_annotation_zip_with_async(  # noqa: ANN201
-        self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None  # noqa: FBT001, FBT002
+        self,
+        project_id: str,
+        dest_path: Union[str, Path],
+        is_latest: bool = False,  # noqa: FBT001, FBT002
+        wait_options: Optional[WaitOptions] = None,
     ):
         loop = asyncio.get_event_loop()
         partial_func = partial(self.download_annotation_zip, project_id, dest_path, is_latest, wait_options)
@@ -117,7 +121,11 @@ class DownloadingFile:
         self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_ANNOTATION, wait_options=wait_options, job_id=job_id)
 
     async def download_input_data_json_with_async(  # noqa: ANN201
-        self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None  # noqa: FBT001, FBT002
+        self,
+        project_id: str,
+        dest_path: Union[str, Path],
+        is_latest: bool = False,  # noqa: FBT001, FBT002
+        wait_options: Optional[WaitOptions] = None,
     ):
         loop = asyncio.get_event_loop()
         partial_func = partial(self.download_input_data_json, project_id, dest_path, is_latest, wait_options)
@@ -125,7 +133,11 @@ class DownloadingFile:
         return result
 
     def download_input_data_json(  # noqa: ANN201
-        self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None  # noqa: FBT001, FBT002
+        self,
+        project_id: str,
+        dest_path: Union[str, Path],
+        is_latest: bool = False,  # noqa: FBT001, FBT002
+        wait_options: Optional[WaitOptions] = None,
     ):
         if is_latest:
             self.wait_until_updated_input_data_json(project_id, wait_options)
@@ -159,7 +171,11 @@ class DownloadingFile:
         self._wait_for_completion(project_id, job_type=ProjectJobType.GEN_INPUTS_LIST, wait_options=wait_options, job_id=job_id)
 
     async def download_task_json_with_async(  # noqa: ANN201
-        self, project_id: str, dest_path: Union[str, Path], is_latest: bool = False, wait_options: Optional[WaitOptions] = None  # noqa: FBT001, FBT002
+        self,
+        project_id: str,
+        dest_path: Union[str, Path],
+        is_latest: bool = False,  # noqa: FBT001, FBT002
+        wait_options: Optional[WaitOptions] = None,
     ):
         loop = asyncio.get_event_loop()
         partial_func = partial(self.download_task_json, project_id, dest_path, is_latest, wait_options)

--- a/annofabcli/experimental/list_out_of_range_annotation_for_movie.py
+++ b/annofabcli/experimental/list_out_of_range_annotation_for_movie.py
@@ -121,7 +121,10 @@ class ListOutOfRangeAnnotationForMovieMain:
         return task_list
 
     def list_out_of_range_annotation_for_movie(
-        self, project_id: str, task_id_list: Optional[List[str]], parse_annotation_zip: bool = False  # noqa: FBT001, FBT002
+        self,
+        project_id: str,
+        task_id_list: Optional[List[str]],
+        parse_annotation_zip: bool = False,  # noqa: FBT001, FBT002
     ) -> pandas.DataFrame:
         cache_dir = annofabcli.common.utils.get_cache_dir()
         downloading_obj = DownloadingFile(self.service)

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,13 +42,13 @@ files = [
 
 [[package]]
 name = "annofabapi"
-version = "0.72.4"
+version = "0.73.0"
 description = "Python Clinet Library of Annofab WebAPI (https://annofab.com/docs/api/)"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "<4.0,>=3.8"
 files = [
-    {file = "annofabapi-0.72.4-py3-none-any.whl", hash = "sha256:72107d73285f65fbaa2654a6f739a89b21979943711a3cb9a767e4545f02b7ea"},
-    {file = "annofabapi-0.72.4.tar.gz", hash = "sha256:0950592632b15a5e00a4d94ca7d0209e9108f344e48c466bf2630f2c2b98855e"},
+    {file = "annofabapi-0.73.0-py3-none-any.whl", hash = "sha256:1942ab01548aba769e180ceedab7d289de0e96262024dd2f880f568e30dba421"},
+    {file = "annofabapi-0.73.0.tar.gz", hash = "sha256:77b96dbf0959158944745f9ee88d225b55b7831ff88aecb72dee08a2b1c5fcb4"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ more-itertools = "*"
 jmespath = "*"
 pyquery = "*"
 isodate = "*"
-annofabapi = ">=0.72.4"
+annofabapi = ">=0.73.0"
 python-datauri = "*"
 
 pandas = "^2"


### PR DESCRIPTION
* `annofabapi`の機能を使って、MFAコードを標準入力から入力できるようにしました。
* Ruffの`FBT001`, `FBT002`を`noqa`ディレクティブで無視しました。
