### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
           poetry install --only main,publish
 
       - name: Create executable file with pyinstaller and zip
-        shell: powershell
         run: |
           poetry run pyinstaller annofabcli\__main__.py  --name annofabcli --add-data "annofabcli/data/logging.yaml;annofabcli/data"
           Compress-Archive -Path dist\annofabcli\  -DestinationPath dist\annofabcli-windows.zip


### PR DESCRIPTION
以下のエラーが出たので対応する
https://github.com/kurusugawa-computer/annofab-cli/actions/runs/10469534829/job/28992775398

```
Run poetry run pyinstaller annofabcli\__main__.py  --name annofabcli --add-data "annofabcli/data/logging.yaml;annofabcli/data"
  poetry run pyinstaller annofabcli\__main__.py  --name annofabcli --add-data "annofabcli/data/logging.yaml;annofabcli/data"
  Compress-Archive -Path dist\annofabcli\  -DestinationPath dist\annofabcli-windows.zip
  Error: powershell: command not found
```