### PR TITLE
`statistics visualize` : グラフにメタデータを表示する

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -9,7 +9,7 @@ import abc
 import itertools
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import bokeh
 import bokeh.layouts
@@ -18,6 +18,7 @@ import pandas
 from annofabapi.models import TaskPhase
 from bokeh.plotting import ColumnDataSource
 
+from annofabcli.common.bokeh import create_pretext_from_metadata
 from annofabcli.statistics.linegraph import (
     LineGraph,
     get_color_from_palette,
@@ -81,6 +82,8 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
         columns_list: list[tuple[str, str]],
         user_id_list: list[str],
         output_file: Path,
+        *,
+        metadata: Optional[dict[str, Any]],
     ) -> None:
         """
         折れ線グラフを、HTMLファイルに出力します。
@@ -110,7 +113,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
         required_columns = get_required_columns()
 
         line_count = 0
-        ploted_users: list[tuple[str, str]] = []
+        plotted_users: list[tuple[str, str]] = []
 
         for user_index, user_id in enumerate(user_id_list):
             df_subset = df[df[f"first_{self.phase.value}_user_id"] == user_id]
@@ -126,7 +129,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
             for line_graph, (x_column, y_column) in zip(line_graph_list, columns_list):
                 line_graph.add_line(source, x_column=x_column, y_column=y_column, legend_label=username, color=color)
 
-            ploted_users.append((user_id, username))
+            plotted_users.append((user_id, username))
 
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
@@ -139,11 +142,14 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
             show_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=False)
             checkbox_group = line_graph.create_checkbox_displaying_markers()
 
-            multi_choice_widget = line_graph.create_multi_choice_widget_for_searching_user(ploted_users)
+            multi_choice_widget = line_graph.create_multi_choice_widget_for_searching_user(plotted_users)
 
             widgets = bokeh.layouts.column([hide_all_button, show_all_button, checkbox_group, multi_choice_widget])
             graph_group = bokeh.layouts.row([line_graph.figure, widgets])
             graph_group_list.append(graph_group)
+
+        if metadata is not None:
+            graph_group_list.insert(0, create_pretext_from_metadata(metadata))
 
         write_bokeh_graph(bokeh.layouts.layout(graph_group_list), output_file)
 
@@ -166,6 +172,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
         output_file: Path,
         *,
         target_user_id_list: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         raise NotImplementedError()
 
@@ -229,6 +236,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         output_file: Path,
         *,
         target_user_id_list: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         生産性を教師付作業者ごとにプロットする。
@@ -287,7 +295,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
             (x_column, "cumulative_annotation_worktime_hour"),
             (x_column, "cumulative_inspection_comment_count"),
         ]
-        self._plot(line_graph_list, columns_list, user_id_list, output_file)
+        self._plot(line_graph_list, columns_list, user_id_list, output_file, metadata=metadata)
 
 
 class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
@@ -348,6 +356,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         output_file: Path,
         *,
         target_user_id_list: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         生産性を検査作業者ごとにプロットする。
@@ -394,7 +403,7 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
             (x_column, "cumulative_inspection_worktime_hour"),
         ]
 
-        self._plot(line_graph_list, columns_list, user_id_list, output_file)
+        self._plot(line_graph_list, columns_list, user_id_list, output_file, metadata=metadata)
 
 
 class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
@@ -449,6 +458,7 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         output_file: Path,
         *,
         target_user_id_list: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         生産性を受入作業者ごとにプロットする。
@@ -494,4 +504,4 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
             (x_column, "cumulative_acceptance_worktime_hour"),
         ]
 
-        self._plot(line_graph_list, columns_list, user_id_list, output_file)
+        self._plot(line_graph_list, columns_list, user_id_list, output_file, metadata=metadata)

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -16,6 +16,7 @@ import bokeh.layouts
 import bokeh.palettes
 import pandas
 from annofabapi.models import TaskPhase
+from bokeh.models.ui import UIElement
 from bokeh.plotting import ColumnDataSource
 
 from annofabcli.common.bokeh import create_pretext_from_metadata
@@ -135,7 +136,7 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
 
-        graph_group_list = []
+        graph_group_list: list[UIElement] = []
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
             hide_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=True)

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import bokeh
 import bokeh.layouts
@@ -20,6 +20,7 @@ from bokeh.models.widgets.markups import Div
 from bokeh.plotting import ColumnDataSource
 from dateutil.parser import parse
 
+from annofabcli.common.bokeh import create_pretext_from_metadata
 from annofabcli.common.utils import datetime_to_date, print_csv
 from annofabcli.statistics.linegraph import (
     LineGraph,
@@ -257,7 +258,12 @@ class WholeProductivityPerCompletedDate:
             """
         )
 
