### PR TITLE
`statistics visualize` : タスクが存在していて一度も作業されていないプロジェクトでエラーが発生

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/whole_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_performance.py
@@ -104,6 +104,11 @@ class WholePerformance:
         all_user_performance = cls._create_all_user_performance(worktime_per_date, task_worktime_by_phase_user)
 
         df_all = all_user_performance.df
+        # タスクは存在するが合計の作業時間が0時間の場合
+        if len(df_all) == 0:
+            return WholePerformance.empty()
+
+        # 1人が作業した場合のパフォーマンス情報を生成しているので、lengthは1のはず
         assert len(df_all) == 1
 
         # 作業している人数をカウントする（実際の計測作業時間でカウントする）


### PR DESCRIPTION
### 変更前

```
$ poetry run annofabcli statistics visualize -p db363f62-405b-424f-99aa-d9dae080aa4f   -o out -tq '{"status":"complete"}' --output_only_text --minimal 

DEBUG    : 2024-06-10 08:49:15,400 : annofabcli.statistics.visualize_statistics : project_id='db363f62-405b-424f-99aa-d9dae080aa4f' :: 集計対象タスクは 0 / 8 件です。
WARNING  : 2024-06-10 08:49:15,410 : annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user : タスク一覧が0件です。
WARNING  : 2024-06-10 08:49:15,414 : annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user : データが0件のため、out/20240610/task-worktime-list-by-user-phase.csv は出力しません。
WARNING  : 2024-06-10 08:49:16,423 : annofabcli.statistics.visualization.dataframe.user_performance : データが0件のため、out/20240610/メンバごとの生産性と品質.csv は出力しません。
WARNING  : 2024-06-10 08:49:16,473 : annofabcli.statistics.visualize_statistics : project_id='db363f62-405b-424f-99aa-d9dae080aa4f'であるプロジェクトでのファイル出力に失敗しました。
Traceback (most recent call last):
  File "/workspaces/annofab-cli/annofabcli/statistics/visualize_statistics.py", line 100, in wrapped
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/annofab-cli/annofabcli/statistics/visualize_statistics.py", line 182, in write_user_performance
    whole_performance = WholePerformance.from_df_wrapper(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/annofab-cli/annofabcli/statistics/visualization/dataframe/whole_performance.py", line 107, in from_df_wrapper
    assert len(df_all) == 1
           ^^^^^^^^^^^^^^^^
AssertionError
WARNING  : 2024-06-10 08:49:16,474 : annofabcli.statistics.visualization.dataframe.worktime_per_date : データが0件のため、out/20240610/ユーザ_日付list-作業時間.csv は出力しません。
```


### 変更後

```
$ poetry run annofabcli statistics visualize -p db363f62-405b-424f-99aa-d9dae080aa4f   -o out -tq '{"status":"complete"}' --output_only_text --minimal 

DEBUG    : 2024-06-10 09:00:03,801 : annofabcli.statistics.visualize_statistics : project_id='db363f62-405b-424f-99aa-d9dae080aa4f' :: 集計対象タスクは 0 / 8 件です。
WARNING  : 2024-06-10 09:00:03,809 : annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user : タスク一覧が0件です。
WARNING  : 2024-06-10 09:00:03,813 : annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user : データが0件のため、out/20240610-1/task-worktime-list-by-user-phase.csv は出力しません。
```

