### PR TITLE
`input_data update_metadata` : 入力データごとにメタデータを指定できるようにしました。

### DIFF
--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -75,7 +75,7 @@ class UpdateMetadataMain(CommandLineWithConfirm):
 
     def set_metadata_to_input_data_wrapper(
         self, tpl: Tuple[int, InputDataMetadataInfo], project_id: str, *, overwrite_metadata: bool = False
-    ) -> None:
+    ) -> bool:
         input_data_index, info = tpl
         return self.set_metadata_to_input_data(
             project_id,
@@ -88,11 +88,12 @@ class UpdateMetadataMain(CommandLineWithConfirm):
     def update_metadata_of_input_data(
         self,
         project_id: str,
-        metadata_info_list: list[InputDataMetadataInfo],
+        metadata_by_input_data_id: dict[str, Metadata],
         *,
         overwrite_metadata: bool = False,
         parallelism: Optional[int] = None,
     ) -> None:
+        metadata_info_list = [InputDataMetadataInfo(input_data_id, metadata) for input_data_id, metadata in metadata_by_input_data_id.items()]
         if overwrite_metadata:
             logger.info(f"{len(metadata_info_list)} 件の入力データのメタデータを変更します（上書き）。")
         else:

--- a/annofabcli/input_data/update_metadata_of_input_data.py
+++ b/annofabcli/input_data/update_metadata_of_input_data.py
@@ -146,6 +146,13 @@ class UpdateMetadata(CommandLine):
             )
             return False
 
+        if args.metadata is not None and args.input_data_id is None:
+            print(  # noqa: T201
+                f"{self.COMMON_MESSAGE} argument --input_data_id: '--metadata' を指定するときは、 '--input_data_id' が必須です。",
+                file=sys.stderr,
+            )
+            return False
+
         return True
 
     def main(self) -> None:

--- a/annofabcli/task/update_metadata_of_task.py
+++ b/annofabcli/task/update_metadata_of_task.py
@@ -38,9 +38,10 @@ class UpdateMetadataOfTaskMain(CommandLineWithConfirm):
     def __init__(
         self,
         service: annofabapi.Resource,
-        is_overwrite_metadata: bool,  # noqa: FBT001
+        *,
+        is_overwrite_metadata: bool,
         parallelism: Optional[int] = None,
-        all_yes: bool = False,  # noqa: FBT001, FBT002
+        all_yes: bool = False,
     ) -> None:
         self.service = service
         self.is_overwrite_metadata = is_overwrite_metadata
@@ -109,7 +110,6 @@ class UpdateMetadataOfTaskMain(CommandLineWithConfirm):
         # 1000件以上の大量のタスクを一度に更新しようとするとwebapiが失敗するので、何回かに分けてメタデータを更新するようにする。
         BATCH_SIZE = 500  # noqa: N806
         first_index = 0
-        # task_id_list = list(task_ids)
 
         metadata_info_list = [TaskMetadataInfo(task_id, metadata) for task_id, metadata in metadata_by_task_id.items()]
 
@@ -248,7 +248,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--metadata_by_task_id",
         type=str,
         help=(
-            "キーがタスクID, 値ががメタデータ( ``--metadata`` 参照)であるオブジェクトをJSON形式で指定してください。\n"
+            "キーがタスクID, 値がメタデータ( ``--metadata`` 参照)であるオブジェクトをJSON形式で指定してください。\n"
             f"(ex) '{json.dumps(sample_metadata_by_task_id)}'\n"
             " ``file://`` を先頭に付けると、JSON形式のファイルを指定できます。"
         ),

--- a/docs/command_reference/input_data/update_metadata.rst
+++ b/docs/command_reference/input_data/update_metadata.rst
@@ -65,6 +65,36 @@ Examples
 
 
 
+.. warning::
+
+    入力データのメタデータを更新すると、入力データの ``updated_datetime`` （更新日時）が更新されます。
+    
+
+
+
+入力データごとにメタデータを指定する
+--------------------------------------
+
+``--metadata_by_input_data_id`` を指定すれば、入力データごとにメタデータを指定できます。
+
+
+.. code-block:: json
+    :caption: all_metadata.json
+    
+    {
+      "input_data1": {"country":"japan"},
+      "input_data2": {"country":"us"}
+    }
+    
+    
+.. code-block::
+
+    $ annofabcli input_data update_metadata --project_id prj1 \
+     --metadata_by_input_data_id file://all_metadata.json
+
+
+
+
 並列処理
 ----------------------------------------------
 


### PR DESCRIPTION
`all_metadata.json`というJSONファイルに対して、以下のコマンドで入力データごとにメタデータを指定できるようにしました。


```
    {
      "input_data1": {"country":"japan"},
      "input_data2": {"country":"us"}
    }
```
    

```
$ annofabcli input_data update_metadata --project_id prj1  --metadata_by_input_data_id file://all_metadata.json
```


