### PR TITLE
TravisCIでWindowsのテストを実行しないようにする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,30 +16,10 @@ jobs:
         - make lint
     - python: 3.12
 
-    # Windowsは最新のPythonバージョンのみテストする。
-    # 最新でないPythonバージョンのテストはすでに実施できているので。
-    # このテストはWindows特有のバグが発生しないことを確認する
-    - os: windows
-      python: 3.11
-      language: shell  # 'language: python' is an error on Travis CI Windows
-      install:
-        - choco install python --version 3.11
-        - python -m pip install --upgrade pip
-        - pip3 install "poetry<1.8"
-        # 以下の環境変数が設定されないと、poetry install時に"A specified logon session does not exist. It may already have been terminated."というエラーが発生する
-        # https://stackoverflow.com/questions/74392324/poetry-install-throws-winerror-1312-when-running-over-ssh-on-windows-10
-        - export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-        # UTF-8 Modeを利用する。これを設定しないと、"UnicodeEncodeError: 'charmap' codec can't encode characters in position 128-135: character maps to <undefined>"というエラーが発生する
-        - export PYTHONUTF8=1
-        - travis_retry poetry install
-      script:
-        - poetry run pytest -n auto -m "not access_webapi"
-      env: PATH=/c/Python311:/c/Python311/Scripts:$PATH PIP_DEFAULT_TIMEOUT=300 ANNOFAB_USER_ID=foo ANNOFAB_PASSWORD=bar
-
 install:
   # pipをアップグレードする理由: pipのバージョンが古いと、pillowなど環境ごとにwheelを提供しているライブラリのインストールに失敗する可能性があるため
   - pip install pip --upgrade
-  - pip install "poetry<1.8"
+  - pip install "poetry<1.9"
   - travis_retry poetry install
 
 branches:


### PR DESCRIPTION
Windowsでも動作できるようにするため、TravisCIのWindows環境でテストを実行していた。
しかし、TravisCIで実行しているテストケースは少ないため、TravisCIでWindows固有のバグが見つかることはほとんどない。
また、TravisCIでのWindowsのテストはUbuntu環境でのテストと比べると環境構築に時間かかって遅い。
したがって、開発効率を上げるためTravisCIのWindows環境でのテストをやめることにした。