### PR TITLE
`statistics visualize` : `累積折れ線-横軸_タスク数-教師付者用.html`を出力しないようにする

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -170,7 +170,6 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
         raise NotImplementedError()
 
 
-
 class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
     def __init__(self, df: pandas.DataFrame, *, custom_production_volume_list: Optional[list[ProductionVolumeColumn]] = None) -> None:
         super().__init__(df, phase=TaskPhase.ANNOTATION, custom_production_volume_list=custom_production_volume_list)
@@ -291,7 +290,6 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
 
-
 class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
     def __init__(self, df: pandas.DataFrame, *, custom_production_volume_list: Optional[list[ProductionVolumeColumn]] = None) -> None:
         super().__init__(df, phase=TaskPhase.INSPECTION, custom_production_volume_list=custom_production_volume_list)
@@ -397,7 +395,6 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         ]
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
-
 
 
 class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -169,9 +169,6 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
     ) -> None:
         raise NotImplementedError()
 
-    @abc.abstractmethod
-    def plot_task_metrics(self, output_file: Path, *, target_user_id_list: Optional[list[str]] = None) -> None:
-        raise NotImplementedError()
 
 
 class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
@@ -293,69 +290,6 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         ]
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_task_metrics(  # noqa: ANN201
-        self,
-        output_file: Path,
-        *,
-        target_user_id_list: Optional[list[str]] = None,
-    ):
-        """
-        教師付者の累積値をタスク単位でプロットする。
-
-        """
-
-        if not self._validate_df_for_output(output_file):
-            return
-
-        logger.debug(f"{output_file} を出力します。")
-
-        if target_user_id_list is not None:  # noqa: SIM108
-            user_id_list = target_user_id_list
-        else:
-            user_id_list = self.default_user_id_list
-
-        user_id_list = get_plotted_user_id_list(user_id_list)
-
-        x_axis_label = "タスク数"
-        tooltip_columns = [
-            "task_id",
-            "first_annotation_user_id",
-            "first_annotation_username",
-            "first_annotation_started_date",
-            "annotation_worktime_hour",
-            "number_of_rejections_by_inspection",
-            "number_of_rejections_by_acceptance",
-        ]
-
-        line_graph_list = [
-            LineGraph(
-                title="累積のタスク数と教師付作業時間",
-                y_axis_label="教師付作業時間[時間]",
-                tooltip_columns=tooltip_columns,
-                x_axis_label=x_axis_label,
-            ),
-            LineGraph(
-                title="累積のタスク数と差し戻し回数(検査フェーズ)",
-                y_axis_label="差し戻し回数(検査フェーズ)",
-                tooltip_columns=tooltip_columns,
-                x_axis_label=x_axis_label,
-            ),
-            LineGraph(
-                title="累積のタスク数と差し戻し回数(受入フェーズ)",
-                y_axis_label="差し戻し回数(受入フェーズ)",
-                tooltip_columns=tooltip_columns,
-                x_axis_label=x_axis_label,
-            ),
-        ]
-
-        x_column = "cumulative_task_count"
-        columns_list = [
-            (x_column, "cumulative_annotation_worktime_hour"),
-            (x_column, "cumulative_number_of_rejections_by_inspection"),
-            (x_column, "cumulative_number_of_rejections_by_acceptance"),
-        ]
-
-        self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
 
 class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
@@ -464,53 +398,6 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
 
         self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
