### PR TITLE
入力データと補助情報から不要な情報（システム内部用のパラメータなど）を出力しないようにしました。

### DIFF
--- a/annofabcli/input_data/list_all_input_data.py
+++ b/annofabcli/input_data/list_all_input_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import datetime
 import json
@@ -25,7 +27,6 @@ DatetimeRange = Tuple[Optional[datetime.datetime], Optional[datetime.datetime]]
 class ListInputDataWithJsonMain:
     def __init__(self, service: annofabapi.Resource) -> None:
         self.service = service
-        self.facade = AnnofabApiFacade(service)
 
     @staticmethod
     def filter_input_data_list(
@@ -40,6 +41,23 @@ class ListInputDataWithJsonMain:
         if input_data_id_set is not None:
             result = result and (dc_input_data.input_data_id in input_data_id_set)
         return result
+
+    @staticmethod
+    def remove_unnecessary_keys_from_input_data(input_data_list: list[dict[str, Any]]) -> None:
+        """
+        入力データから不要なキーを取り除きます。
+
+        Args:
+            input_data_list: (IN/OUT) 入力データのlist
+        """
+        unnecessary_keys = [
+            "url",  # システム内部用のプロパティ
+            "original_input_data_path",  # システム内部用のプロパティ
+            "etag",  # annofab-cliで見ることはない
+        ]
+        for input_data in input_data_list:
+            for key in unnecessary_keys:
+                input_data.pop(key, None)
 
     def get_input_data_list(
         self,
@@ -72,6 +90,9 @@ class ListInputDataWithJsonMain:
         filtered_input_data_list = [
             e for e in input_data_list if self.filter_input_data_list(e, input_data_query=input_data_query, input_data_id_set=input_data_id_set)
         ]
+
+        # 入力データの不要なキーを削除する
+        self.remove_unnecessary_keys_from_input_data(filtered_input_data_list)
         return filtered_input_data_list
 
 
@@ -101,8 +122,8 @@ class ListInputDataWithJson(CommandLine):
         if len(input_data_list) > 0:
             output_format = FormatArgument(args.format)
             if output_format == FormatArgument.CSV:
-                # panadas.DataFramdでなくpandas.json_normalizeを使う理由:
-                # ネストしたオブジェクトを`system_metadata.input_daration`のような列名でアクセスできるようにするため
+                # pandas.DataFrameでなくpandas.json_normalizeを使う理由:
+                # ネストしたオブジェクトを`system_metadata.input_duration`のような列名でアクセスできるようにするため
                 df = pandas.json_normalize(input_data_list)
                 print_csv(df, output=args.output)
             else:

--- a/annofabcli/input_data/list_all_input_data.py
+++ b/annofabcli/input_data/list_all_input_data.py
@@ -18,6 +18,7 @@ from annofabcli.common.cli import ArgumentParser, CommandLine, build_annofabapi_
 from annofabcli.common.download import DownloadingFile
 from annofabcli.common.enums import FormatArgument
 from annofabcli.common.facade import AnnofabApiFacade, InputDataQuery, match_input_data_with_query
+from annofabcli.input_data.utils import remove_unnecessary_keys_from_input_data
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class ListInputDataWithJsonMain:
         return result
 
     @staticmethod
-    def remove_unnecessary_keys_from_input_data(input_data_list: list[dict[str, Any]]) -> None:
+    def remove_unnecessary_keys_from_input_data2(input_data_list: list[dict[str, Any]]) -> None:
         """
         入力データから不要なキーを取り除きます。
 
@@ -92,7 +93,8 @@ class ListInputDataWithJsonMain:
         ]
 
         # 入力データの不要なキーを削除する
-        self.remove_unnecessary_keys_from_input_data(filtered_input_data_list)
+        for input_data in input_data_list:
+            remove_unnecessary_keys_from_input_data(input_data)
         return filtered_input_data_list
 
 

--- a/annofabcli/input_data/list_input_data.py
+++ b/annofabcli/input_data/list_input_data.py
@@ -12,6 +12,7 @@ from annofabcli.common.cli import ArgumentParser, CommandLine, build_annofabapi_
 from annofabcli.common.enums import FormatArgument
 from annofabcli.common.facade import AnnofabApiFacade
 from annofabcli.common.visualize import AddProps
+from annofabcli.input_data.utils import remove_unnecessary_keys_from_input_data
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,9 @@ class ListInputDataMain:
         if add_details:
             self.add_details_to_input_data_list(input_data_list)
 
+        # 入力データの不要なキーを削除する
+        for input_data in input_data_list:
+            remove_unnecessary_keys_from_input_data(input_data)
         return input_data_list
 
 
@@ -165,8 +169,8 @@ class ListInputData(CommandLine):
         output_format = FormatArgument(args.format)
         if len(input_data_list) > 0:
             if output_format == FormatArgument.CSV:
-                # panadas.DataFramdでなくpandas.json_normalizeを使う理由:
-                # ネストしたオブジェクトを`system_metadata.input_daration`のような列名でアクセスできるようにするため
+                # pandas.DataFrameでなくpandas.json_normalizeを使う理由:
+                # ネストしたオブジェクトを`system_metadata.input_duration`のような列名でアクセスできるようにするため
                 df = pandas.json_normalize(input_data_list)
                 print_csv(df, output=args.output)
             else:

--- a/annofabcli/input_data/list_input_data_merged_task.py
+++ b/annofabcli/input_data/list_input_data_merged_task.py
@@ -25,6 +25,7 @@ from annofabcli.common.download import DownloadingFile
 from annofabcli.common.enums import FormatArgument
 from annofabcli.common.facade import AnnofabApiFacade, InputDataQuery, match_input_data_with_query
 from annofabcli.common.utils import print_csv
+from annofabcli.input_data.utils import remove_unnecessary_keys_from_input_data
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,8 @@ def create_input_data_list_with_merged_task(input_data_list: list[dict[str, Any]
     dict_tasks_by_input_data_id = _create_dict_tasks_by_input_data_id(task_list)
     for input_data in input_data_list:
         input_data["parent_task_list"] = dict_tasks_by_input_data_id.get(input_data["input_data_id"], [])
-
+        # 不要なキーを削除する
+        remove_unnecessary_keys_from_input_data(input_data)
     return input_data_list
 
 
@@ -88,8 +90,8 @@ def create_df_input_data_with_merged_task(input_data_list: list[dict[str, Any]])
             new_input_data.pop("parent_task_list")
             new_input_data_list.append(new_input_data)
 
-    # panadas.DataFramdでなくpandas.json_normalizeを使う理由:
-    # ネストしたオブジェクトを`system_metadata.input_daration`のような列名でアクセスできるようにするため
+    # pandas.DataFrameでなくpandas.json_normalizeを使う理由:
+    # ネストしたオブジェクトを`system_metadata.input_duration`のような列名でアクセスできるようにするため
     df_input_data = pandas.json_normalize(new_input_data_list)
 
     for column in ["task_id", "task_status", "task_phase", "task_phase_stage", "frame_no"]:

--- a/annofabcli/input_data/utils.py
+++ b/annofabcli/input_data/utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def remove_unnecessary_keys_from_input_data(input_data: dict[str, Any]) -> None:
+    """
+    入力データから不要なキーを取り除きます。
+    システム内部用のプロパティなど、annofab-cliを使う上で不要な情報を削除します。
+
+    Args:
+        input_data: (IN/OUT) 入力データ情報。引数が変更されます。
+    """
+    unnecessary_keys = [
+        "url",  # システム内部用のプロパティ
+        "original_input_data_path",  # システム内部用のプロパティ
+        "etag",  # annofab-cliで見ることはない
+    ]
+    for key in unnecessary_keys:
+        input_data.pop(key, None)


### PR DESCRIPTION
以下のコマンドの出力結果から、不要な情報を出力しないようにしました。
* `input_data list_all`
* `input_data list`
* `input_data list_merged_task`
* `supplementary list`

削除したキーは以下の通りです。
* `url` : システム内部用のプロパティのため。
* `original_input_data_path`: システム内部用のプロパティのため
* `etag` : annofab-cliの出力結果で参照することがなさそうなので。もしETagを利用するなら、annofab-api-python-clientを使うはず。


# きっかけ
* `url`には認証済み一時URLが格納されています。セキュリティ的に認証済一時URLをファイルなどに出力するのはよろしくないので、`url`を出力しないようにしました。
* 入力データ全件ファイルでは、`url`と`etag`にはnullが格納されています。入力データ全件ファイルを利用する`list_all`コマンドで、入力データ全件ファイルを利用しない`list`コマンドの出力結果を揃えるため、`etag`も出力しないようにしました。