-    def plot(self, output_file: Path) -> None:
+    def plot(
+        self,
+        output_file: Path,
+        *,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
         """
         全体の生産量や生産性をプロットする
         """
@@ -499,9 +505,13 @@ class WholeProductivityPerCompletedDate:
             line_graph.process_after_adding_glyphs()
 
         div_element = self._create_div_element()
-        write_bokeh_graph(bokeh.layouts.column([div_element] + [e.figure for e in line_graph_list]), output_file)
+        element_list = [div_element] + [e.figure for e in line_graph_list]
+        if metadata is not None:
+            element_list.insert(0, create_pretext_from_metadata(metadata))
 
-    def plot_cumulatively(self, output_file: Path) -> None:
+        write_bokeh_graph(bokeh.layouts.column(element_list), output_file)
+
+    def plot_cumulatively(self, output_file: Path, *, metadata: Optional[dict[str, Any]] = None) -> None:
         """
         全体の生産量や作業時間の累積折れ線グラフを出力する
         """
@@ -716,6 +726,11 @@ class WholeProductivityPerCompletedDate:
             line_graph.process_after_adding_glyphs()
 
         div_element = self._create_div_element()
+
+        element_list = [div_element] + [e.figure for e in line_graph_list]
+        if metadata is not None:
+            element_list.insert(0, create_pretext_from_metadata(metadata))
+
         write_bokeh_graph(bokeh.layouts.column([div_element] + [e.figure for e in line_graph_list]), output_file)
 
     def to_csv(self, output_file: Path) -> None:
@@ -902,7 +917,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
 
         print_csv(self.df[columns], str(output_file))
 
-    def plot(self, output_file: Path) -> None:
+    def plot(self, output_file: Path, *, metadata: Optional[dict[str, Any]] = None) -> None:
         """
         全体の生産量や生産性をプロットする
         """
@@ -1117,4 +1132,8 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
 
-        write_bokeh_graph(bokeh.layouts.column([create_div_element()] + [e.figure for e in line_graph_list]), output_file)
+        element_list = [create_div_element()] + [e.figure for e in line_graph_list]
+        if metadata is not None:
+            element_list.insert(0, create_pretext_from_metadata(metadata))
+
+        write_bokeh_graph(bokeh.layouts.column(element_list), output_file)

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -732,7 +732,7 @@ class WholeProductivityPerCompletedDate:
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 
-        write_bokeh_graph(bokeh.layouts.column([div_element] + [e.figure for e in line_graph_list]), output_file)
+        write_bokeh_graph(bokeh.layouts.column(element_list), output_file)
 
     def to_csv(self, output_file: Path) -> None:
         """

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -16,6 +16,7 @@ import bokeh.palettes
 import pandas
 from annofabapi.models import TaskStatus
 from bokeh.models import DataRange1d
+from bokeh.models.ui import UIElement
 from bokeh.models.widgets.markups import Div
 from bokeh.plotting import ColumnDataSource
 from dateutil.parser import parse
@@ -505,7 +506,7 @@ class WholeProductivityPerCompletedDate:
             line_graph.process_after_adding_glyphs()
 
         div_element = self._create_div_element()
-        element_list = [div_element] + [e.figure for e in line_graph_list]
+        element_list:list[UIElement] = [div_element] + [e.figure for e in line_graph_list]
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 
@@ -727,7 +728,7 @@ class WholeProductivityPerCompletedDate:
 
         div_element = self._create_div_element()
 
-        element_list = [div_element] + [e.figure for e in line_graph_list]
+        element_list:list[UIElement] = [div_element] + [e.figure for e in line_graph_list]
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 
@@ -1132,7 +1133,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
 
-        element_list = [create_div_element()] + [e.figure for e in line_graph_list]
+        element_list:list[UIElement] = [create_div_element()] + [e.figure for e in line_graph_list]
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -506,7 +506,7 @@ class WholeProductivityPerCompletedDate:
             line_graph.process_after_adding_glyphs()
 
         div_element = self._create_div_element()
-        element_list:list[UIElement] = [div_element] + [e.figure for e in line_graph_list]
+        element_list: list[UIElement] = [div_element] + [e.figure for e in line_graph_list]
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 
@@ -728,7 +728,7 @@ class WholeProductivityPerCompletedDate:
 
         div_element = self._create_div_element()
 
-        element_list:list[UIElement] = [div_element] + [e.figure for e in line_graph_list]
+        element_list: list[UIElement] = [div_element] + [e.figure for e in line_graph_list]
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 
@@ -1133,7 +1133,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
 
-        element_list:list[UIElement] = [create_div_element()] + [e.figure for e in line_graph_list]
+        element_list: list[UIElement] = [create_div_element()] + [e.figure for e in line_graph_list]
         if metadata is not None:
             element_list.insert(0, create_pretext_from_metadata(metadata))
 

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import datetime
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import annofabapi
 import bokeh
@@ -16,8 +16,10 @@ import bokeh.layouts
 import bokeh.palettes
 import numpy
 import pandas
+from bokeh.models.ui import UIElement
 from bokeh.plotting import ColumnDataSource
 
+from annofabcli.common.bokeh import create_pretext_from_metadata
 from annofabcli.common.utils import print_csv
 from annofabcli.statistics.linegraph import (
     LineGraph,
@@ -341,11 +343,13 @@ class WorktimePerDate:
 
         return df
 
-    def plot_cumulatively(  # noqa: ANN201
+    def plot_cumulatively(
         self,
         output_file: Path,
+        *,
         target_user_id_list: Optional[list[str]] = None,
-    ):
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
         """
         作業時間の累積値をプロットする。
         """
@@ -460,7 +464,7 @@ class WorktimePerDate:
 
             plotted_users.append((user_id, username))
 
-        graph_group_list = []
+        graph_group_list: list[UIElement] = []
         for line_graph in line_graph_list:
             line_graph.process_after_adding_glyphs()
             hide_all_button = line_graph.create_button_hiding_showing_all_lines(is_hiding=True)
@@ -475,6 +479,9 @@ class WorktimePerDate:
         if line_count == 0:
             logger.warning(f"プロットするデータがなかっため、'{output_file}'は出力しません。")
             return
+
+        if metadata is not None:
+            graph_group_list.insert(0, create_pretext_from_metadata(metadata))
 
         write_bokeh_graph(bokeh.layouts.layout(graph_group_list), output_file)
 

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -373,7 +373,9 @@ class ProjectDir(DataClassJsonMixin):
 
     def write_worktime_line_graph(self, obj: WorktimePerDate, user_id_list: Optional[list[str]] = None) -> None:
         """横軸が日付、縦軸がユーザごとの作業時間である折れ線グラフを出力します。"""
-        obj.plot_cumulatively(self.project_dir / "line-graph/累積折れ線-横軸_日-縦軸_作業時間.html", user_id_list, metadata=self.metadata)
+        obj.plot_cumulatively(
+            self.project_dir / "line-graph/累積折れ線-横軸_日-縦軸_作業時間.html", target_user_id_list=user_id_list, metadata=self.metadata
+        )
 
     def read_project_info(self) -> ProjectInfo:
         """

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -106,8 +106,8 @@ class ProjectDir(DataClassJsonMixin):
         """
         タスク単位のヒストグラムを出力します。
         """
-        obj.plot_histogram_of_worktime(self.project_dir / "histogram/ヒストグラム-作業時間.html")
-        obj.plot_histogram_of_others(self.project_dir / "histogram/ヒストグラム.html")
+        obj.plot_histogram_of_worktime(self.project_dir / "histogram/ヒストグラム-作業時間.html", metadata=self.metadata)
+        obj.plot_histogram_of_others(self.project_dir / "histogram/ヒストグラム.html", metadata=self.metadata)
 
     def write_cumulative_line_graph(
         self,
@@ -135,6 +135,7 @@ class ProjectDir(DataClassJsonMixin):
             production_volume_name="アノテーション数",
             output_file=output_dir / f"{phase_name}者用/累積折れ線-横軸_アノテーション数-{phase_name}者用.html",
             target_user_id_list=user_id_list,
+            metadata=self.metadata,
         )
         for custom_production_volume in obj.custom_production_volume_list:
             obj.plot_production_volume_metrics(
@@ -142,6 +143,7 @@ class ProjectDir(DataClassJsonMixin):
                 production_volume_name=custom_production_volume.name,
                 output_file=output_dir / f"{phase_name}者用/累積折れ線-横軸_{custom_production_volume.name}-{phase_name}者用.html",
                 target_user_id_list=user_id_list,
+                metadata=self.metadata,
             )
 
         if not minimal_output:
@@ -151,6 +153,7 @@ class ProjectDir(DataClassJsonMixin):
                 production_volume_name="入力データ数",
                 output_file=output_dir / f"{phase_name}者用/累積折れ線-横軸_入力データ数-{phase_name}者用.html",
                 target_user_id_list=user_id_list,
+                metadata=self.metadata,
             )
 
     def write_performance_per_started_date_csv(self, obj: AbstractPhaseProductivityPerDate, phase: TaskPhase) -> None:
