### PR TITLE
`statistics visualize` : １個のタスクを複数人で作業した場合に、`折れ線-横軸_教師付開始日`などのグラフに対応するようにしました。

### DIFF
--- a/annofabcli/stat_visualization/mask_visualization_dir.py
+++ b/annofabcli/stat_visualization/mask_visualization_dir.py
@@ -119,9 +119,9 @@ def write_line_graph(
         minimal_output=minimal_output,
     )
 
-    annotator_per_date_obj = AnnotatorProductivityPerDate.from_task(task)
-    inspector_per_date_obj = InspectorProductivityPerDate.from_task(task)
-    acceptor_per_date_obj = AcceptorProductivityPerDate.from_task(task)
+    annotator_per_date_obj = AnnotatorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+    inspector_per_date_obj = InspectorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+    acceptor_per_date_obj = AcceptorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
 
     output_project_dir.write_performance_per_started_date_csv(annotator_per_date_obj, phase=TaskPhase.ANNOTATION)
     output_project_dir.write_performance_per_started_date_csv(inspector_per_date_obj, phase=TaskPhase.INSPECTION)

--- a/annofabcli/stat_visualization/mask_visualization_dir.py
+++ b/annofabcli/stat_visualization/mask_visualization_dir.py
@@ -29,7 +29,6 @@ from annofabcli.statistics.visualization.dataframe.productivity_per_date import 
     AnnotatorProductivityPerDate,
     InspectorProductivityPerDate,
 )
-from annofabcli.statistics.visualization.dataframe.task import Task
 from annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user import TaskWorktimeByPhaseUser
 from annofabcli.statistics.visualization.dataframe.user_performance import UserPerformance
 from annofabcli.statistics.visualization.dataframe.worktime_per_date import WorktimePerDate
@@ -94,21 +93,27 @@ def create_replacement_dict(
     )
 
 
-def write_line_graph(task: Task, output_project_dir: ProjectDir, user_id_list: Optional[List[str]] = None, minimal_output: bool = False):  # noqa: ANN201, FBT001, FBT002
+def write_line_graph(
+    task_worktime_by_phase_user: TaskWorktimeByPhaseUser,
+    output_project_dir: ProjectDir,
+    *,
+    user_id_list: Optional[List[str]] = None,
+    minimal_output: bool = False,
+) -> None:
     output_project_dir.write_cumulative_line_graph(
-        AnnotatorCumulativeProductivity.from_task(task),
+        AnnotatorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user),
         phase=TaskPhase.ANNOTATION,
         user_id_list=user_id_list,
         minimal_output=minimal_output,
     )
     output_project_dir.write_cumulative_line_graph(
-        InspectorCumulativeProductivity.from_task(task),
+        InspectorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user),
         phase=TaskPhase.INSPECTION,
         user_id_list=user_id_list,
         minimal_output=minimal_output,
     )
     output_project_dir.write_cumulative_line_graph(
-        AcceptorCumulativeProductivity.from_task(task),
+        AcceptorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user),
         phase=TaskPhase.ACCEPTANCE,
         user_id_list=user_id_list,
         minimal_output=minimal_output,
@@ -189,7 +194,7 @@ def mask_visualization_dir(
     )
     output_project_dir.write_task_list(masked_task)
 
-    write_line_graph(masked_task, output_project_dir, minimal_output=minimal_output)
+    write_line_graph(masked_task_worktime_by_phase_user, output_project_dir, minimal_output=minimal_output)
 
     if not masked_worktime_per_date.is_empty():
         output_project_dir.write_worktime_per_date_user(masked_worktime_per_date)

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -233,8 +233,8 @@ def merge_visualization_dir(  # pylint: disable=too-many-statements
     writing_obj.write_user_performance(user_performance)
     writing_obj.write_whole_performance(whole_performance)
 
-    writing_obj.write_cumulative_line_graph(task)
-    writing_obj.write_line_graph(task)
+    writing_obj.write_cumulative_line_graph(task_worktime_by_phase_user)
+    writing_obj.write_line_graph(task_worktime_by_phase_user)
 
     writing_obj.write_merge_performance_per_date(task, worktime_per_date)
     writing_obj.write_performance_per_first_annotation_started_date(task)

--- a/annofabcli/stat_visualization/merge_visualization_dir.py
+++ b/annofabcli/stat_visualization/merge_visualization_dir.py
@@ -68,34 +68,34 @@ class WritingVisualizationFile:
         self.output_project_dir.write_whole_performance(whole_performance)
 
     @_catch_exception
-    def write_cumulative_line_graph(self, task: Task) -> None:
+    def write_cumulative_line_graph(self, task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> None:
         """ユーザごとにプロットした累積折れ線グラフを出力する。"""
         self.output_project_dir.write_cumulative_line_graph(
-            AnnotatorCumulativeProductivity.from_task(task),
+            AnnotatorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user),
             phase=TaskPhase.ANNOTATION,
             user_id_list=self.user_id_list,
             minimal_output=self.minimal_output,
         )
         self.output_project_dir.write_cumulative_line_graph(
-            InspectorCumulativeProductivity.from_task(task),
+            InspectorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user),
             phase=TaskPhase.INSPECTION,
             user_id_list=self.user_id_list,
             minimal_output=self.minimal_output,
         )
         self.output_project_dir.write_cumulative_line_graph(
-            AcceptorCumulativeProductivity.from_task(task),
+            AcceptorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user),
             phase=TaskPhase.ACCEPTANCE,
             user_id_list=self.user_id_list,
             minimal_output=self.minimal_output,
         )
 
     @_catch_exception
