### PR TITLE
`statistics visualize` : "--annotation_count_csv"を指定したときは、対象プロジェクトのアノテーションZIPをダウンロードしないようにする

### DIFF
--- a/annofabcli/statistics/visualization/visualization_source_files.py
+++ b/annofabcli/statistics/visualization/visualization_source_files.py
@@ -104,7 +104,9 @@ class VisualizationSourceFiles:
         logger.debug(f"{self.logging_prefix}: '{self.comment_json_path}'を読み込みました。{len(comment_list)}件のコメントが含まれています。")
         return comment_list
 
-    def write_files(self, *, is_latest: bool = False, should_get_task_histories_one_of_each: bool = False) -> None:
+    def write_files(
+        self, *, is_latest: bool = False, should_get_task_histories_one_of_each: bool = False, should_download_annotation_zip: bool = True
+    ) -> None:
         """
         可視化に必要なファイルを作成します。
         原則、全件ファイルをダウンロードしてファイルを作成します。必要に応じて個別にAPIを実行してファイルを作成します。
@@ -121,12 +123,14 @@ class VisualizationSourceFiles:
         wait_options = WaitOptions(interval=60, max_tries=360)
 
         downloading_obj.download_task_json(self.project_id, dest_path=self.task_json_path, is_latest=is_latest, wait_options=wait_options)
-        downloading_obj.download_annotation_zip(
-            self.project_id,
-            dest_path=self.annotation_zip_path,
-            is_latest=is_latest,
-            wait_options=wait_options,
-        )
+
+        if should_download_annotation_zip:
+            downloading_obj.download_annotation_zip(
+                self.project_id,
+                dest_path=self.annotation_zip_path,
+                is_latest=is_latest,
+                wait_options=wait_options,
+            )
 
         try:
             downloading_obj.download_comment_json(self.project_id, dest_path=self.comment_json_path)

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -364,7 +364,9 @@ class VisualizingStatisticsMain:
         )
         if not self.not_download_visualization_source_files:
             visualization_source_files.write_files(
-                is_latest=self.download_latest, should_get_task_histories_one_of_each=self.is_get_task_histories_one_of_each
+                is_latest=self.download_latest,
+                should_get_task_histories_one_of_each=self.is_get_task_histories_one_of_each,
+                should_download_annotation_zip=(annotation_count is None),
             )
 
         write_obj = WriteCsvGraph(


### PR DESCRIPTION
`--annotation_count_csv`を指定した場合は、アノテーションZIPをダウンロードする必要はないので、ダウンロードしないようにした。

３次元プロジェクトでセグメントを利用している場合、アノテーションZIPは1GBを超えることがあるので、このようなケースでは処理時間が大きく短くなる。