@@ -173,12 +176,14 @@ class ProjectDir(DataClassJsonMixin):
             production_volume_name="アノテーション",
             output_file=output_dir / Path(f"{phase_name}者用/折れ線-横軸_{phase_name}開始日-縦軸_アノテーション単位の指標-{phase_name}者用.html"),
             target_user_id_list=user_id_list,
+            metadata=self.metadata,
         )
         obj.plot_production_volume_metrics(
             production_volume_column="input_data_count",
             production_volume_name="入力データ",
             output_file=output_dir / Path(f"{phase_name}者用/折れ線-横軸_{phase_name}開始日-縦軸_入力データ単位の指標-{phase_name}者用.html"),
             target_user_id_list=user_id_list,
+            metadata=self.metadata,
         )
         for custom_production_volume in obj.custom_production_volume_list:
             obj.plot_production_volume_metrics(
@@ -187,6 +192,7 @@ class ProjectDir(DataClassJsonMixin):
                 output_file=output_dir
                 / Path(f"{phase_name}者用/折れ線-横軸_{phase_name}開始日-縦軸_{custom_production_volume.name}単位の指標-{phase_name}者用.html"),
                 target_user_id_list=user_id_list,
+                metadata=self.metadata,
             )
 
     def read_whole_performance(self) -> WholePerformance:
