### PR TITLE
`supplementary list`: コマンドライン引数を変更しました

### DIFF
--- a/annofabcli/supplementary/list_supplementary_data.py
+++ b/annofabcli/supplementary/list_supplementary_data.py
@@ -61,7 +61,7 @@ class ListSupplementaryDataMain:
                 remove_unnecessary_keys_from_supplementary_data(supplementary_data)
             return supplementary_data_list
         else:
-            logger.warning(f"入力データ '{input_data_id}' に紐づく補助情報が見つかりませんでした。")
+            logger.warning(f"input_data_id='{input_data_id}'である入力データは存在しません。")
             return []
 
     def get_supplementary_data_list_wrapper(self, tpl: tuple[int, str]) -> list[dict[str, Any]]:
@@ -99,20 +99,6 @@ class ListSupplementaryDataMain:
                 except Exception:
                     logger.warning(f"input_data_id='{input_data_index}': 補助情報の取得に失敗しました。", exc_info=True)
                     continue
-
-        for index, input_data_id in enumerate(input_data_id_list):
-            if (index + 1) % 100 == 0:
-                logger.debug(f"{index+1} 件目の入力データに紐づく補助情報を取得します。")
-
-            supplementary_data_list = self.service.wrapper.get_supplementary_data_list_or_none(project_id, input_data_id)
-
-            if supplementary_data_list is not None:
-                # 補助情報から不要なキーを取り除く
-                for supplementary_data in supplementary_data_list:
-                    remove_unnecessary_keys_from_supplementary_data(supplementary_data)
-                all_supplementary_data_list.extend(supplementary_data_list)
-            else:
-                logger.warning(f"入力データ '{input_data_id}' に紐づく補助情報が見つかりませんでした。")
 
         return all_supplementary_data_list
 

--- a/annofabcli/supplementary/list_supplementary_data.py
+++ b/annofabcli/supplementary/list_supplementary_data.py
@@ -72,9 +72,7 @@ class ListSupplementaryDataMain:
             logger.warning(f"input_data_id='{input_data_index}': 補助情報の取得に失敗しました。", exc_info=True)
             return []
 
-    def get_all_supplementary_data_list(
-        self, project_id: str, input_data_id_list: List[str], *, parallelism: Optional[int] = None
-    ) -> List[SupplementaryData]:
+    def get_all_supplementary_data_list(self, input_data_id_list: List[str], *, parallelism: Optional[int] = None) -> List[SupplementaryData]:
         """
         補助情報一覧を取得する。
         """
@@ -130,7 +128,7 @@ class ListSupplementaryData(CommandLine):
             input_data_id_list = self.get_input_data_id_list_from_input_data_json(project_id)
 
         main_obj = ListSupplementaryDataMain(self.service, project_id=project_id)
-        all_supplementary_data_list = main_obj.get_all_supplementary_data_list(project_id, input_data_id_list, parallelism=args.parallelism)
+        all_supplementary_data_list = main_obj.get_all_supplementary_data_list(input_data_id_list, parallelism=args.parallelism)
         logger.info(f"補助情報一覧の件数: {len(all_supplementary_data_list)}")
         self.print_according_to_format(all_supplementary_data_list)
 

--- a/annofabcli/supplementary/list_supplementary_data.py
+++ b/annofabcli/supplementary/list_supplementary_data.py
@@ -86,7 +86,6 @@ class ListSupplementaryData(CommandLine):
                     input_data_list = json.load(f)
 
             input_data_id_list = [e["input_data_id"] for e in input_data_list]
-            return
 
         supplementary_data_list = self.get_all_supplementary_data_list(project_id, input_data_id_list=input_data_id_list)
         logger.info(f"補助情報一覧の件数: {len(supplementary_data_list)}")
@@ -95,9 +94,8 @@ class ListSupplementaryData(CommandLine):
     def main(self) -> None:
         args = self.args
         input_data_id_list = annofabcli.common.cli.get_list_from_args(args.input_data_id) if args.input_data_id is not None else None
-        task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
 
-        self.print_supplementary_data_list(project_id=args.project_id, input_data_id_list=input_data_id_list, task_id_list=task_id_list)
+        self.print_supplementary_data_list(project_id=args.project_id, input_data_id_list=input_data_id_list)
 
 
 def main(args: argparse.Namespace) -> None:


### PR DESCRIPTION
### 引数の削除
* `--task_id` : タスクIDを指定しても、どのタスクに関連する補助情報か分からないため（補助情報はタスクで入力データに紐づく）、かえって混乱するかと思い削除しました。
* `--query` : 利用用途が少ないため削除しました。
* `--csv_format` : 利用用途が少ないため削除しました。

### 引数の変更
* `--input_data_id`を指定しない場合は、入力データ全件ファイルをダウンロードして、すべての入力データに紐づく補助情報を参照するようにしました。そうすることで、どの入力データに補助情報が存在するか分からない状態でもコマンドを利用できるためです。
* `--parallelism`を追加しました。
