### PR TITLE
`project put` : `--custom_project_type`, `--configuration`オプションを追加

### DIFF
--- a/annofabcli/project/put_project.py
+++ b/annofabcli/project/put_project.py
@@ -12,6 +12,7 @@ from annofabapi.plugin import EditorPluginId, ExtendSpecsPluginId
 
 import annofabcli
 from annofabcli.common.cli import (
+    COMMAND_LINE_ERROR_STATUS_CODE,
     CommandLine,
     build_annofabapi_resource_and_login,
     get_json_from_args,
@@ -64,7 +65,7 @@ class PutProject(CommandLine):
         }
         new_project, _ = self.service.api.put_project(new_project_id, request_body=request_body)
         logger.info(
-            f"project_id='{new_project['project_id']}'のプロジェクトを作成しました。 :: "
+            f"'{organization}'組織に、project_id='{new_project['project_id']}'のプロジェクトを作成しました。 :: "
             f"title='{new_project['title']}', input_data_type='{new_project['input_data_type']}'"
         )
 
@@ -83,6 +84,8 @@ class PutProject(CommandLine):
 
     def main(self) -> None:
         args = self.args
+        if not self.validate(args):
+            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         self.put_project(
             args.organization,
@@ -134,8 +137,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--configuration",
         type=str,
-        help="プロジェクトの設定情報をJSON形式で指定します。"
-        "JSON構造については https://annofab.com/docs/api/#operation/putProject のリクエストボディを参照してください。\n"
+        help="プロジェクトの設定情報。JSON形式で指定します。"
+        "JSONの構造については https://annofab.com/docs/api/#operation/putProject のリクエストボディを参照してください。\n"
         "``file://`` を先頭に付けると、JSON形式のファイルを指定できます。",
     )
 

--- a/docs/command_reference/project/put.rst
+++ b/docs/command_reference/project/put.rst
@@ -19,8 +19,8 @@ Examples
     $ annofabcli project put --organization org --title foo --input_data_type image
 
 
-デフォルトでは、作成されるプロジェクトのproject_idはUUIDv4です。
-``--project_id`` で作成されるプロジェクトのproject_idを指定することもできます。
+デフォルトでは、作成したプロジェクトのproject_idのフォーマットはUUIDv4です。
+``--project_id`` オプションで、作成するプロジェクトのproject_idを指定することもできます。
 
 .. code-block::
 
@@ -28,6 +28,33 @@ Examples
      --project_id bar
 
 
+プロジェクトの設定情報を指定
+----------------------------------------------------
+
+``--configuration`` オプションで、プロジェクトの設定情報を指定できます。
+以下のコマンドで作成したプロジェクトは、アノテーションエディタのバージョンがプレビュー版になります。
+
+.. code-block::
+
+    $ annofabcli project put --organization org --title foo --input_data_type image \
+     --configuration '{"editor_version":"preview"}'
+
+
+JSONの構造については、 `putProject <https://annofab.com/docs/api/#operation/putProject>`_ APIのリクエストボディを参照してください。
+
+
+
+3次元プロジェクトの作成
+----------------------------------------------------
+3次元プロジェクトを作成するには、 ``--custom_project_type`` オプションも指定する必要があります。
+
+
+.. code-block::
+
+    $ annofabcli project put --organization org --title foo --input_data_type custom \
+     --custom_project_type 3d
+
+     
 
 
 


### PR DESCRIPTION
３次元プロジェクトを作成できるようにするため、`--custom_project_type`を追加しました。`--custom_project_type 3d`を指定すると、ビルトインのプラグインIDが設定されます。

あわせて、`--configuration`でプロジェクトの設定情報を指定できるようんしました。