@@ -367,7 +373,7 @@ class ProjectDir(DataClassJsonMixin):
 
     def write_worktime_line_graph(self, obj: WorktimePerDate, user_id_list: Optional[list[str]] = None) -> None:
         """横軸が日付、縦軸がユーザごとの作業時間である折れ線グラフを出力します。"""
-        obj.plot_cumulatively(self.project_dir / "line-graph/累積折れ線-横軸_日-縦軸_作業時間.html", user_id_list)
+        obj.plot_cumulatively(self.project_dir / "line-graph/累積折れ線-横軸_日-縦軸_作業時間.html", user_id_list, metadata=self.metadata)
 
     def read_project_info(self) -> ProjectInfo:
         """

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -4,7 +4,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from annofabapi.models import TaskPhase
 from dataclasses_json import DataClassJsonMixin
@@ -35,6 +35,7 @@ class ProjectDir(DataClassJsonMixin):
 
     Args:
         project_dir: ``annofabcli statistics visualize``コマンドによって出力されたプロジェクトディレクトリ
+        metadata:
     """
 
     FILENAME_WHOLE_PERFORMANCE = "全体の生産性と品質.csv"
@@ -48,8 +49,9 @@ class ProjectDir(DataClassJsonMixin):
     FILENAME_PROJECT_INFO = "project_info.json"
     FILENAME_MERGE_INFO = "merge_info.json"
 
-    def __init__(self, project_dir: Path) -> None:
+    def __init__(self, project_dir: Path, *, metadata: Optional[dict[str, Any]] = None) -> None:
         self.project_dir = project_dir
+        self.metadata = metadata
 
     def __repr__(self) -> str:
         return f"ProjectDir(project_dir={self.project_dir!r})"
@@ -216,8 +218,8 @@ class ProjectDir(DataClassJsonMixin):
         """
         横軸が日付、縦軸が全体の生産性などをプロットした折れ線グラフを出力します。
         """
