### PR TITLE
`statistics visualize` : `--task_completion_criteria accpetance_reached`を指定したときに、受入作業時間を0にする

### DIFF
--- a/annofabcli/stat_visualization/mask_visualization_dir.py
+++ b/annofabcli/stat_visualization/mask_visualization_dir.py
@@ -176,7 +176,9 @@ def mask_visualization_dir(
     )
 
     # CSVのユーザ情報をマスクする
-    masked_user_performance = UserPerformance.from_df_wrapper(masked_worktime_per_date, masked_task_worktime_by_phase_user)
+    masked_user_performance = UserPerformance.from_df_wrapper(
+        masked_worktime_per_date, masked_task_worktime_by_phase_user, task_completion_criteria=project_dir.task_completion_criteria
+    )
     output_project_dir.write_user_performance(masked_user_performance)
 
     # メンバのパフォーマンスを散布図で出力する

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -213,8 +213,16 @@ def merge_visualization_dir(  # pylint: disable=too-many-statements
     task = merging_obj.merge_task_list()
     worktime_per_date = merging_obj.merge_worktime_per_date()
 
-    user_performance = UserPerformance.from_df_wrapper(task_worktime_by_phase_user=task_worktime_by_phase_user, worktime_per_date=worktime_per_date)
-    whole_performance = WholePerformance.from_df_wrapper(task_worktime_by_phase_user=task_worktime_by_phase_user, worktime_per_date=worktime_per_date)
+    user_performance = UserPerformance.from_df_wrapper(
+        task_worktime_by_phase_user=task_worktime_by_phase_user,
+        worktime_per_date=worktime_per_date,
+        task_completion_criteria=task_completion_criteria,
+    )
+    whole_performance = WholePerformance.from_df_wrapper(
+        task_worktime_by_phase_user=task_worktime_by_phase_user,
+        worktime_per_date=worktime_per_date,
+        task_completion_criteria=task_completion_criteria,
+    )
     writing_obj = WritingVisualizationFile(
         output_project_dir, user_id_list=user_id_list, minimal_output=minimal_output, task_completion_criteria=task_completion_criteria
     )

--- a/annofabcli/statistics/visualization/dataframe/task.py
+++ b/annofabcli/statistics/visualization/dataframe/task.py
@@ -82,6 +82,19 @@ class Task:
             return False
         return True
 
+    def to_non_acceptance(self) -> Task:
+        """
+        受入フェーズの作業時間を0にした新しいインスタンスを生成します。
+
+        `--task_completion_criteria acceptance_reached`を指定したときに利用します。
+        この場合、受入フェーズの作業時間を無視して集計する必要があるためです。
+
+        """
+        df = self.df.copy()
+        df["first_acceptance_worktime_hour"] = 0
+        df["acceptance_worktime_hour"] = 0
+        return Task(df, custom_production_volume_list=self.custom_production_volume_list)
+
     @property
     def columns(self) -> list[str]:
         return [

--- a/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
+++ b/annofabcli/statistics/visualization/dataframe/task_worktime_by_phase_user.py
@@ -51,6 +51,18 @@ class TaskWorktimeByPhaseUser:
             "rejected_count",
         ]
 
+    def to_non_acceptance(self) -> TaskWorktimeByPhaseUser:
+        """
+        受入フェーズの作業時間を0にした新しいインスタンスを生成します。
+
+        `--task_completion_criteria acceptance_reached`を指定したときに利用します。
+        この場合、受入フェーズの作業時間を無視して集計する必要があるためです。
+
+        """
+        df = self.df.copy()
+        df = df[df["phase"] != TaskPhase.ACCEPTANCE.value]
+        return TaskWorktimeByPhaseUser(df, custom_production_volume_list=self.custom_production_volume_list)
+
     @property
     def columns(self) -> list[str]:
         """

--- a/annofabcli/statistics/visualization/dataframe/user_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/user_performance.py
@@ -303,10 +303,10 @@ class UserPerformance:
 
         if task_completion_criteria == TaskCompletionCriteria.ACCEPTANCE_REACHED:
             # 受入フェーズに到達したらタスクの作業が完了したとみなす場合、受入フェーズの作業時間や生産量は不要な情報なので、削除する
-            df2 = df2[[col for col in df2.columns if col[0] != TaskPhase.ACCEPTANCE.value]]
+            df2 = df2[[col for col in df2.columns if col[1] != TaskPhase.ACCEPTANCE.value]]
 
         phase_list = list(df2["monitored_worktime_hour"].columns)
-
+        
         # 計測作業時間の合計値を算出する
         df2[("monitored_worktime_hour", "sum")] = df2[[("monitored_worktime_hour", phase) for phase in phase_list]].sum(axis=1)
         return df2

--- a/annofabcli/statistics/visualization/dataframe/whole_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_performance.py
@@ -241,7 +241,7 @@ class WholePerformance:
             return
 
         # 列の順番を整える
-        phase_list = UserPerformance.get_phase_list(self.series.index, self.task_completion_criteria)
+        phase_list = UserPerformance.get_phase_list(self.series.index)
         production_volume_columns = ["input_data_count", "annotation_count", *[e.value for e in self.custom_production_volume_list]]
         indexes = self.get_series_index(phase_list, production_volume_columns=production_volume_columns)
         series = self.series[indexes]

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -159,6 +159,10 @@ class WholeProductivityPerCompletedDate:
                 monitored_acceptance_worktime_hour
         """
 
+        if task_completion_criteria == TaskCompletionCriteria.ACCEPTANCE_REACHED:
+            # 受入フェーズに到達したらタスクの作業が完了したとみなす場合、受入フェーズの作業時間や生産量は不要な情報なので、受入作業時間を0にする
+            worktime_per_date = worktime_per_date.to_non_acceptance()
+
         # 生産量を表す列名
         production_volume_columns = ["input_data_count", "annotation_count", *[e.value for e in task.custom_production_volume_list]]
 
@@ -875,6 +879,10 @@ class WholeProductivityPerFirstAnnotationStartedDate:
     def from_task(cls, task: Task, task_completion_criteria: TaskCompletionCriteria) -> WholeProductivityPerFirstAnnotationStartedDate:
         # 生産量を表す列名
         production_volume_columns = ["input_data_count", "annotation_count", *[e.value for e in task.custom_production_volume_list]]
+
+        if task_completion_criteria == TaskCompletionCriteria.ACCEPTANCE_REACHED:
+            # 受入フェーズに到達したらタスクの作業が完了したとみなす場合、受入フェーズの作業時間や生産量は不要な情報なので、受入作業時間を0にする
+            task = task.to_non_acceptance()
 
         df_task = task.df
         if task_completion_criteria == TaskCompletionCriteria.ACCEPTANCE_COMPLETED:

--- a/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/whole_productivity_per_date.py
@@ -280,7 +280,11 @@ class WholeProductivityPerCompletedDate:
             str_task = "受入フェーズ"
         else:
             assert_noreturn(self.task_completion_criteria)
-        return Div(text="<h4>注意</h4>" f"<p>「X日のタスク数」は、X日に初めて{str_task}になったタスクの個数です。</p>")
+
+        elm_list = ["<h4>注意</h4>", f"<p>「X日のタスク数」は、X日に初めて{str_task}になったタスクの個数です。</p>"]
+        if self.task_completion_criteria == TaskCompletionCriteria.ACCEPTANCE_REACHED:
+            elm_list.append("<p>タスクが受入フェーズに到達したら作業が完了したとみなしているため、受入作業時間は0にしています。</p>")
+        return Div(text=" ".join(elm_list))
 
     def plot(
         self,
@@ -995,7 +999,7 @@ class WholeProductivityPerFirstAnnotationStartedDate:
 
         print_csv(self.df[self.columns], str(output_file))
 
-    def plot(self, output_file: Path, *, metadata: Optional[dict[str, Any]] = None) -> None:
+    def plot(self, output_file: Path, *, metadata: Optional[dict[str, Any]] = None) -> None:  # noqa: PLR0915
         """
         全体の生産量や生産性をプロットする
         """
@@ -1028,11 +1032,12 @@ class WholeProductivityPerFirstAnnotationStartedDate:
                 str_task = "受入フェーズ"
             else:
                 assert_noreturn(self.task_completion_criteria)
-            return Div(
-                text="<h4>注意</h4>"
-                f"<p>「X日のタスク数」は、X日に教師付フェーズを開始したタスクの内、{str_task}であるタスクの個数です。</p>"
-                f"<p>「X日の作業時間」は、X日のタスク数にかけた作業時間です。X日に作業した時間ではないことに注意してください。</p>"
-            )
+
+            elm_list = ["<h4>注意</h4>", f"<p>「X日のタスク数」は、X日に教師付フェーズを開始したタスクの内、{str_task}であるタスクの個数です。</p>"]
+            if self.task_completion_criteria == TaskCompletionCriteria.ACCEPTANCE_REACHED:
+                elm_list.append("<p>タスクが受入フェーズに到達したら作業が完了したとみなしているため、受入作業時間は0にしています。</p>")
+
+            return Div(text=" ".join(elm_list))
 
         def create_line_graph(title: str, y_axis_label: str, tooltip_columns: list[str]) -> LineGraph:
             return LineGraph(

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -100,6 +100,21 @@ class WorktimePerDate:
         "monitored_acceptance_worktime_hour",
     ]
 
+    def to_non_acceptance(self) -> WorktimePerDate:
+        """
+        受入フェーズの作業時間を0にした新しいインスタンスを生成します。
+
+        `--task_completion_criteria acceptance_reached`を指定したときに利用します。
+        この場合、受入フェーズの作業時間を無視して集計する必要があるためです。
+
+        """
+        df = self.df.copy()
+        df["monitored_acceptance_worktime_hour"] = 0
+        df["monitored_worktime_hour"] = (
+            df["monitored_annotation_worktime_hour"] + df["monitored_inspection_worktime_hour"] + df["monitored_acceptance_worktime_hour"]
+        )
+        return WorktimePerDate(df)
+
     def is_empty(self) -> bool:
         """
         空のデータフレームを持つかどうかを返します。

--- a/annofabcli/statistics/visualization/project_dir.py
+++ b/annofabcli/statistics/visualization/project_dir.py
@@ -209,10 +209,14 @@ class ProjectDir(DataClassJsonMixin):
         """`全体の生産性と品質.csv`を読み込む。"""
         file = self.project_dir / self.FILENAME_WHOLE_PERFORMANCE
         if file.exists():
-            return WholePerformance.from_csv(file, custom_production_volume_list=self.custom_production_volume_list)
+            return WholePerformance.from_csv(
+                file, custom_production_volume_list=self.custom_production_volume_list, task_completion_criteria=self.task_completion_criteria
+            )
         else:
             logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
-            return WholePerformance.empty(custom_production_volume_list=self.custom_production_volume_list)
+            return WholePerformance.empty(
+                custom_production_volume_list=self.custom_production_volume_list, task_completion_criteria=self.task_completion_criteria
+            )
 
     def write_whole_performance(self, whole_performance: WholePerformance) -> None:
         """`全体の生産性と品質.csv`を出力します。"""
@@ -281,10 +285,14 @@ class ProjectDir(DataClassJsonMixin):
         """
         file = self.project_dir / self.FILENAME_USER_PERFORMANCE
         if file.exists():
-            return UserPerformance.from_csv(file, custom_production_volume_list=self.custom_production_volume_list)
+            return UserPerformance.from_csv(
+                file, custom_production_volume_list=self.custom_production_volume_list, task_completion_criteria=self.task_completion_criteria
+            )
         else:
             logger.warning(f"'{file!s}'を読み込もうとしましたが、ファイルは存在しません。")
-            return UserPerformance.empty(custom_production_volume_list=self.custom_production_volume_list)
+            return UserPerformance.empty(
+                custom_production_volume_list=self.custom_production_volume_list, task_completion_criteria=self.task_completion_criteria
+            )
 
     def write_user_performance(self, user_performance: UserPerformance) -> None:
         """

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -176,6 +176,7 @@ class WriteCsvGraph:
         user_performance = UserPerformance.from_df_wrapper(
             task_worktime_by_phase_user=task_worktime_obj,
             worktime_per_date=self._get_worktime_per_date(),
+            task_completion_criteria=self.task_completion_criteria,
         )
 
         self.project_dir.write_user_performance(user_performance)
@@ -183,6 +184,7 @@ class WriteCsvGraph:
         whole_performance = WholePerformance.from_df_wrapper(
             task_worktime_by_phase_user=task_worktime_obj,
             worktime_per_date=self._get_worktime_per_date(),
+            task_completion_criteria=self.task_completion_criteria,
         )
         self.project_dir.write_whole_performance(whole_performance)
 

--- a/tests/statistics/visualization/dataframe/test_user_performance.py
+++ b/tests/statistics/visualization/dataframe/test_user_performance.py
@@ -47,14 +47,13 @@ class TestUserPerformance:
         actual = UserPerformance.from_df_wrapper(
             task_worktime_by_phase_user=task_worktime_by_phase_user,
             worktime_per_date=worktime_per_date,
-            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED
+            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED,
         )
         actual.to_csv(output_dir / "test__from_df__集計対象タスクが0件のとき.csv")
         assert len(actual.df) == 2
         assert actual.df[("user_id", "")][0] == "alice"
         assert actual.df[("real_actual_worktime_hour", "sum")][0] == 6
         assert actual.df[("task_count", "annotation")][0] == 0
-
 
     def test__from_df_wrapper__task_completion_criteria_is_acceptance_reached(self):
         task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
@@ -70,9 +69,7 @@ class TestUserPerformance:
             worktime_per_date=worktime_per_date,
             task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_REACHED,
         )
-        assert ("task_count","acceptance") not in actual.df.columns
-
-
+        assert ("task_count", "acceptance") not in actual.df.columns
 
     def test___create_df_working_period(self) -> None:
         worktime_per_date = WorktimePerDate.from_csv(data_dir / "worktime-per-date.csv")

--- a/tests/statistics/visualization/dataframe/test_user_performance.py
+++ b/tests/statistics/visualization/dataframe/test_user_performance.py
@@ -39,9 +39,6 @@ class TestUserPerformance:
         assert actual.df[("user_id", "")][0] == "alice"
         assert actual.df[("real_actual_worktime_hour", "sum")][0] == 6
         assert actual.df[("task_count", "annotation")][0] == 1
-        import pandas
-
-        pandas.set_option("display.max_rows", None)
 
     def test__from_df_wrapper__集計対象タスクが0件のとき(self):
         task_worktime_by_phase_user = TaskWorktimeByPhaseUser.empty()
@@ -57,6 +54,25 @@ class TestUserPerformance:
         assert actual.df[("user_id", "")][0] == "alice"
         assert actual.df[("real_actual_worktime_hour", "sum")][0] == 6
         assert actual.df[("task_count", "annotation")][0] == 0
+
+
+    def test__from_df_wrapper__task_completion_criteria_is_acceptance_reached(self):
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
+            data_dir / "task-worktime-by-user-phase.csv",
+            custom_production_volume_list=[
+                ProductionVolumeColumn("custom_production_volume1", "custom_生産量1"),
+            ],
+        )
+        worktime_per_date = WorktimePerDate.from_csv(data_dir / "worktime-per-date.csv")
+
+        actual = UserPerformance.from_df_wrapper(
+            task_worktime_by_phase_user=task_worktime_by_phase_user,
+            worktime_per_date=worktime_per_date,
+            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_REACHED,
+        )
+        assert ("task_count","acceptance") not in actual.df.columns
+
+
 
     def test___create_df_working_period(self) -> None:
         worktime_per_date = WorktimePerDate.from_csv(data_dir / "worktime-per-date.csv")

--- a/tests/statistics/visualization/dataframe/test_user_performance.py
+++ b/tests/statistics/visualization/dataframe/test_user_performance.py
@@ -6,7 +6,7 @@ from annofabcli.statistics.visualization.dataframe.user_performance import (
     WorktimeType,
 )
 from annofabcli.statistics.visualization.dataframe.worktime_per_date import WorktimePerDate
-from annofabcli.statistics.visualization.model import ProductionVolumeColumn
+from annofabcli.statistics.visualization.model import ProductionVolumeColumn, TaskCompletionCriteria
 
 output_dir = Path("./tests/out/statistics/visualization/dataframe/user_perforamance")
 data_dir = Path("./tests/data/statistics")
@@ -18,7 +18,7 @@ class TestUserPerformance:
 
     @classmethod
     def setup_class(cls) -> None:
-        cls.obj = UserPerformance.from_csv(data_dir / "productivity-per-user2.csv")
+        cls.obj = UserPerformance.from_csv(data_dir / "productivity-per-user2.csv", TaskCompletionCriteria.ACCEPTANCE_COMPLETED)
 
     def test__from_df_wrapper__to_csv(self):
         task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
@@ -32,6 +32,7 @@ class TestUserPerformance:
         actual = UserPerformance.from_df_wrapper(
             task_worktime_by_phase_user=task_worktime_by_phase_user,
             worktime_per_date=worktime_per_date,
+            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED,
         )
         actual.to_csv(output_dir / "test__from_df__to_csv.csv")
         assert len(actual.df) == 2
@@ -49,6 +50,7 @@ class TestUserPerformance:
         actual = UserPerformance.from_df_wrapper(
             task_worktime_by_phase_user=task_worktime_by_phase_user,
             worktime_per_date=worktime_per_date,
+            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED
         )
         actual.to_csv(output_dir / "test__from_df__集計対象タスクが0件のとき.csv")
         assert len(actual.df) == 2

--- a/tests/statistics/visualization/dataframe/test_whole_performance.py
+++ b/tests/statistics/visualization/dataframe/test_whole_performance.py
@@ -5,6 +5,7 @@ from annofabcli.statistics.visualization.dataframe.whole_performance import (
     WholePerformance,
 )
 from annofabcli.statistics.visualization.dataframe.worktime_per_date import WorktimePerDate
+from annofabcli.statistics.visualization.model import TaskCompletionCriteria
 
 output_dir = Path("./tests/out/statistics/visualization/dataframe/whole_performance")
 data_dir = Path("./tests/data/statistics")
@@ -19,6 +20,7 @@ class TestWholePerformance:
         actual = WholePerformance.from_df_wrapper(
             task_worktime_by_phase_user=task_worktime_by_phase_user,
             worktime_per_date=worktime_per_date,
+            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED,
         )
         actual.to_csv(output_dir / "test__from_df__to_csv.csv")
 
@@ -27,13 +29,13 @@ class TestWholePerformance:
         assert actual.series[("working_user_count", "annotation")] == 2
 
     def test__empty__to_csv(self):
-        empty = WholePerformance.empty()
+        empty = WholePerformance.empty(TaskCompletionCriteria.ACCEPTANCE_COMPLETED)
         empty.to_csv(output_dir / "test__empty__to_csv.csv")
         assert empty.series[("real_monitored_worktime_hour", "sum")] == 0
         assert empty.series[("task_count", "annotation")] == 0
 
     def test__from_csv__to_csv(self):
-        actual = WholePerformance.from_csv(data_dir / "全体の生産性と品質.csv")
+        actual = WholePerformance.from_csv(data_dir / "全体の生産性と品質.csv", TaskCompletionCriteria.ACCEPTANCE_COMPLETED)
 
         assert actual.series["task_count"]["annotation"] == 110.0
         actual.to_csv(output_dir / "test__from_csv__to_csv.csv")
@@ -44,5 +46,6 @@ class TestWholePerformance:
         actual = WholePerformance._create_all_user_performance(
             task_worktime_by_phase_user=task_worktime_by_phase_user,
             worktime_per_date=worktime_per_date,
+            task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED,
         )
         assert len(actual.df) == 1


### PR DESCRIPTION
#645 

以下のCSVとそのCSVから生成したグラフでは、`--task_completion_criteria accpetance_reached`を指定したときに受入作業時間を0にしました。

* `メンバごとの生産性と品質.csv`
* `全体の生産性と品質.csv`
* `日毎の生産量と生産性.csv`
* `教師付開始日毎の生産量と生産性.csv`

受入フェーズに到達したらタスクが完了したことになるため、受入作業時間は不要だからです。