-    def write_line_graph(self, task: Task) -> None:
+    def write_line_graph(self, task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> None:
         """ユーザごとにプロットした折れ線グラフを出力する。"""
 
-        annotator_per_date_obj = AnnotatorProductivityPerDate.from_task(task)
-        inspector_per_date_obj = InspectorProductivityPerDate.from_task(task)
-        acceptor_per_date_obj = AcceptorProductivityPerDate.from_task(task)
+        annotator_per_date_obj = AnnotatorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+        inspector_per_date_obj = InspectorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+        acceptor_per_date_obj = AcceptorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
 
         self.output_project_dir.write_performance_per_started_date_csv(annotator_per_date_obj, phase=TaskPhase.ANNOTATION)
         self.output_project_dir.write_performance_per_started_date_csv(inspector_per_date_obj, phase=TaskPhase.INSPECTION)

--- a/annofabcli/stat_visualization/write_graph.py
+++ b/annofabcli/stat_visualization/write_graph.py
@@ -20,7 +20,7 @@ from annofabcli.statistics.visualization.dataframe.productivity_per_date import 
     AnnotatorProductivityPerDate,
     InspectorProductivityPerDate,
 )
-from annofabcli.statistics.visualization.dataframe.task import Task
+from annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user import TaskWorktimeByPhaseUser
 from annofabcli.statistics.visualization.model import ProductionVolumeColumn, TaskCompletionCriteria
 from annofabcli.statistics.visualization.project_dir import ProjectDir
 
@@ -41,30 +41,30 @@ class WritingGraph:
         self.user_id_list = user_id_list
         self.minimal_output = minimal_output
 
-    def write_line_graph(self, task: Task) -> None:
+    def write_line_graph(self, task_worktime_list: TaskWorktimeByPhaseUser) -> None:
         self.output_project_dir.write_cumulative_line_graph(
-            AnnotatorCumulativeProductivity.from_task(task),
+            AnnotatorCumulativeProductivity.from_df_wrapper(task_worktime_list),
             phase=TaskPhase.ANNOTATION,
             user_id_list=self.user_id_list,
             minimal_output=self.minimal_output,
         )
         self.output_project_dir.write_cumulative_line_graph(
-            InspectorCumulativeProductivity.from_task(task),
+            InspectorCumulativeProductivity.from_df_wrapper(task_worktime_list),
             phase=TaskPhase.INSPECTION,
             user_id_list=self.user_id_list,
             minimal_output=self.minimal_output,
         )
         self.output_project_dir.write_cumulative_line_graph(
-            AcceptorCumulativeProductivity.from_task(task),
+            AcceptorCumulativeProductivity.from_df_wrapper(task_worktime_list),
             phase=TaskPhase.ACCEPTANCE,
             user_id_list=self.user_id_list,
             minimal_output=self.minimal_output,
         )
 
         if not self.minimal_output:
-            annotator_per_date_obj = AnnotatorProductivityPerDate.from_task(task)
-            inspector_per_date_obj = InspectorProductivityPerDate.from_task(task)
-            acceptor_per_date_obj = AcceptorProductivityPerDate.from_task(task)
+            annotator_per_date_obj = AnnotatorProductivityPerDate.from_df_wrapper(task_worktime_list)
+            inspector_per_date_obj = InspectorProductivityPerDate.from_df_wrapper(task_worktime_list)
+            acceptor_per_date_obj = AcceptorProductivityPerDate.from_df_wrapper(task_worktime_list)
 
             self.output_project_dir.write_performance_line_graph_per_date(
                 annotator_per_date_obj, phase=TaskPhase.ANNOTATION, user_id_list=self.user_id_list
@@ -89,6 +89,13 @@ class WritingGraph:
             self.output_project_dir.write_task_histogram(task)
             # ユーザごとにプロットした折れ線グラフを出力
             self.write_line_graph(task)
+        except Exception:
+            logger.warning("'タスクlist.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
+
+        try:
+            task_worktime_list = self.project_dir.read_task_worktime_list()
+            # ユーザごとにプロットした折れ線グラフを出力
+            self.write_line_graph(task_worktime_list)
         except Exception:
             logger.warning("'タスクlist.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
 

--- a/annofabcli/stat_visualization/write_graph.py
+++ b/annofabcli/stat_visualization/write_graph.py
@@ -87,8 +87,6 @@ class WritingGraph:
             task = self.project_dir.read_task_list()
             # ヒストグラムを出力
             self.output_project_dir.write_task_histogram(task)
-            # ユーザごとにプロットした折れ線グラフを出力
-            self.write_line_graph(task)
         except Exception:
             logger.warning("'タスクlist.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
 
@@ -97,7 +95,7 @@ class WritingGraph:
             # ユーザごとにプロットした折れ線グラフを出力
             self.write_line_graph(task_worktime_list)
         except Exception:
-            logger.warning("'タスクlist.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
+            logger.warning("'task-worktime-by-user-phase.csv'から生成できるグラフの出力に失敗しました。", exc_info=True)
 
         try:
             self.output_project_dir.write_whole_productivity_line_graph_per_date(self.project_dir.read_whole_productivity_per_date())

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -37,9 +37,8 @@ def _create_cumulative_dataframe(task_worktime_by_phase_user: TaskWorktimeByPhas
     累積情報が格納されたDataFrameを生成する。
     """
     df = task_worktime_by_phase_user.df.copy()
-    str_phase = phase
+    str_phase = phase.value
     df = df[df["phase"] == str_phase]
-
     df = df.rename(columns={"pointed_out_inspection_comment_count": "inspection_comment_count", "worktime_hour": f"{str_phase}_worktime_hour"})
 
     # 教師付の開始時刻でソートして、indexを更新する
@@ -67,7 +66,6 @@ def _create_cumulative_dataframe(task_worktime_by_phase_user: TaskWorktimeByPhas
     # TODO この問題が解決されたら、削除する
     # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
     df[f"first_{str_phase}_started_date"] = df[f"first_{str_phase}_started_date"].astype("object")
-
     return df
 
 

--- a/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
+++ b/annofabcli/statistics/visualization/dataframe/cumulative_productivity.py
@@ -26,11 +26,49 @@ from annofabcli.statistics.linegraph import (
     get_plotted_user_id_list,
     write_bokeh_graph,
 )
-from annofabcli.statistics.visualization.dataframe.task import Task
 from annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user import TaskWorktimeByPhaseUser
 from annofabcli.statistics.visualization.model import ProductionVolumeColumn
 
 logger = logging.getLogger(__name__)
+
+
+def _create_cumulative_dataframe(task_worktime_by_phase_user: TaskWorktimeByPhaseUser, phase: TaskPhase) -> pandas.DataFrame:
+    """
+    累積情報が格納されたDataFrameを生成する。
+    """
+    df = task_worktime_by_phase_user.df.copy()
+    str_phase = phase
+    df = df[df["phase"] == str_phase]
+
+    df = df.rename(columns={"pointed_out_inspection_comment_count": "inspection_comment_count", "worktime_hour": f"{str_phase}_worktime_hour"})
+
+    # 教師付の開始時刻でソートして、indexを更新する
+
+    df = df.sort_values(["user_id", "started_datetime"]).reset_index(drop=True)
+
+    groupby_obj = df.groupby("user_id")
+    df[f"cumulative_{str_phase}_worktime_hour"] = groupby_obj[f"{str_phase}_worktime_hour"].cumsum()
+
+    # 生産量の累積値を算出
+    df["cumulative_task_count"] = groupby_obj["task_count"].cumsum()
+    df["cumulative_input_data_count"] = groupby_obj["input_data_count"].cumsum()
+    df["cumulative_annotation_count"] = groupby_obj["annotation_count"].cumsum()
+    for column in [e.value for e in task_worktime_by_phase_user.custom_production_volume_list]:
+        df[f"cumulative_{column}"] = groupby_obj[column].cumsum()
+
+    # タスク完了数、差し戻し数など
+    df["cumulative_inspection_comment_count"] = groupby_obj["inspection_comment_count"].cumsum()
+
+    # 追加理由：ツールチップでは時間情報は不要なので、作業開始「日」のみ表示するため
+    # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
+    # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
+    df[f"first_{str_phase}_started_date"] = df["started_datetime"].astype("string").str[:10]
+    # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
+    # TODO この問題が解決されたら、削除する
+    # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
+    df[f"first_{str_phase}_started_date"] = df[f"first_{str_phase}_started_date"].astype("object")
+
+    return df
 
 
 class AbstractPhaseCumulativeProductivity(abc.ABC):
@@ -152,17 +190,6 @@ class AbstractPhaseCumulativeProductivity(abc.ABC):
         write_bokeh_graph(bokeh.layouts.layout(graph_group_list), output_file)
 
     @abc.abstractmethod
-    def _get_cumulative_dataframe(self) -> pandas.DataFrame:
-        """
-        累計情報が格納されたDataFrameを生成します。
-
-         * 指定したフェーズを初めて作業したユーザごと
-         * 指定したフェーズを初めて作業した日時順に並べた上で、累計値を算出する
-
-        """
-        raise NotImplementedError()
-
-    @abc.abstractmethod
     def plot_production_volume_metrics(
         self,
         production_volume_column: str,
@@ -180,171 +207,9 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         super().__init__(df, phase=TaskPhase.ANNOTATION, custom_production_volume_list=custom_production_volume_list)
 
     @classmethod
-    def from_task(cls, task: Task) -> AnnotatorCumulativeProductivity:
-        """
-        `タスクlist.csv`に相当する情報から、インスタンスを生成します。
-        """
-        # task.df
-        return cls(task.df.copy(), custom_production_volume_list=task.custom_production_volume_list)
-
-    @classmethod
     def from_df_wrapper(cls, task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> AnnotatorCumulativeProductivity:
-        """
-        `タスクlist.csv`に相当する情報から、インスタンスを生成します。
-        """
-        # task.df
-        df = cls._create_cumulative_dataframe(task_worktime_by_phase_user)
+        df = _create_cumulative_dataframe(task_worktime_by_phase_user, TaskPhase.ANNOTATION)
         return cls(df, custom_production_volume_list=task_worktime_by_phase_user.custom_production_volume_list)
-
-    @staticmethod
-    def _create_cumulative_dataframe(task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> pandas.DataFrame:
-        """
-        累積情報が格納されたDataFrameを生成する。
-        """
-        df = task_worktime_by_phase_user.df.copy()
-        str_phase = TaskPhase.ANNOTATION.value
-        df = df[df["phase"] == str_phase]
-
-        df = df.rename(columns={"pointed_out_inspection_comment_count": "inspection_comment_count", "worktime_hour": f"{str_phase}_worktime_hour"})
-
-        # 教師付の開始時刻でソートして、indexを更新する
-
-        df = df.sort_values(["user_id", "started_datetime"]).reset_index(drop=True)
-
-        # groupby_obj = df.groupby("first_annotation_user_id")
-        # TODO sort
-        groupby_obj = df.groupby("user_id")
-        df[f"cumulative_{str_phase}_worktime_hour"] = groupby_obj[f"{str_phase}_worktime_hour"].cumsum()
-
-        # 生産量の累積値を算出
-        df["cumulative_task_count"] = groupby_obj["task_count"].cumsum()
-        df["cumulative_input_data_count"] = groupby_obj["input_data_count"].cumsum()
-        df["cumulative_annotation_count"] = groupby_obj["annotation_count"].cumsum()
-        for column in [e.value for e in task_worktime_by_phase_user.custom_production_volume_list]:
-            df[f"cumulative_{column}"] = groupby_obj[column].cumsum()
-
-        # タスク完了数、差し戻し数など
-        df["cumulative_inspection_comment_count"] = groupby_obj["inspection_comment_count"].cumsum()
-
-        # 追加理由：ツールチップでは時間情報は不要なので、作業開始「日」のみ表示するため
-        # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
-        # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
-        df["first_annotation_started_date"] = df["started_datetime"].astype("string").str[:10]
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_annotation_started_date"] = df["first_annotation_started_date"].astype("object")
-
-        return df
-
-    def _get_cumulative_dataframe(self) -> pandas.DataFrame:
-        """
-        累積情報が格納されたDataFrameを生成する。
-        """
-        # 教師付の開始時刻でソートして、indexを更新する
-        df = self.df.sort_values(["first_annotation_user_id", "first_annotation_started_datetime"]).reset_index(drop=True)
-        # タスクの累計数を取得するために設定する
-        df["task_count"] = 1
-        # 教師付の作業者でgroupby
-        groupby_obj = df.groupby("first_annotation_user_id")
-
-        # 作業時間の累積値
-        df["cumulative_annotation_worktime_hour"] = groupby_obj["annotation_worktime_hour"].cumsum()
-        df["cumulative_acceptance_worktime_hour"] = groupby_obj["acceptance_worktime_hour"].cumsum()
-        df["cumulative_inspection_worktime_hour"] = groupby_obj["inspection_worktime_hour"].cumsum()
-
-        # 生産量
-        df["cumulative_task_count"] = groupby_obj["task_count"].cumsum()
-        df["cumulative_input_data_count"] = groupby_obj["input_data_count"].cumsum()
-        df["cumulative_annotation_count"] = groupby_obj["annotation_count"].cumsum()
-        for column in [e.value for e in self.custom_production_volume_list]:
-            df[f"cumulative_{column}"] = groupby_obj[column].cumsum()
-
-        # タスク完了数、差し戻し数など
-        df["cumulative_inspection_comment_count"] = groupby_obj["inspection_comment_count"].cumsum()
-        df["cumulative_number_of_rejections_by_inspection"] = groupby_obj["number_of_rejections_by_inspection"].cumsum()
-        df["cumulative_number_of_rejections_by_acceptance"] = groupby_obj["number_of_rejections_by_acceptance"].cumsum()
-
-        # 追加理由：ツールチップでは時間情報は不要なので、作業開始「日」のみ表示するため
-        # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
-        # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
-        df["first_annotation_started_date"] = df["first_annotation_started_datetime"].astype("string").str[:10]
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_annotation_started_date"] = df["first_annotation_started_date"].astype("object")
-
-        # 元に戻す
-        df = df.drop(["task_count"], axis=1)
-        return df
-
-    def plot_production_volume_metrics__old(
-        self,
-        production_volume_column: str,
-        production_volume_name: str,
-        output_file: Path,
-        *,
-        target_user_id_list: Optional[list[str]] = None,
-        metadata: Optional[dict[str, Any]] = None,
-    ) -> None:
-        """
-        生産性を教師付作業者ごとにプロットする。
-
-        Args:
-            df:
-            first_annotation_user_id_list:
-
-        Returns:
-
-        """
-
-        if not self._validate_df_for_output(output_file):
-            return
-
-        logger.debug(f"{output_file} を出力します。")
-
-        if target_user_id_list is not None:  # noqa: SIM108
-            user_id_list = target_user_id_list
-        else:
-            user_id_list = self.default_user_id_list
-
-        user_id_list = get_plotted_user_id_list(user_id_list)
-
-        line_graph_list = [
-            LineGraph(
-                title=f"累積の{production_volume_name}と教師付作業時間",
-                y_axis_label="教師付作業時間[時間]",
-                tooltip_columns=[
-                    "task_id",
-                    "first_annotation_user_id",
-                    "first_annotation_username",
-                    "first_annotation_started_date",
-                    production_volume_column,
-                    "annotation_worktime_hour",
-                ],
-                x_axis_label=production_volume_name,
-            ),
-            LineGraph(
-                title=f"累積の{production_volume_name}と検査コメント数",
-                y_axis_label="検査コメント数",
-                tooltip_columns=[
-                    "task_id",
-                    "first_annotation_user_id",
-                    "first_annotation_username",
-                    "first_annotation_started_date",
-                    production_volume_column,
-                    "inspection_comment_count",
-                ],
-                x_axis_label=production_volume_name,
-            ),
-        ]
-
-        x_column = f"cumulative_{production_volume_column}"
-        columns_list = [
-            (x_column, "cumulative_annotation_worktime_hour"),
-            (x_column, "cumulative_inspection_comment_count"),
-        ]
-        self._plot(line_graph_list, columns_list, user_id_list, output_file, metadata=metadata)
 
     def plot_production_volume_metrics(
         self,
@@ -358,12 +223,6 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         """
         生産性を教師付作業者ごとにプロットする。
 
-        Args:
-            df:
-            first_annotation_user_id_list:
-
-        Returns:
-
         """
 
         if not self._validate_df_for_output(output_file):
@@ -388,6 +247,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
                     "username",
                     "biography",
                     "first_annotation_started_date",
+                    "task_count",
                     production_volume_column,
                     "annotation_worktime_hour",
                 ],
@@ -402,6 +262,7 @@ class AnnotatorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
                     "username",
                     "biography",
                     "first_annotation_started_date",
+                    "task_count",
                     production_volume_column,
                     "inspection_comment_count",
                 ],
@@ -422,51 +283,9 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         super().__init__(df, phase=TaskPhase.INSPECTION, custom_production_volume_list=custom_production_volume_list)
 
     @classmethod
-    def from_task(cls, task: Task) -> InspectorCumulativeProductivity:
-        """
-        `タスクlist.csv`に相当する情報から、インスタンスを生成します。
-        """
-        return cls(task.df.copy(), custom_production_volume_list=task.custom_production_volume_list)
-
-    def _get_cumulative_dataframe(self) -> pandas.DataFrame:
-        """
-        最初のアノテーション作業の開始時刻の順にソートして、検査者に関する累計値を算出する
-        Args:
-            task_df: タスク一覧のDataFrame. 列が追加される
-        """
-        df = self.df.sort_values(["first_inspection_user_id", "first_inspection_started_datetime"]).reset_index(drop=True)
-
-        # タスクの累計数を取得するために設定する
-        df["task_count"] = 1
-
-        groupby_obj = df.groupby("first_inspection_user_id")
-
-        # 作業時間の累積値
-        df["cumulative_inspection_worktime_hour"] = groupby_obj["inspection_worktime_hour"].cumsum()
-
-        df["cumulative_inspection_comment_count"] = groupby_obj["inspection_comment_count"].cumsum()
-
-        # 生産量
-        df["cumulative_task_count"] = groupby_obj["task_count"].cumsum()
-        df["cumulative_input_data_count"] = groupby_obj["input_data_count"].cumsum()
-        df["cumulative_annotation_count"] = groupby_obj["annotation_count"].cumsum()
-        for column in [e.value for e in self.custom_production_volume_list]:
-            df[f"cumulative_{column}"] = groupby_obj[column].cumsum()
-
-        # 追加理由：ツールチップでは時間情報は不要なので、作業開始「日」のみ表示するため
-        # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
-        # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
-        df["first_inspection_started_date"] = df["first_inspection_started_datetime"].astype("string").str[:10]
-
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_inspection_started_date"] = df["first_inspection_started_date"].astype("object")
-
-        # 元に戻す
-        df = df.drop(["task_count"], axis=1)
-
-        return df
+    def from_df_wrapper(cls, task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> InspectorCumulativeProductivity:
+        df = _create_cumulative_dataframe(task_worktime_by_phase_user, TaskPhase.INSPECTION)
+        return cls(df, custom_production_volume_list=task_worktime_by_phase_user.custom_production_volume_list)
 
     def plot_production_volume_metrics(
         self,
@@ -479,12 +298,6 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
     ) -> None:
         """
         生産性を検査作業者ごとにプロットする。
-
-        Args:
-            df:
-            first_inspection_user_id_list:
-
-        Returns:
 
         """
 
@@ -506,9 +319,11 @@ class InspectorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
                 y_axis_label="検査作業時間[時間]",
                 tooltip_columns=[
                     "task_id",
-                    "first_inspection_user_id",
-                    "first_inspection_username",
+                    "user_id",
+                    "username",
+                    "biography",
                     "first_inspection_started_date",
+                    "task_count",
                     production_volume_column,
                     "inspection_worktime_hour",
                     "annotation_count",
@@ -530,45 +345,9 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
         super().__init__(df, phase=TaskPhase.ACCEPTANCE, custom_production_volume_list=custom_production_volume_list)
 
     @classmethod
-    def from_task(cls, task: Task) -> AcceptorCumulativeProductivity:
-        """
-        `タスクlist.csv`に相当する情報から、インスタンスを生成します。
-        """
-        return cls(task.df.copy(), custom_production_volume_list=task.custom_production_volume_list)
-
-    def _get_cumulative_dataframe(self) -> pandas.DataFrame:
-        """
-        最初のアノテーション作業の開始時刻の順にソートして、受入者に関する累計値を算出する
-        """
-        df = self.df.sort_values(["first_acceptance_user_id", "first_acceptance_started_datetime"]).reset_index(drop=True)
-        # タスクの累計数を取得するために設定する
-        df["task_count"] = 1
-
-        groupby_obj = df.groupby("first_acceptance_user_id")
-
-        # 作業時間の累積値
-        df["cumulative_acceptance_worktime_hour"] = groupby_obj["acceptance_worktime_hour"].cumsum()
-
-        # 生産量
-        df["cumulative_task_count"] = groupby_obj["task_count"].cumsum()
-        df["cumulative_input_data_count"] = groupby_obj["input_data_count"].cumsum()
-        df["cumulative_annotation_count"] = groupby_obj["annotation_count"].cumsum()
-        for column in [e.value for e in self.custom_production_volume_list]:
-            df[f"cumulative_{column}"] = groupby_obj[column].cumsum()
-
-        # 追加理由：ツールチップでは時間情報は不要なので、作業開始「日」のみ表示するため
-        # `YYYY-MM-DDThh:mm:ss.sss+09:00`から`YYYY-MM-DD`を取得する
-        # キャストする理由: 全部nanだとfloat型になって、".str"にアクセスできないため
-        df["first_acceptance_started_date"] = df["first_acceptance_started_datetime"].astype("string").str[:10]
-        # bokeh3.0.3では、string型の列を持つpandas.DataFrameを描画できないため、改めてobject型に戻す
-        # TODO この問題が解決されたら、削除する
-        # https://qiita.com/yuji38kwmt/items/b5da6ed521e827620186
-        df["first_acceptance_started_date"] = df["first_acceptance_started_date"].astype("object")
-
-        # 元に戻す
-        df = df.drop(["task_count"], axis=1)
-
-        return df
+    def from_df_wrapper(cls, task_worktime_by_phase_user: TaskWorktimeByPhaseUser) -> AcceptorCumulativeProductivity:
+        df = _create_cumulative_dataframe(task_worktime_by_phase_user, TaskPhase.ACCEPTANCE)
+        return cls(df, custom_production_volume_list=task_worktime_by_phase_user.custom_production_volume_list)
 
     def plot_production_volume_metrics(
         self,
@@ -581,12 +360,6 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
     ) -> None:
         """
         生産性を受入作業者ごとにプロットする。
-
-        Args:
-            df:
-            first_acceptance_user_id_list:
-
-        Returns:
 
         """
 
@@ -608,9 +381,11 @@ class AcceptorCumulativeProductivity(AbstractPhaseCumulativeProductivity):
                 y_axis_label="受入作業時間[時間]",
                 tooltip_columns=[
                     "task_id",
-                    "first_acceptance_user_id",
-                    "first_acceptance_username",
+                    "user_id",
+                    "username",
+                    "biography",
                     "first_acceptance_started_date",
+                    "task_count",
                     production_volume_column,
                     "acceptance_worktime_hour",
                 ],

--- a/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/worktime_per_date.py
@@ -316,7 +316,7 @@ class WorktimePerDate:
         return True
 
     def _get_default_user_id_list(self) -> list[str]:
-        return list(self.df.sort_values(by="date", ascending=False)["user_id"].dropna().unique())
+        return list(self.df.sort_values(by="user_id", ascending=False)["user_id"].dropna().unique())
 
     def _get_continuous_date_dataframe(self) -> pandas.DataFrame:
         """

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -243,11 +243,11 @@ class WriteCsvGraph:
 
     def write_user_productivity_per_date(self, user_id_list: Optional[List[str]] = None) -> None:
         """ユーザごとの日ごとの生産性情報を出力する。"""
-        task = self._get_task()
+        task_worktime_obj = self._get_task_worktime_obj()
 
-        annotator_per_date_obj = AnnotatorProductivityPerDate.from_task(task)
-        inspector_per_date_obj = InspectorProductivityPerDate.from_task(task)
-        acceptor_per_date_obj = AcceptorProductivityPerDate.from_task(task)
+        annotator_per_date_obj = AnnotatorProductivityPerDate.from_df_wrapper(task_worktime_obj)
+        inspector_per_date_obj = InspectorProductivityPerDate.from_df_wrapper(task_worktime_obj)
+        acceptor_per_date_obj = AcceptorProductivityPerDate.from_df_wrapper(task_worktime_obj)
 
         # 開始日ごとのCSVを出力
         self.project_dir.write_performance_per_started_date_csv(annotator_per_date_obj, phase=TaskPhase.ANNOTATION)

--- a/tests/data/statistics/task-worktime-by-user-phase.csv
+++ b/tests/data/statistics/task-worktime-by-user-phase.csv
@@ -1,6 +1,6 @@
-﻿project_id,task_id,status,phase,phase_stage,account_id,user_id,username,biography,worktime_hour,task_count,input_data_count,annotation_count,pointed_out_inspection_comment_count,rejected_count,custom_production_volume1,started_datetime
-prj1,task1,complete,annotation,1,alice,alice,Alice,USA,2,1,2,100,5,1,102,2024-10-25T11:00:00.000+09:00
-prj1,task1,complete,inspection,1,bob,bob,Bob,USA,0.5,0.5,1,50,0,0,40,2024-10-26T11:00:00.000+09:00
-prj1,task2,complete,annotation,1,bob,bob,Bob,USA,2,1,4,200,6,1,399,2024-10-27T11:00:00.000+09:00
-prj1,task2,complete,inspection,1,alice,alice,Alice,USA,0.5,0.5,2,100,0,0,123,2024-10-28T11:00:00.000+09:00
-prj1,task2,complete,acceptance,1,alice,alice,Alice,USA,0.1,1,4,200,0,0,242,2024-10-29T11:00:00.000+09:00
+﻿project_id,task_id,status,phase,phase_stage,account_id,user_id,username,biography,worktime_hour,task_count,input_data_count,annotation_count,custom_production_volume1,custom_production_volume2,pointed_out_inspection_comment_count,rejected_count,custom_production_volume1,started_datetime
+prj1,task1,complete,annotation,1,alice,alice,Alice,USA,2,1,2,100,10,20,5,1,102,2024-10-25T11:00:00.000+09:00
+prj1,task1,complete,inspection,1,bob,bob,Bob,USA,0.5,0.5,1,50,4,8,0,0,40,2024-10-26T11:00:00.000+09:00
+prj1,task2,complete,annotation,1,bob,bob,Bob,USA,2,1,4,200,21,40,6,1,399,2024-10-27T11:00:00.000+09:00
+prj1,task2,complete,inspection,1,alice,alice,Alice,USA,0.5,0.5,2,100,10,30,0,0,123,2024-10-28T11:00:00.000+09:00
+prj1,task2,complete,acceptance,1,alice,alice,Alice,USA,0.1,1,4,200,20,23,0,0,242,2024-10-29T11:00:00.000+09:00

--- a/tests/statistics/visualization/dataframe/test_cumulative_productivity.py
+++ b/tests/statistics/visualization/dataframe/test_cumulative_productivity.py
@@ -23,6 +23,22 @@ def test_foo():
     obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
 
 
+def test_foo2():
+    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+    obj = InspectorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
+    assert len(obj.df) == 2
+    obj.df.to_csv("out/foo2.csv")
+    obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
+
+
+def test_foo3():
+    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+    obj = AcceptorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
+    assert len(obj.df) == 2
+    obj.df.to_csv("out/foo3.csv")
+    obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
+
+
 class TestAnnotatorCumulativeProductivity:
     obj: AnnotatorCumulativeProductivity
 

--- a/tests/statistics/visualization/dataframe/test_cumulative_productivity.py
+++ b/tests/statistics/visualization/dataframe/test_cumulative_productivity.py
@@ -8,12 +8,19 @@ from annofabcli.statistics.visualization.dataframe.cumulative_productivity impor
     InspectorCumulativeProductivity,
 )
 from annofabcli.statistics.visualization.dataframe.task import Task
+from annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user import TaskWorktimeByPhaseUser
 
 output_dir = Path("./tests/out/statistics/visualization/dataframe")
 data_dir = Path("./tests/data/statistics")
 output_dir.mkdir(exist_ok=True, parents=True)
 
-# 出力できることを確認する
+
+def test_foo():
+    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+    obj = AnnotatorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
+    assert len(obj.df) == 2
+    obj.df.to_csv("out/foo.csv")
+    obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
 
 
 class TestAnnotatorCumulativeProductivity:

--- a/tests/statistics/visualization/dataframe/test_cumulative_productivity.py
+++ b/tests/statistics/visualization/dataframe/test_cumulative_productivity.py
@@ -1,77 +1,37 @@
 from pathlib import Path
 
-import pandas
-
 from annofabcli.statistics.visualization.dataframe.cumulative_productivity import (
     AcceptorCumulativeProductivity,
     AnnotatorCumulativeProductivity,
     InspectorCumulativeProductivity,
 )
-from annofabcli.statistics.visualization.dataframe.task import Task
 from annofabcli.statistics.visualization.dataframe.task_worktime_by_phase_user import TaskWorktimeByPhaseUser
 
-output_dir = Path("./tests/out/statistics/visualization/dataframe")
+output_dir = Path("./tests/out/statistics/visualization/dataframe/cumulative_productivity")
 data_dir = Path("./tests/data/statistics")
 output_dir.mkdir(exist_ok=True, parents=True)
 
 
-def test_foo():
-    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
-    obj = AnnotatorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
-    assert len(obj.df) == 2
-    obj.df.to_csv("out/foo.csv")
-    obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
-
-
-def test_foo2():
-    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
-    obj = InspectorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
-    assert len(obj.df) == 2
-    obj.df.to_csv("out/foo2.csv")
-    obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
-
-
-def test_foo3():
-    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
-    obj = AcceptorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
-    assert len(obj.df) == 2
-    obj.df.to_csv("out/foo3.csv")
-    obj.plot_production_volume_metrics("annotation_count", "アノテーション数", Path("out/foo.html"))
-
-
 class TestAnnotatorCumulativeProductivity:
-    obj: AnnotatorCumulativeProductivity
-
-    @classmethod
-    def setup_class(cls):
-        task = Task.from_csv(data_dir / "task.csv")
-        cls.obj = AnnotatorCumulativeProductivity.from_task(task)
-
     def test_plot_production_volume_metrics(self):
-        self.obj.plot_production_volume_metrics(
-            "annotation_count", "アノテーション数", output_dir / "累積折れ線-横軸_アノテーション数-教師付者用.html"
-        )
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+
+        obj = AnnotatorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
+        assert len(obj.df) == 2
+        obj.plot_production_volume_metrics("annotation_count", "アノテーション数", output_dir / "累積折れ線-横軸_アノテーション数-教師付者用.html")
 
 
 class TestInspectorCumulativeProductivity:
-    obj: InspectorCumulativeProductivity
-
-    @classmethod
-    def setup_class(cls):
-        df_task = pandas.read_csv(str(data_dir / "task.csv"))
-        cls.obj = InspectorCumulativeProductivity(df_task)
-
     def test_plot_production_volume_metrics(self):
-        self.obj.plot_production_volume_metrics("annotation_count", "アノテーション数", output_dir / "累積折れ線-横軸_アノテーション数-検査者用.html")
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+        obj = InspectorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
+        assert len(obj.df) == 2
+        obj.plot_production_volume_metrics("annotation_count", "アノテーション数", output_dir / "累積折れ線-横軸_アノテーション数-検査者用.html")
 
 
 class TestAcceptorCumulativeProductivity:
-    obj: AcceptorCumulativeProductivity
-
-    @classmethod
-    def setup_class(cls):
-        df_task = pandas.read_csv(str(data_dir / "task.csv"))
-        cls.obj = AcceptorCumulativeProductivity(df_task)
-
     def test_plot_production_volume_metrics(self):
-        self.obj.plot_production_volume_metrics("annotation_count", "アノテーション数", output_dir / "累積折れ線-横軸_アノテーション数-受入者用.html")
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+        obj = AcceptorCumulativeProductivity.from_df_wrapper(task_worktime_by_phase_user)
+        assert len(obj.df) == 1
+        obj.plot_production_volume_metrics("annotation_count", "アノテーション数", output_dir / "累積折れ線-横軸_アノテーション数-受入者用.html")

--- a/tests/statistics/visualization/dataframe/test_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_productivity_per_date.py
@@ -5,22 +5,12 @@ from annofabcli.statistics.visualization.dataframe.productivity_per_date import 
     AnnotatorProductivityPerDate,
     InspectorProductivityPerDate,
     ProductionVolumeColumn,
-    TaskPhase,
     TaskWorktimeByPhaseUser,
-    create_df_productivity_per_date,
 )
 
 output_dir = Path("./tests/out/statistics/visualization/dataframe/productivity_per_date")
 data_dir = Path("./tests/data/statistics")
 output_dir.mkdir(exist_ok=True, parents=True)
-
-# 出力できることを確認する
-
-
-def test_foo():
-    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
-    df = create_df_productivity_per_date(task_worktime_by_phase_user, TaskPhase.ANNOTATION)
-    df.to_csv("out/foo.csv")
 
 
 class TestAnnotatorProductivityPerDate:

--- a/tests/statistics/visualization/dataframe/test_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_productivity_per_date.py
@@ -26,11 +26,14 @@ def test_foo():
 
 class TestAnnotatorProductivityPerDate:
     def test_scenario(self):
-        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv",             custom_production_volume_list=[
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
+            data_dir / "task-worktime-by-user-phase.csv",
+            custom_production_volume_list=[
                 ProductionVolumeColumn("custom_production_volume1", "custom_生産量1"),
                 ProductionVolumeColumn("custom_production_volume2", "custom_生産量2"),
-            ],)
-        
+            ],
+        )
+
         obj = AnnotatorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
         obj.to_csv(output_dir / "教師付開始日ごとの教師付者の生産性.csv")
         obj.plot_production_volume_metrics(
@@ -39,28 +42,22 @@ class TestAnnotatorProductivityPerDate:
 
 
 class TestInspectorProductivityPerDate:
-    obj: InspectorProductivityPerDate
 
-    @classmethod
-    def setup_class(cls):
-        task = Task.from_csv(
-            data_dir / "task.csv",
+
+    def test_scenario(self):
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
+            data_dir / "task-worktime-by-user-phase.csv",
             custom_production_volume_list=[
                 ProductionVolumeColumn("custom_production_volume1", "custom_生産量1"),
                 ProductionVolumeColumn("custom_production_volume2", "custom_生産量2"),
             ],
         )
 
-        cls.obj = InspectorProductivityPerDate.from_task(task)
-
-    def test_to_csv(self):
-        self.obj.to_csv(output_dir / "検査開始日ごとの検査者の生産性.csv")
-
-    def test__plot_production_volume_metrics(self):
-        self.obj.plot_production_volume_metrics(
+        obj = InspectorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+        obj.to_csv(output_dir / "検査開始日ごとの検査者の生産性.csv")
+        obj.plot_production_volume_metrics(
             "annotation_count", "アノテーション", output_dir / "折れ線-横軸_検査開始日-縦軸_アノテーションあたりの指標-検査者用.html"
         )
-
 
 class TestAcceptorProductivityPerDate:
     obj: AcceptorProductivityPerDate

--- a/tests/statistics/visualization/dataframe/test_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_productivity_per_date.py
@@ -6,6 +6,9 @@ from annofabcli.statistics.visualization.dataframe.productivity_per_date import 
     InspectorProductivityPerDate,
     ProductionVolumeColumn,
     Task,
+    TaskPhase,
+    TaskWorktimeByPhaseUser,
+    create_df_productivity_per_date,
 )
 
 output_dir = Path("./tests/out/statistics/visualization/dataframe/productivity_per_date")
@@ -15,25 +18,22 @@ output_dir.mkdir(exist_ok=True, parents=True)
 # 出力できることを確認する
 
 
-class TestAnnotatorProductivityPerDate:
-    obj: AnnotatorProductivityPerDate
+def test_foo():
+    task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv")
+    df = create_df_productivity_per_date(task_worktime_by_phase_user, TaskPhase.ANNOTATION)
+    df.to_csv("out/foo.csv")
 
-    @classmethod
-    def setup_class(cls):
-        task = Task.from_csv(
-            data_dir / "task.csv",
-            custom_production_volume_list=[
+
+class TestAnnotatorProductivityPerDate:
+    def test_scenario(self):
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(data_dir / "task-worktime-by-user-phase.csv",             custom_production_volume_list=[
                 ProductionVolumeColumn("custom_production_volume1", "custom_生産量1"),
                 ProductionVolumeColumn("custom_production_volume2", "custom_生産量2"),
-            ],
-        )
-        cls.obj = AnnotatorProductivityPerDate.from_task(task)
-
-    def test_to_csv(self):
-        self.obj.to_csv(output_dir / "教師付開始日ごとの教師付者の生産性.csv")
-
-    def test__plot_production_volume_metrics(self):
-        self.obj.plot_production_volume_metrics(
+            ],)
+        
+        obj = AnnotatorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+        obj.to_csv(output_dir / "教師付開始日ごとの教師付者の生産性.csv")
+        obj.plot_production_volume_metrics(
             "annotation_count", "アノテーション", output_dir / "折れ線-横軸_教師付開始日-縦軸_アノテーションあたりの指標-教師付者用.html"
         )
 

--- a/tests/statistics/visualization/dataframe/test_productivity_per_date.py
+++ b/tests/statistics/visualization/dataframe/test_productivity_per_date.py
@@ -5,7 +5,6 @@ from annofabcli.statistics.visualization.dataframe.productivity_per_date import 
     AnnotatorProductivityPerDate,
     InspectorProductivityPerDate,
     ProductionVolumeColumn,
-    Task,
     TaskPhase,
     TaskWorktimeByPhaseUser,
     create_df_productivity_per_date,
@@ -42,8 +41,6 @@ class TestAnnotatorProductivityPerDate:
 
 
 class TestInspectorProductivityPerDate:
-
-
     def test_scenario(self):
         task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
             data_dir / "task-worktime-by-user-phase.csv",
@@ -59,25 +56,19 @@ class TestInspectorProductivityPerDate:
             "annotation_count", "アノテーション", output_dir / "折れ線-横軸_検査開始日-縦軸_アノテーションあたりの指標-検査者用.html"
         )
 
-class TestAcceptorProductivityPerDate:
-    obj: AcceptorProductivityPerDate
 
-    @classmethod
-    def setup_class(cls):
-        task = Task.from_csv(
-            data_dir / "task.csv",
+class TestAcceptorProductivityPerDate:
+    def test_scenario(self):
+        task_worktime_by_phase_user = TaskWorktimeByPhaseUser.from_csv(
+            data_dir / "task-worktime-by-user-phase.csv",
             custom_production_volume_list=[
                 ProductionVolumeColumn("custom_production_volume1", "custom_生産量1"),
                 ProductionVolumeColumn("custom_production_volume2", "custom_生産量2"),
             ],
         )
 
-        cls.obj = AcceptorProductivityPerDate.from_task(task)
-
-    def test_to_csv(self):
-        self.obj.to_csv(output_dir / "受入開始日ごとの受入者の生産性.csv")
-
-    def test__plot_production_volume_metrics(self):
-        self.obj.plot_production_volume_metrics(
+        obj = AcceptorProductivityPerDate.from_df_wrapper(task_worktime_by_phase_user)
+        obj.to_csv(output_dir / "受入開始日ごとの受入者の生産性.csv")
+        obj.plot_production_volume_metrics(
             "annotation_count", "アノテーション", output_dir / "折れ線-横軸_受入開始日-縦軸_アノテーションあたりの指標-受入者用.html"
         )


### PR DESCRIPTION
#630 

以下のグラフの表示方法を変更しました。
* `折れ線-横軸_教師付開始日-縦軸_アノテーション単位の指標-教師付者用.html`
* `累積折れ線-横軸_アノテーション数-教師付者用.html`