-        obj.plot(self.project_dir / "line-graph/折れ線-横軸_日-全体.html")
-        obj.plot_cumulatively(self.project_dir / "line-graph/累積折れ線-横軸_日-全体.html")
+        obj.plot(self.project_dir / "line-graph/折れ線-横軸_日-全体.html", metadata=self.metadata)
+        obj.plot_cumulatively(self.project_dir / "line-graph/累積折れ線-横軸_日-全体.html", metadata=self.metadata)
 
     def read_whole_productivity_per_first_annotation_started_date(
         self,
@@ -239,7 +241,7 @@ class ProjectDir(DataClassJsonMixin):
         """
         横軸が教師付開始日、縦軸が全体の生産性などをプロットした折れ線グラフを出力します。
         """
-        obj.plot(self.project_dir / "line-graph/折れ線-横軸_教師付開始日-全体.html")
+        obj.plot(self.project_dir / "line-graph/折れ線-横軸_教師付開始日-全体.html", metadata=self.metadata)
 
     def read_user_performance(self) -> UserPerformance:
         """
@@ -268,21 +270,25 @@ class ProjectDir(DataClassJsonMixin):
             output_dir / "散布図-アノテーションあたり作業時間と累計作業時間の関係-計測時間.html",
             worktime_type=WorktimeType.MONITORED,
             production_volume_column="annotation_count",
+            metadata=self.metadata,
         )
         obj.plot_productivity(
             output_dir / "散布図-入力データあたり作業時間と累計作業時間の関係-計測時間.html",
             worktime_type=WorktimeType.MONITORED,
             production_volume_column="input_data_count",
+            metadata=self.metadata,
         )
         obj.plot_quality_and_productivity(
             output_dir / "散布図-アノテーションあたり作業時間と品質の関係-計測時間-教師付者用.html",
             worktime_type=WorktimeType.MONITORED,
             production_volume_column="annotation_count",
+            metadata=self.metadata,
         )
         obj.plot_quality_and_productivity(
             output_dir / "散布図-入力データあたり作業時間と品質の関係-計測時間-教師付者用.html",
             worktime_type=WorktimeType.MONITORED,
             production_volume_column="input_data_count",
+            metadata=self.metadata,
         )
 
         for custom_production_volume in obj.custom_production_volume_list:
@@ -290,11 +296,13 @@ class ProjectDir(DataClassJsonMixin):
                 output_dir / f"散布図-{custom_production_volume.name}あたり作業時間と累計作業時間の関係-計測時間.html",
                 worktime_type=WorktimeType.MONITORED,
                 production_volume_column=custom_production_volume.value,
+                metadata=self.metadata,
             )
             obj.plot_quality_and_productivity(
                 output_dir / f"散布図-{custom_production_volume.name}あたり作業時間と品質の関係-計測時間-教師付者用.html",
                 worktime_type=WorktimeType.MONITORED,
                 production_volume_column=custom_production_volume.value,
+                metadata=self.metadata,
             )
 
         if obj.actual_worktime_exists():
@@ -302,33 +310,39 @@ class ProjectDir(DataClassJsonMixin):
                 output_dir / "散布図-アノテーションあたり作業時間と累計作業時間の関係-実績時間.html",
                 worktime_type=WorktimeType.ACTUAL,
                 production_volume_column="annotation_count",
+                metadata=self.metadata,
             )
             obj.plot_productivity(
                 output_dir / "散布図-入力データあたり作業時間と累計作業時間の関係-実績時間.html",
                 worktime_type=WorktimeType.ACTUAL,
                 production_volume_column="input_data_count",
+                metadata=self.metadata,
             )
 
             obj.plot_quality_and_productivity(
                 output_dir / "散布図-アノテーションあたり作業時間と品質の関係-実績時間-教師付者用.html",
                 worktime_type=WorktimeType.ACTUAL,
                 production_volume_column="annotation_count",
+                metadata=self.metadata,
             )
             obj.plot_quality_and_productivity(
                 output_dir / "散布図-入力データあたり作業時間と品質の関係-実績時間-教師付者用.html",
                 worktime_type=WorktimeType.ACTUAL,
                 production_volume_column="input_data_count",
+                metadata=self.metadata,
             )
             for custom_production_volume in obj.custom_production_volume_list:
                 obj.plot_productivity(
                     output_dir / f"散布図-{custom_production_volume.name}あたり作業時間と累計作業時間の関係-実績時間.html",
                     worktime_type=WorktimeType.ACTUAL,
                     production_volume_column=custom_production_volume.value,
+                    metadata=self.metadata,
                 )
                 obj.plot_quality_and_productivity(
                     output_dir / f"散布図-{custom_production_volume.name}あたり作業時間と品質の関係-実績時間-教師付者用.html",
                     worktime_type=WorktimeType.ACTUAL,
                     production_volume_column=custom_production_volume.value,
+                    metadata=self.metadata,
                 )
 
         else:


### PR DESCRIPTION
HTMLファイルだけでは、どのプロジェクトに対してどのようにグラフを出力したのかが分からないため、グラフ上部にメタデータを表示できるようにしました。