### PR TITLE
`annofab-cli`のユーザー用のDockerfileを削除しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,6 @@ https://pypi.org/project/annofabcli/
 zipの中にある`annofabcli.exe`が実行ファイルになります。
 
 
-## Dockerを利用する場合
-
-```
-$ git clone https://github.com/kurusugawa-computer/annofab-cli.git
-$ cd annofab-cli
-$ chmod u+x docker-build.sh
-$ ./docker-build.sh
-
-$ docker run -it annofab-cli --help
-
-# Annofabの認証情報を標準入力から指定する
-$ docker run -it annofab-cli project diff prj1 prj2
-Enter Annofab User ID: XXXXXX
-Enter Annofab Password: 
-
-# Annofabの認証情報を環境変数で指定する
-$ docker run -it -e ANNOFAB_USER_ID=XXXX -e ANNOFAB_PASSWORD=YYYYY annofab-cli project diff prj1 prj2
-```
-
 
 ## Annofabの認証情報の設定
 https://annofab-cli.readthedocs.io/ja/latest/user_guide/configurations.html 参照

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -uxv
-
-# scriptの絶対パス
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
-pushd ${SCRIPT_DIR}
-
-docker build -t annofab-cli docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.8
-
-RUN pip install annofabcli -U && pip install annofabapi -U
-# && apt-get update  \
-# && apt-get install -y \
-# && apt-get clean \
-# && rm -rf /var/lib/apt/lists/*
-
-ENTRYPOINT [ "annofabcli" ]


### PR DESCRIPTION
複数のPythonバージョンや複数のOS(Linux, Windows)で動作するように努めているため（動作確認はできていないが）、ユーザー用の`Dockerfile`を削除しました。
`Dockerfile`の中身は`pip install annofabcli`を実行しているだけなので、この`Dockerfile`を削除しても大きな問題ないはないと考えています。