### PR TITLE
sensitiveな情報をログに出力しないようにする

### DIFF
--- a/tests/test____main__.py
+++ b/tests/test____main__.py
@@ -1,0 +1,13 @@
+from annofabcli.__main__ import mask_sensitive_value_in_argv
+
+
+def test__mask_sensitive_value_in_argv():
+    actual = mask_sensitive_value_in_argv(["--annofab_user_id", "alice", "--annofab_password", "pw"])
+    assert actual == ["--annofab_user_id", "***", "--annofab_password", "***"]
+
+
+def test__mask_sensitive_value_in_argv__同じ引数を指定する():
+    actual = mask_sensitive_value_in_argv(
+        ["--annofab_user_id", "alice", "--annofab_password", "pw_alice", "--annofab_user_id", "bob", "--annofab_password", "pw_bob"]
+    )
+    assert actual == ["--annofab_user_id", "***", "--annofab_password", "***", "--annofab_user_id", "***", "--annofab_password", "***"]


### PR DESCRIPTION
### 変更前
`--annofab_password a --annofab_password 2`と複数した場合、1つ目の`a`しかマスクされなかった。

### 変更後
`--annofab_password a --annofab_password 2`は`--annofab_password *** --annofab_password **`と複数マスクされるように変更した。