### PR TITLE
`statisitcs visualize` : pandasの警告メッセージに対応しました

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
+++ b/annofabcli/statistics/visualization/dataframe/productivity_per_date.py
@@ -180,8 +180,20 @@ class AbstractPhaseProductivityPerDate(abc.ABC):
             df2[user_column] = df[user_column].iloc[0]
 
         # その他の欠損値（作業時間や生産量）を0で埋める
-        df2 = df2.infer_objects(copy=False)
-        df2.fillna(0, inplace=True)
+        df2 = df2.fillna(
+            {
+                col: 0
+                for col in [
+                    "annotation_worktime_hour",
+                    "inspection_worktime_hour",
+                    "acceptance_worktime_hour",
+                    "task_count",
+                    "inspection_comment_count",
+                    *self.production_volume_columns,
+                ]
+            }
+        )
+
         return df2
 
     @property


### PR DESCRIPTION
以下の警告メッセージが出ないように対応しました。

```
FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df2 = df2.fillna(0).infer_objects(copy=False)
```