-    def plot_task_metrics(  # noqa: ANN201
-        self,
-        output_file: Path,
-        *,
-        target_user_id_list: Optional[list[str]] = None,
-    ):
-        """
-        検査者者の累積値をタスク単位でプロットする。
-
-        """
-
-        if not self._validate_df_for_output(output_file):
-            return
-
-        logger.debug(f"{output_file} を出力します。")
-
-        if target_user_id_list is not None:  # noqa: SIM108
-            user_id_list = target_user_id_list
-        else:
-            user_id_list = self.default_user_id_list
-
-        user_id_list = get_plotted_user_id_list(user_id_list)
-
-        x_axis_label = "タスク数"
-
-        line_graph_list = [
-            LineGraph(
-                title="累積のタスク数と検査作業時間",
-                y_axis_label="検査作業時間[時間]",
-                tooltip_columns=[
-                    "task_id",
-                    "first_inspection_user_id",
-                    "first_inspection_username",
-                    "first_inspection_started_date",
-                    "inspection_worktime_hour",
-                    "inspection_comment_count",
-                ],
-                x_axis_label=x_axis_label,
-            ),
-        ]
-
-        x_column = "cumulative_task_count"
-        columns_list = [
-            (x_column, "cumulative_inspection_worktime_hour"),
-        ]
-
-        self._plot(line_graph_list, columns_list, user_id_list, output_file)
 
 
 class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
@@ -606,52 +493,6 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         ]
 
         x_column = f"cumulative_{production_volume_column}"
-        columns_list = [
-            (x_column, "cumulative_acceptance_worktime_hour"),
-        ]
-
-        self._plot(line_graph_list, columns_list, user_id_list, output_file)
-
-    def plot_task_metrics(  # noqa: ANN201
-        self,
-        output_file: Path,
-        *,
-        target_user_id_list: Optional[list[str]] = None,
-    ):
-        """
-        受入者の累積値をタスク単位でプロットする。
-        """
-        if not self._validate_df_for_output(output_file):
-            return
-
-        logger.debug(f"{output_file} を出力します。")
-
-        if target_user_id_list is not None:  # noqa: SIM108
-            user_id_list = target_user_id_list
-        else:
-            user_id_list = self.default_user_id_list
-
-        user_id_list = get_plotted_user_id_list(user_id_list)
-
-        x_axis_label = "タスク数"
-
-        line_graph_list = [
-            LineGraph(
-                title="累積のタスク数と受入作業時間",
-                y_axis_label="受入作業時間[時間]",
-                tooltip_columns=[
-                    "task_id",
-                    "first_acceptance_user_id",
-                    "first_acceptance_username",
-                    "first_acceptance_started_date",
-                    "acceptance_worktime_hour",
-                    "inspection_comment_count",
-                ],
-                x_axis_label=x_axis_label,
-            ),
-        ]
-
-        x_column = "cumulative_task_count"
         columns_list = [
             (x_column, "cumulative_acceptance_worktime_hour"),
         ]

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -151,11 +151,6 @@ class ProjectDir(DataClassJsonMixin):
                 target_user_id_list=user_id_list,
             )
 
-            if phase == TaskPhase.ANNOTATION:
-                # 教師付フェーズの場合は、「差し戻し回数」で品質を評価した場合があるので、タスク単位の指標も出力する
-                obj.plot_task_metrics(
-                    output_dir / f"{phase_name}者用/累積折れ線-横軸_タスク数-{phase_name}者用.html", target_user_id_list=user_id_list
-                )
 
     def write_performance_per_started_date_csv(self, obj: AbstractPhaseProductivityPerDate, phase: TaskPhase) -> None:
         """

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -151,7 +151,6 @@ class ProjectDir(DataClassJsonMixin):
                 target_user_id_list=user_id_list,
             )
 
-
     def write_performance_per_started_date_csv(self, obj: AbstractPhaseProductivityPerDate, phase: TaskPhase) -> None:
         """
         指定したフェーズの開始日ごとの作業時間や生産性情報を、CSVに出力します。


### PR DESCRIPTION
以下の理由から、 `累積折れ線-横軸_タスク数-教師付者用.html`を出力しないようにしました。
* 累積折れ線グラフでタスクあたりの作業時間を生産性の指標として確認するケースはあまりないため
    * 入力データあたりの作業時間の方が、生産性の指標としてより表現できている
* 累積折れ線グラフでタスクあたりの差戻し回数を品質の指標として確認するケースはあまりないため
    * 差戻しはルールの変更などでも行われるため、そもそも品質の指標として使いにくい