### PR TITLE
`annotation change_attributes`など: `--annotation_query`の`label_id`をオプショナルにしました。

### DIFF
--- a/annofabcli/annotation/annotation_query.py
+++ b/annofabcli/annotation/annotation_query.py
@@ -203,7 +203,7 @@ def convert_attributes_from_cli_to_api(
     return attributes_for_webapi
 
 
-def convert_attributes_from_cli_to_api_v2(
+def convert_attributes_from_cli_to_additional_data_list_v2(
     attributes: dict[str, AttributeValue], annotation_specs: dict[str, Any], *, label_id: Optional[str] = None
 ) -> list[dict[str, Any]]:
     """

--- a/annofabcli/annotation/annotation_query.py
+++ b/annofabcli/annotation/annotation_query.py
@@ -68,7 +68,7 @@ def _get_attribute_to_api(additional_data: dict[str, Any], attribute_value: Attr
             )
         if len(tmp) > 1:
             raise ValueError(
-                f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{attribute_value}'である選択肢が複数（{len(tmp)} 個）存在します。"
+                f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{attribute_value}'である選択肢が複数（{len(tmp)} 個）存在します。"  # noqa: E501
                 f" :: additional_data_definition_id='{additional_data_definition_id}'"
             )
 
@@ -103,7 +103,7 @@ def _get_additional_data_v2(additional_data: dict[str, Any], attribute_value: At
             )
         elif len(tmp) > 1:
             raise ValueError(
-                f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{choice_name_en}'である選択肢が複数（{len(tmp)} 個）存在します。"
+                f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{choice_name_en}'である選択肢が複数（{len(tmp)} 個）存在します。"  # noqa: E501
             )
 
         return tmp[0]["choice_id"]
@@ -282,6 +282,10 @@ class AnnotationQueryForCLI(DataClassJsonMixin):
     属性値がNoneのときは、「未指定」で絞り込む。
     """
 
+    def __post_init__(self) -> None:
+        if self.label is None and self.attributes is None:
+            raise ValueError("'label'か'attributes'のいずれかは'not None'である必要があります。")
+
     def to_query_for_api(self, annotation_specs: dict[str, Any]) -> AnnotationQueryForAPI:
         """
         WebAPIのquery_params( https://annofab.com/docs/api/#section/AnnotationQuery )に渡すdictに変換する。
@@ -320,6 +324,7 @@ class AnnotationQueryForCLI(DataClassJsonMixin):
 class AnnotationQueryForAPI(DataClassJsonMixin):
     """
     WebAPIでアノテーションを絞り込むためのクエリ。
+    https://annofab.com/docs/api/#section/AnnotationQuery に対応しています。
     """
 
     label_id: Optional[str] = None
@@ -327,3 +332,7 @@ class AnnotationQueryForAPI(DataClassJsonMixin):
 
     attributes: Optional[List[AdditionalDataV1]] = None
     """属性IDと属性値のList"""
+
+    def __post_init__(self) -> None:
+        if self.label_id is None and self.attributes is None:
+            raise ValueError("'label_id'か'attributes'のいずれかは'not None'である必要があります。")

--- a/annofabcli/annotation/annotation_query.py
+++ b/annofabcli/annotation/annotation_query.py
@@ -10,6 +10,7 @@ from annofabapi.util.annotation_specs import get_english_message
 from dataclasses_json import DataClassJsonMixin
 
 AttributeValue = Optional[Union[str, int, bool]]
+"""属性値の型情報"""
 
 
 def _get_attribute_to_api(additional_data: dict[str, Any], attribute_value: AttributeValue) -> AdditionalDataV1:
@@ -17,7 +18,7 @@ def _get_attribute_to_api(additional_data: dict[str, Any], attribute_value: Attr
 
     Args:
         additional_data: アノテーション仕様の属性情報
-        attribute_value: 属性値
+        attribute_value: コマンドライン引数から渡された属性値。選択肢属性の場合は、選択肢の英語名になります。
 
     Raises:
         ValueError: 属性が排他選択の場合、属性値に指定された選択肢名の選択肢情報が見つからなかった
@@ -56,16 +57,17 @@ def _get_attribute_to_api(additional_data: dict[str, Any], attribute_value: Attr
         AdditionalDataDefinitionType.SELECT.value,
     ]:
         # 排他選択の場合、属性値に選択肢IDが入っているため、対象の選択肢を探す
+        # TODO コードの処理を確認する
         choice_info = more_itertools.first_true(additional_data["choices"], pred=lambda e: get_english_message(e["name"]) == attribute_value)
         tmp = [e for e in additional_data["choices"] if get_english_message(e["name"]) == attribute_value]
 
         if len(tmp) == 0:
-            raise ValueError(  # noqa: TRY003
+            raise ValueError(
                 f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{attribute_value}'である選択肢は存在しません。"
                 f" :: additional_data_definition_id='{additional_data_definition_id}'"
             )
         if len(tmp) > 1:
-            raise ValueError(  # noqa: TRY003
+            raise ValueError(
                 f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{attribute_value}'である選択肢が複数存在します。"
                 f" :: additional_data_definition_id='{additional_data_definition_id}'"
             )
@@ -76,8 +78,70 @@ def _get_attribute_to_api(additional_data: dict[str, Any], attribute_value: Attr
     return AdditionalDataV1.from_dict(result, infer_missing=True)
 
 
+def _get_additional_data_v2(additional_data: dict[str, Any], attribute_value: AttributeValue) -> dict[str, Any]:
+    """
+    アノテーション仕様の属性情報と属性値から、API用の `AdditionalDataV2` に相当するdictを取得します。
+
+    Args:
+        additional_data: アノテーション仕様の属性情報
+        attribute_value: コマンドライン引数から渡された属性値。選択肢属性の場合は、選択肢の英語名になります。
+
+    Raises:
+        ValueError: 属性が排他選択の場合、属性値に指定された選択肢名の選択肢情報が見つからなかった
+
+    Returns:
+        WebAPI用の属性情報
+    """
+
+    def get_choice_id_from_choice_name_en(choice_name_en: str) -> str:
+        # 排他選択の場合、属性値に選択肢IDが入っているため、対象の選択肢を探す
+        tmp = [e for e in additional_data["choices"] if get_english_message(e["name"]) == choice_name_en]
+
+        if len(tmp) == 0:  # pylint: disable=no-else-raise
+            raise ValueError(
+                f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{choice_name_en}'である選択肢は存在しません。"
+            )
+        elif len(tmp) > 1:
+            raise ValueError(
+                f"アノテーション仕様の'{get_attribute_name(additional_data)}'属性に、選択肢名(英語)が'{choice_name_en}'である選択肢が複数存在します。"
+            )
+
+        return tmp[0]["choice_id"]
+
+    def get_attribute_name(additional_data: dict[str, Any]) -> str:
+        return get_english_message(additional_data["name"])
+
+    additional_data_definition_id = additional_data["additional_data_definition_id"]
+
+    additional_data_type: str = additional_data["type"]
+
+    if additional_data_type == AdditionalDataDefinitionType.FLAG.value:
+        result_value = {"value": attribute_value, "_type": "Flag"}
+    elif additional_data_type == AdditionalDataDefinitionType.INTEGER.value:
+        result_value = {"value": attribute_value, "_type": "Integer"}
+    elif additional_data_type == AdditionalDataDefinitionType.COMMENT.value:
+        result_value = {"value": attribute_value, "_type": "Comment"}
+    elif additional_data_type == AdditionalDataDefinitionType.TEXT.value:
+        result_value = {"value": attribute_value, "_type": "Text"}
+    elif additional_data_type == AdditionalDataDefinitionType.CHOICE.value:
+        assert isinstance(attribute_value, str)
+        result_value = {"choice_id": get_choice_id_from_choice_name_en(attribute_value), "_type": "Choice"}
+    elif additional_data_type == AdditionalDataDefinitionType.SELECT.value:
+        assert isinstance(attribute_value, str)
+        result_value = {"choice_id": get_choice_id_from_choice_name_en(attribute_value), "_type": "Select"}
+    elif additional_data_type == AdditionalDataDefinitionType.TRACKING.value:
+        result_value = {"value": attribute_value, "_type": "Tracking"}
+    elif additional_data_type == AdditionalDataDefinitionType.LINK.value:
+        result_value = {"annotation_id": attribute_value, "_type": "Link"}
+
+    else:
+        raise RuntimeError(f"{additional_data_type=}がサポート対象外です。")
+
+    return {"definition_id": additional_data_definition_id, "value": result_value}
+
+
 def convert_attributes_from_cli_to_api(
-    attributes: dict[str, AttributeValue], annotation_specs: dict[str, Any], label_id: Optional[str] = None
+    attributes: dict[str, AttributeValue], annotation_specs: dict[str, Any], *, label_id: Optional[str] = None
 ) -> list[AdditionalDataV1]:
     """
     CLI用の属性をAPI用の属性に変換します。
@@ -102,7 +166,7 @@ def convert_attributes_from_cli_to_api(
     else:
         label_info = more_itertools.first_true(annotation_specs["labels"], pred=lambda e: e["label_id"] == label_id)
         if label_info is None:
-            raise ValueError(f"アノテーション仕様に、label_id='{label_id}' であるラベルは存在しません。")  # noqa: TRY003
+            raise ValueError(f"アノテーション仕様に、label_id='{label_id}' であるラベルは存在しません。")
 
         tmp_additional_data_definition_ids = set(label_info["additional_data_definitions"])
         tmp_additionals = [e for e in annotation_specs["additionals"] if e["additional_data_definition_id"] in tmp_additional_data_definition_ids]
@@ -137,6 +201,69 @@ def convert_attributes_from_cli_to_api(
         attributes_for_webapi.append(_get_attribute_to_api(additional_data, attribute_value))
 
     return attributes_for_webapi
+
+
+def convert_attributes_from_cli_to_api_v2(
+    attributes: dict[str, AttributeValue], annotation_specs: dict[str, Any], *, label_id: Optional[str] = None
+) -> list[dict[str, Any]]:
+    """
+    CLI用の属性情報をAPI用の `AdditionalDataV2` に相当するdictに変換します。
+
+    Args:
+        attributes: CLI用の属性情報
+        annotation_specs: アノテーション仕様
+        label_id: 指定したlabel_idを持つラベル配下の属性から、属性情報を探します。Noneの場合は、すべての属性から属性情報を探します。
+
+    Raises:
+        ValueError: 指定された属性名や選択肢名の情報が見つからない、または複数見つかった
+
+    Returns:
+        API用の属性情報のList
+    """
+
+    def get_label_name(label_info: dict[str, Any]) -> str:
+        return get_english_message(label_info["label_name"])
+
+    if label_id is None:
+        tmp_additionals = annotation_specs["additionals"]
+    else:
+        label_info = more_itertools.first_true(annotation_specs["labels"], pred=lambda e: e["label_id"] == label_id)
+        if label_info is None:
+            raise ValueError(f"アノテーション仕様に、label_id='{label_id}' であるラベルは存在しません。")
+
+        tmp_additional_data_definition_ids = set(label_info["additional_data_definitions"])
+        tmp_additionals = [e for e in annotation_specs["additionals"] if e["additional_data_definition_id"] in tmp_additional_data_definition_ids]
+
+    result = []
+    for attribute_name, attribute_value in attributes.items():
+        additional_data = more_itertools.first_true(
+            tmp_additionals,
+            pred=lambda e: get_english_message(e["name"]) == attribute_name,  # noqa: B023  # pylint: disable=cell-var-from-loop
+        )
+        tmp = [e for e in tmp_additionals if get_english_message(e["name"]) == attribute_name]
+        if len(tmp) == 0:  # pylint: disable=no-else-raise
+            if label_info is None:
+                error_message = f"アノテーション仕様に、属性名(英語)が'{attribute_name}'である属性は存在しません。"
+            else:
+                error_message = (
+                    f"アノテーション仕様の'{get_label_name(label_info)}'ラベルに、"
+                    f"属性名(英語)が'{attribute_name}'である属性は存在しません。 :: label_id='{label_id}'"
+                )
+            raise ValueError(error_message)
+
+        elif len(tmp) > 1:
+            if label_info is None:
+                error_message = f"アノテーション仕様に、属性名(英語)が'{attribute_name}'である属性が複数存在します。"
+            else:
+                error_message = (
+                    f"アノテーション仕様の'{get_label_name(label_info)}'ラベルに、"
+                    f"属性名(英語)が'{attribute_name}'である属性が複数存在します。 :: label_id='{label_id}'"
+                )
+            raise ValueError(error_message)
+        additional_data = tmp[0]
+        result.append(_get_additional_data_v2(additional_data, attribute_value))
+
+    return result
 
 
 @dataclass

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -147,7 +147,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
 
         annotation_list = self.get_annotation_list_for_task(task_id, annotation_query)
         logger.info(
-            f"{logger_prefix}task_id='{task_id}'の変更対象アノテーション数：{len(annotation_list)}, phase={task.phase.value}, status={task.status.value}, updated_datetime={task.updated_datetime}"  # noqa: E501
+            f"{logger_prefix}task_id='{task_id}'の変更対象アノテーション数は{len(annotation_list)}個です。 :: task_phase='{task.phase.value}', task_status='{task.status.value}', task_updated_datetime='{task.updated_datetime}'"  # noqa: E501
         )
         if len(annotation_list) == 0:
             logger.info(f"{logger_prefix}task_id='{task_id}'には変更対象のアノテーションが存在しないので、スキップします。")

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import functools
 import logging
 import multiprocessing
@@ -11,7 +10,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import annofabapi
-from annofabapi.dataclass.annotation import AdditionalDataV1
 from annofabapi.dataclass.task import Task
 from annofabapi.models import ProjectMemberRole, TaskStatus
 
@@ -19,7 +17,7 @@ import annofabcli
 from annofabcli.annotation.annotation_query import (
     AnnotationQueryForAPI,
     AnnotationQueryForCLI,
-    convert_attributes_from_cli_to_api,
+    convert_attributes_from_cli_to_additional_data_list_v2,
 )
 from annofabcli.annotation.dump_annotation import DumpAnnotationMain
 from annofabcli.common.cli import (
@@ -59,14 +57,14 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
         self.dump_annotation_obj = DumpAnnotationMain(service, project_id)
 
     def change_annotation_attributes(
-        self, annotation_list: List[Dict[str, Any]], attributes: List[AdditionalDataV1]
+        self, annotation_list: List[Dict[str, Any]], additional_data_list: list[dict[str, Any]]
     ) -> Optional[List[Dict[str, Any]]]:
         """
         アノテーション属性値を変更する。
 
         Args:
             annotation_list: 変更対象のアノテーション一覧
-            attributes: 変更後の属性値
+            additional_data_list: 変更後の属性値(`AdditionalDataListV2`スキーマ)
 
         Returns:
             `batch_update_annotations`メソッドのレスポンス
@@ -83,12 +81,11 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
                     "updated_datetime": annotation["updated_datetime"],
                     "annotation_id": detail["annotation_id"],
                     "label_id": detail["label_id"],
-                    "additional_data_list": attributes_for_dict,
+                    "additional_data_list": additional_data_list,
                 },
                 "_type": "PutV2",
             }
 
-        attributes_for_dict: List[Dict[str, Any]] = [dataclasses.asdict(e) for e in attributes]
         request_body = [_to_request_body_elm(annotation) for annotation in annotation_list]
         return self.service.api.batch_update_annotations(self.project_id, request_body=request_body)[0]
 
@@ -113,7 +110,8 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
         self,
         task_id: str,
         annotation_query: AnnotationQueryForAPI,
-        attributes: List[AdditionalDataV1],
+        additional_data_list: list[dict[str, Any]],
+        *,
         backup_dir: Optional[Path] = None,
         task_index: Optional[int] = None,
     ) -> bool:
@@ -124,7 +122,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
             project_id:
             task_id:
             annotation_query: 変更対象のアノテーションの検索条件
-            attributes: 変更後のアノテーション属性
+            additional_data_list: 変更後の属性値(`AdditionalDataListV2`スキーマ)
             force: タスクのステータスによらず更新する
             backup_dir: アノテーションをバックアップとして保存するディレクトリ。指定しない場合は、バックアップを取得しない。
 
@@ -161,7 +159,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
         if backup_dir is not None:
             self.dump_annotation_obj.dump_annotation_for_task(task_id, output_dir=backup_dir)
 
-        self.change_annotation_attributes(annotation_list, attributes)
+        self.change_annotation_attributes(annotation_list, additional_data_list)
         logger.info(f"{logger_prefix}task_id={task_id}: アノテーション属性を変更しました。")
         return True
 
@@ -169,7 +167,8 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
         self,
         tpl: tuple[int, str],
         annotation_query: AnnotationQueryForAPI,
-        attributes: List[AdditionalDataV1],
+        additional_data_list: list[dict[str, Any]],
+        *,
         backup_dir: Optional[Path] = None,
     ) -> bool:
         task_index, task_id = tpl
@@ -177,7 +176,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
             return self.change_attributes_for_task(
                 task_id,
                 annotation_query=annotation_query,
-                attributes=attributes,
+                additional_data_list=additional_data_list,
                 backup_dir=backup_dir,
                 task_index=task_index,
             )
@@ -189,10 +188,22 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
         self,
         task_id_list: List[str],
         annotation_query: AnnotationQueryForAPI,
-        attributes: List[AdditionalDataV1],
+        additional_data_list: list[dict[str, Any]],
+        *,
         backup_dir: Optional[Path] = None,
         parallelism: Optional[int] = None,
     ) -> None:
+        """
+        複数のタスクに対してアノテーションの属性値を変更します。
+
+        Args:
+            task_id_list: 変更対象のタスクのIDのlist
+            annotation_query: 変更対象のアノテーションを特定するためのクエリー
+            additional_data_list: 変更後の属性値(`AdditionalDataListV2`スキーマ)
+            backup_dir: バックアップ先のディレクトリ
+            parallelism: 並列数
+
+        """
         project_title = self.facade.get_project_title(self.project_id)
         logger.info(f"プロジェクト'{project_title}'に対して、タスク{len(task_id_list)} 件のアノテーションの属性を変更します。")
 
@@ -204,7 +215,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
             func = functools.partial(
                 self.change_attributes_for_task_wrapper,
                 annotation_query=annotation_query,
-                attributes=attributes,
+                additional_data_list=additional_data_list,
                 backup_dir=backup_dir,
             )
             with multiprocessing.Pool(parallelism) as pool:
@@ -217,7 +228,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
                     result = self.change_attributes_for_task(
                         task_id,
                         annotation_query=annotation_query,
-                        attributes=attributes,
+                        additional_data_list=additional_data_list,
                         backup_dir=backup_dir,
                         task_index=task_index,
                     )
@@ -257,12 +268,14 @@ class ChangeAttributesOfAnnotation(CommandLine):
         return annotation_query_for_cli.to_query_for_api(annotation_specs)
 
     @classmethod
-    def get_attributes_for_api(cls, str_attributes: str, annotation_specs: dict[str, Any], label_id: str) -> list[AdditionalDataV1]:
+    def get_additional_data_list_from_cli_attributes(
+        cls, str_attributes: str, annotation_specs: dict[str, Any], label_id: str
+    ) -> list[dict[str, Any]]:
         """
-        CLIから受け取った`--attributes`の値から、APIに渡す属性情報を返す。
+        CLIから受け取った`--attributes`の値から、APIに渡す属性情報(`AdditionalDataListV2`)を返します。
         """
         dict_attributes = get_json_from_args(str_attributes)
-        return convert_attributes_from_cli_to_api(dict_attributes, annotation_specs, label_id=label_id)
+        return convert_attributes_from_cli_to_additional_data_list_v2(dict_attributes, annotation_specs, label_id=label_id)
 
     def main(self) -> None:
         args = self.args
@@ -282,7 +295,9 @@ class ChangeAttributesOfAnnotation(CommandLine):
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         try:
-            attributes = self.get_attributes_for_api(args.attributes, annotation_specs, label_id=annotation_query.label_id)
+            additional_data_list = self.get_additional_data_list_from_cli_attributes(
+                args.attributes, annotation_specs, label_id=annotation_query.label_id
+            )
         except ValueError as e:
             print(f"{self.COMMON_MESSAGE} argument '--attributes' の値が不正です。 :: {e}", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
@@ -304,7 +319,7 @@ class ChangeAttributesOfAnnotation(CommandLine):
         main_obj.change_annotation_attributes_for_task_list(
             task_id_list,
             annotation_query=annotation_query,
-            attributes=attributes,
+            additional_data_list=additional_data_list,
             backup_dir=backup_dir,
             parallelism=args.parallelism,
         )

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -85,7 +85,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
                     "label_id": detail["label_id"],
                     "additional_data_list": attributes_for_dict,
                 },
-                "_type": "Put",
+                "_type": "PutV2",
             }
 
         attributes_for_dict: List[Dict[str, Any]] = [dataclasses.asdict(e) for e in attributes]
@@ -185,14 +185,14 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
             logger.warning(f"タスク'{task_id}'のアノテーションの属性の変更に失敗しました。", exc_info=True)
             return False
 
-    def change_annotation_attributes_for_task_list(  # noqa: ANN201
+    def change_annotation_attributes_for_task_list(
         self,
         task_id_list: List[str],
         annotation_query: AnnotationQueryForAPI,
         attributes: List[AdditionalDataV1],
         backup_dir: Optional[Path] = None,
         parallelism: Optional[int] = None,
-    ):
+    ) -> None:
         project_title = self.facade.get_project_title(self.project_id)
         logger.info(f"プロジェクト'{project_title}'に対して、タスク{len(task_id_list)} 件のアノテーションの属性を変更します。")
 
@@ -273,7 +273,7 @@ class ChangeAttributesOfAnnotation(CommandLine):
         project_id = args.project_id
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id)
 
-        annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"v": "2"})
+        annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"v": "3"})
 
         try:
             annotation_query = self.get_annotation_query_for_api(args.annotation_query, annotation_specs)

--- a/annofabcli/annotation/change_annotation_attributes.py
+++ b/annofabcli/annotation/change_annotation_attributes.py
@@ -160,7 +160,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
             self.dump_annotation_obj.dump_annotation_for_task(task_id, output_dir=backup_dir)
 
         self.change_annotation_attributes(annotation_list, additional_data_list)
-        logger.info(f"{logger_prefix}task_id={task_id}: アノテーション属性を変更しました。")
+        logger.info(f"{logger_prefix}task_id='{task_id}': {len(annotation_list)} 個のアノテーションの属性値を変更しました。")
         return True
 
     def change_attributes_for_task_wrapper(
@@ -205,7 +205,7 @@ class ChangeAnnotationAttributesMain(CommandLineWithConfirm):
 
         """
         project_title = self.facade.get_project_title(self.project_id)
-        logger.info(f"プロジェクト'{project_title}'に対して、タスク{len(task_id_list)} 件のアノテーションの属性を変更します。")
+        logger.info(f"プロジェクト'{project_title}'に対して、タスク{len(task_id_list)} 件のアノテーションの属性値を変更します。")
 
         if backup_dir is not None:
             backup_dir.mkdir(exist_ok=True, parents=True)
@@ -269,7 +269,7 @@ class ChangeAttributesOfAnnotation(CommandLine):
 
     @classmethod
     def get_additional_data_list_from_cli_attributes(
-        cls, str_attributes: str, annotation_specs: dict[str, Any], label_id: str
+        cls, str_attributes: str, annotation_specs: dict[str, Any], label_id: Optional[str]
     ) -> list[dict[str, Any]]:
         """
         CLIから受け取った`--attributes`の値から、APIに渡す属性情報(`AdditionalDataListV2`)を返します。

--- a/annofabcli/annotation/copy_annotation.py
+++ b/annofabcli/annotation/copy_annotation.py
@@ -84,11 +84,11 @@ def parse_copy_target(str_copy_target: str) -> CopyTarget:
         elif len(tmp) == 2:
             return (tmp[0], tmp[1])
         else:
-            raise ValueError(f"'{str_copy_target}' の形式が間違っています。")  # noqa: TRY003
+            raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
 
     tmp_array = str_copy_target.split(":")
     if len(tmp_array) != 2:
-        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")  # noqa: TRY003
+        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
 
     str_src = tmp_array[0]
     str_dest = tmp_array[1]
@@ -106,7 +106,7 @@ def parse_copy_target(str_copy_target: str) -> CopyTarget:
     elif src_input_data_id is None and dest_input_data_id is None:
         return CopyTargetByTask(src_task_id=src_task_id, dest_task_id=dest_task_id)
     else:
-        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")  # noqa: TRY003
+        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
 
 
 def get_copy_target_list(str_copy_target_list: list[str]) -> list[CopyTarget]:

--- a/annofabcli/annotation_specs/list_annotation_specs_label.py
+++ b/annofabcli/annotation_specs/list_annotation_specs_label.py
@@ -58,7 +58,7 @@ def decimal_to_hex_color(red: int, green: int, blue: int) -> str:
     """
     # 各値が0から255の範囲内にあるか確認
     if not (0 <= red <= 255 and 0 <= green <= 255 and 0 <= blue <= 255):
-        raise ValueError(f"RGB values must be in the range 0-255 :: {red=}, {blue=}, {green=}")  # noqa: TRY003
+        raise ValueError(f"RGB values must be in the range 0-255 :: {red=}, {blue=}, {green=}")
 
     return f"#{red:02X}{green:02X}{blue:02X}"
 

--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -255,7 +255,7 @@ def load_logging_config_from_args(args: argparse.Namespace) -> None:
     data = pkgutil.get_data("annofabcli", "data/logging.yaml")
     if data is None:
         logger.warning("annofabcli/data/logging.yaml が読み込めませんでした")
-        raise AnnofabCliException("annofabcli/data/logging.yaml が読み込めませんでした")  # noqa: TRY003
+        raise AnnofabCliException("annofabcli/data/logging.yaml が読み込めませんでした")
 
     logging_config = yaml.safe_load(data.decode("utf-8"))
 

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -232,7 +232,7 @@ def convert_annotation_specs_labels_v2_to_v1(labels_v2: List[Dict[str, Any]], ad
             if additional is not None:
                 new_additional_data_definitions.append(additional)
             else:
-                raise ValueError(  # noqa: TRY003
+                raise ValueError(
                     f"additional_data_definition_id='{additional_data_definition_id}' に対応する属性情報が存在しません。"
                     f"label_id='{label_v2['label_id']}', label_name_en='{AnnofabApiFacade.get_label_name_en(label_v2)}'"
                 )

--- a/annofabcli/common/image.py
+++ b/annofabcli/common/image.py
@@ -320,7 +320,7 @@ def write_annotation_images_from_path(
             return _get_image_size_from_system_metadata(input_data)
 
         else:
-            raise ValueError("引数`image_size`または`input_data_dict`のどちらかはnot Noneである必要があります。")  # noqa: TRY003
+            raise ValueError("引数`image_size`または`input_data_dict`のどちらかはnot Noneである必要があります。")
 
     if not annotation_path.exists():
         logger.warning(f"annotation_path: '{annotation_path}' は存在しません。")

--- a/annofabcli/filesystem/merge_annotation.py
+++ b/annofabcli/filesystem/merge_annotation.py
@@ -37,7 +37,7 @@ class MergeAnnotationMain:
         elif annotation_path.is_dir():
             return lazy_parse_simple_annotation_dir(annotation_path)
         else:
-            raise RuntimeError(f"{annotation_path} はサポート対象外です。")  # noqa: TRY003
+            raise RuntimeError(f"{annotation_path} はサポート対象外です。")
 
     @staticmethod
     def _write_outer_file(parser: SimpleAnnotationParser, anno: Dict[str, Any], output_json: Path) -> None:
@@ -121,7 +121,7 @@ class MergeAnnotationMain:
                 return SimpleAnnotationZipParser(zip_file, str(json_path))
             return None
         else:
-            raise RuntimeError(f"{annotation_path} はサポート対象外です。")  # noqa: TRY003
+            raise RuntimeError(f"{annotation_path} はサポート対象外です。")
 
     @staticmethod
     def create_is_target_parser_func(

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -135,7 +135,7 @@ class AnnotationCounterByInputData(AnnotationCounter, DataClassJsonMixin):
 
 def lazy_parse_simple_annotation_by_input_data(annotation_path: Path) -> Iterator[SimpleAnnotationParser]:
     if not annotation_path.exists():
-        raise RuntimeError(f"'{annotation_path}' は存在しません。")  # noqa: TRY003
+        raise RuntimeError(f"'{annotation_path}' は存在しません。")
 
     if annotation_path.is_dir():
         return lazy_parse_simple_annotation_dir(annotation_path)
@@ -147,7 +147,7 @@ def lazy_parse_simple_annotation_by_input_data(annotation_path: Path) -> Iterato
 
 def lazy_parse_simple_annotation_by_task(annotation_path: Path) -> Iterator[SimpleAnnotationParserByTask]:
     if not annotation_path.exists():
-        raise RuntimeError(f"'{annotation_path}' は存在しません。")  # noqa: TRY003
+        raise RuntimeError(f"'{annotation_path}' は存在しません。")
 
     if annotation_path.is_dir():
         return lazy_parse_simple_annotation_dir_by_task(annotation_path)
@@ -350,7 +350,7 @@ class ListAnnotationCounterByTask:
             input_data_count += 1
 
         if last_simple_annotation is None:
-            raise RuntimeError(f"{task_parser.task_id} ディレクトリにはjsonファイルが1つも含まれていません。")  # noqa: TRY003
+            raise RuntimeError(f"{task_parser.task_id} ディレクトリにはjsonファイルが1つも含まれていません。")
 
         return AnnotationCounterByTask(
             task_id=last_simple_annotation["task_id"],

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -74,7 +74,7 @@ class CsvType(Enum):
 
 def lazy_parse_simple_annotation_by_input_data(annotation_path: Path) -> Iterator[SimpleAnnotationParser]:
     if not annotation_path.exists():
-        raise RuntimeError(f"'{annotation_path}' は存在しません。")  # noqa: TRY003
+        raise RuntimeError(f"'{annotation_path}' は存在しません。")
 
     if annotation_path.is_dir():
         return lazy_parse_simple_annotation_dir(annotation_path)

--- a/annofabcli/statistics/visualization/dataframe/actual_worktime.py
+++ b/annofabcli/statistics/visualization/dataframe/actual_worktime.py
@@ -33,7 +33,7 @@ class ActualWorktime:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")
         self.df = df
 
     def is_empty(self) -> bool:

--- a/annofabcli/statistics/visualization/dataframe/annotation_count.py
+++ b/annofabcli/statistics/visualization/dataframe/annotation_count.py
@@ -38,7 +38,7 @@ class AnnotationCount:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")
         self.df = df
 
     @classmethod

--- a/annofabcli/statistics/visualization/dataframe/inspection_comment_count.py
+++ b/annofabcli/statistics/visualization/dataframe/inspection_comment_count.py
@@ -39,7 +39,7 @@ class InspectionCommentCount:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")
         self.df = df
 
     @classmethod

--- a/annofabcli/statistics/visualization/dataframe/task.py
+++ b/annofabcli/statistics/visualization/dataframe/task.py
@@ -54,7 +54,7 @@ class Task:
             logger.warning("引数`df`に重複したキー（project_id, task_id）が含まれています。")
 
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")
 
         self.df = df
 

--- a/annofabcli/statistics/visualization/dataframe/task_history.py
+++ b/annofabcli/statistics/visualization/dataframe/task_history.py
@@ -37,7 +37,7 @@ class TaskHistory:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")
 
         self.df = df
 

--- a/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
+++ b/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
@@ -65,7 +65,7 @@ class TaskWorktimeByPhaseUser:
             logger.warning("引数`df`に重複したキー（project_id, task_id, phase, phase_stage, account_id）が含まれています。")
 
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")
 
         self.df = df
 

--- a/annofabcli/statistics/visualization/dataframe/user.py
+++ b/annofabcli/statistics/visualization/dataframe/user.py
@@ -40,7 +40,7 @@ class User:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")
 
         if self._duplicated_keys(df):
             logger.warning(f"引数`df`の`user_id`列または`account_id`が重複しています。 :: {df.columns=}")

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -65,7 +65,7 @@ class WorktimePerDate:
 
     def __init__(self, df: pandas.DataFrame) -> None:
         if not self.required_columns_exist(df):
-            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")  # noqa: TRY003
+            raise ValueError(f"引数`df`には、{self.columns}の列が必要です。 :: {df.columns=}")
 
         if self._duplicated_keys(df):
             logger.warning("引数`df`に重複したキー（date, account_id）が含まれています。")

--- a/annofabcli/task/copy_tasks.py
+++ b/annofabcli/task/copy_tasks.py
@@ -39,7 +39,7 @@ def parse_copy_target(str_copy_target: str) -> CopyTarget:
     """
     tmp_array = str_copy_target.split(":")
     if len(tmp_array) != 2:
-        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")  # noqa: TRY003
+        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
 
     return CopyTarget(src_task_id=tmp_array[0], dest_task_id=tmp_array[1])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ ignore = [
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
     "PERF203", # try-except-in-loop: ループ内でtry-exceptを使うこともあるため無視する。
     "COM812", # missing-trailing-comma: 末尾のカンマを考慮しないため無視する
+    "TRY003", # raise-vanilla-args: `ValueError`にf-stringで長いメッセージを渡すことが多いので無視する
     "FIX", # TODOやFIXMEを使うため無視する
     "TD", # TODOコメントの書き方に気にしていないので無視する
     


### PR DESCRIPTION
# 背景
もともと、コマンドライン引数 `--annotation_query` の`label`キーは必須でした。
属性値だけで絞り込みたいときがあるので、`label`キーをオプショナルにしました。
ただし、`label`と`attribute`のどちらかを指定する必要があります。

# その他の変更
* `batchUpdateAnnotations` APIのリクエストボディを`BatchAnnotationRequestItemPutV1`から`BatchAnnotationRequestItemPutV2`に変更しました。
* Ruffの`TRY003`を`pyproject.toml`で無視するようにしました。
