### PR TITLE
`statistics visualize_video_duration` : タスクに含まれている入力データが見つからないときにエラーが発生する問題を修正しました。

### DIFF
--- a/annofabcli/statistics/visualize_video_duration.py
+++ b/annofabcli/statistics/visualize_video_duration.py
@@ -179,8 +179,9 @@ def get_video_durations(input_data_json: Path, task_json: Path) -> tuple[list[fl
         first_input_data_id = task["input_data_id_list"][0]
         duration = video_durations_dict_for_input_data.get(first_input_data_id)
         if duration is None:
-            logger.warning(f"task_id='{task_id}' :: input_data='{first_input_data_id}'のinput_durationがNoneです。")
-        video_durations_dict_for_task[task_id] = duration
+            logger.warning(f"task_id='{task_id}' :: input_data_id='{first_input_data_id}'のinput_durationがNoneです。")
+        else:
+            video_durations_dict_for_task[task_id] = duration
 
     return list(video_durations_dict_for_input_data.values()), list(video_durations_dict_for_task.values())
 


### PR DESCRIPTION
以下のエラーが発生していたのを修正しました。
```
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```