### PR TITLE
`statistics visualize` : `--input_data_count_csv`オプションを追加しました。

### DIFF
--- a/annofabcli/statistics/visualization/dataframe/input_data_count.py
+++ b/annofabcli/statistics/visualization/dataframe/input_data_count.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+
+import pandas
+
+logger = logging.getLogger(__name__)
+
+
+class InputDataCount:
+    """
+    入力データ数が格納されたDataFrameをラップしたクラスです。
+
+    DataFrameは`project_id`,`task_id`のペアがユニークなキーです。
+    """
+
+    @classmethod
+    def columns(cls) -> list[str]:
+        return [
+            "project_id",
+            "task_id",
+            "input_data_count",
+        ]
+
+    @classmethod
+    def required_columns_exist(cls, df: pandas.DataFrame) -> bool:
+        """
+        必須の列が存在するかどうかを返します。
+
+        Returns:
+            必須の列が存在するかどうか
+        """
+        return len(set(cls.columns()) - set(df.columns)) == 0
+
+    def __init__(self, df: pandas.DataFrame) -> None:
+        if not self.required_columns_exist(df):
+            raise ValueError(f"引数`df`には、{self.columns()}の列が必要です。 :: {df.columns=}")
+        self.df = df
+
+    def is_empty(self) -> bool:
+        """
+        空のデータフレームを持つかどうかを返します。
+
+        Returns:
+            空のデータフレームを持つかどうか
+        """
+        return len(self.df) == 0
+
+    @classmethod
+    def empty(cls) -> InputDataCount:
+        """空のデータフレームを持つインスタンスを生成します。"""
+
+        df_dtype: dict[str, str] = {
+            "project_id": "string",
+            "task_id": "string",
+            "input_data_count": "int",
+        }
+
+        df = pandas.DataFrame(columns=cls.columns()).astype(df_dtype)
+        return cls(df)

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -601,7 +601,7 @@ class VisualizeStatistics(CommandLine):
                     "引数`--input_data_count_csv`のCSVには以下の列が存在しないので、終了します。\n`project_id`, `task_id`, `input_data_count`"
                 )
                 sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
-            input_data_count = InputDataCount(df_annotation_count)
+            input_data_count = InputDataCount(df_input_data_count)
         else:
             input_data_count = None
 
@@ -751,6 +751,20 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
             "* project_id\n"
             "* task_id\n"
             "* annotation_count\n"
+        ),
+    )
+
+    parser.add_argument(
+        "--input_data_count_csv",
+        type=Path,
+        help=(
+            "指定されたCSVに記載されている入力データ数を参照して、生産量や生産性を算出します。未指定の場合はタスクに含まれている入力データ数から算出します。"
+            "タスクに、作業しない参照用のフレームが含まれている場合に有用なオプションです。"
+            "CSVには以下の列が必要です。\n"
+            "\n"
+            "* project_id\n"
+            "* task_id\n"
+            "* input_data_count\n"
         ),
     )
 

--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -34,6 +34,7 @@ from annofabcli.statistics.visualization.dataframe.cumulative_productivity impor
     InspectorCumulativeProductivity,
 )
 from annofabcli.statistics.visualization.dataframe.custom_production_volume import CustomProductionVolume
+from annofabcli.statistics.visualization.dataframe.input_data_count import InputDataCount
 from annofabcli.statistics.visualization.dataframe.inspection_comment_count import InspectionCommentCount
 from annofabcli.statistics.visualization.dataframe.productivity_per_date import (
     AcceptorProductivityPerDate,
@@ -79,6 +80,7 @@ class WriteCsvGraph:
         actual_worktime: ActualWorktime,
         *,
         annotation_count: Optional[AnnotationCount] = None,
+        input_data_count: Optional[InputDataCount] = None,
         custom_production_volume: Optional[CustomProductionVolume] = None,
         minimal_output: bool = False,
         output_only_text: bool = False,
@@ -93,6 +95,7 @@ class WriteCsvGraph:
         self.minimal_output = minimal_output
         self.output_only_text = output_only_text
         self.annotation_count = annotation_count
+        self.input_data_count = input_data_count
         self.custom_production_volume = custom_production_volume
 
         self.task: Optional[Task] = None
@@ -133,6 +136,7 @@ class WriteCsvGraph:
                 task_histories=task_histories,
                 inspection_comment_count=inspection_comment_count,
                 annotation_count=annotation_count,
+                input_data_count=self.input_data_count,
                 project_id=self.project_id,
                 annofab_service=self.service,
                 custom_production_volume=self.custom_production_volume,
@@ -284,6 +288,7 @@ class VisualizingStatisticsMain:
         is_get_task_histories_one_of_each: bool = False,
         actual_worktime: Optional[ActualWorktime] = None,
         annotation_count: Optional[AnnotationCount] = None,
+        input_data_count: Optional[InputDataCount] = None,
         custom_production_volume: Optional[CustomProductionVolume] = None,
         user_ids: Optional[list[str]] = None,
         not_download_visualization_source_files: bool = False,
@@ -299,6 +304,7 @@ class VisualizingStatisticsMain:
         self.is_get_task_histories_one_of_each = is_get_task_histories_one_of_each
         self.actual_worktime = actual_worktime
         self.annotation_count = annotation_count
+        self.input_data_count = input_data_count
         self.custom_production_volume = custom_production_volume
         self.user_ids = user_ids
         self.not_download_visualization_source_files = not_download_visualization_source_files
@@ -379,6 +385,7 @@ class VisualizingStatisticsMain:
             project_dir=project_dir,
             actual_worktime=ActualWorktime(df_actual_worktime),
             annotation_count=annotation_count,
+            input_data_count=self.input_data_count,
             custom_production_volume=self.custom_production_volume,
             minimal_output=self.minimal_output,
             output_only_text=self.output_only_text,
@@ -483,6 +490,7 @@ class VisualizeStatistics(CommandLine):
         user_id_list: Optional[list[str]],
         actual_worktime: ActualWorktime,
         annotation_count: Optional[AnnotationCount],
+        input_data_count: Optional[InputDataCount],
         custom_production_volume: Optional[CustomProductionVolume],
         download_latest: bool,  # noqa: FBT001
         is_get_task_histories_one_of_each: bool,  # noqa: FBT001
@@ -501,6 +509,7 @@ class VisualizeStatistics(CommandLine):
             user_ids=user_id_list,
             actual_worktime=actual_worktime,
             annotation_count=annotation_count,
+            input_data_count=input_data_count,
             custom_production_volume=custom_production_volume,
             download_latest=download_latest,
             is_get_task_histories_one_of_each=is_get_task_histories_one_of_each,
@@ -585,6 +594,17 @@ class VisualizeStatistics(CommandLine):
         else:
             annotation_count = None
 
+        if args.input_data_count_csv is not None:
+            df_input_data_count = pandas.read_csv(args.input_data_count_csv)
+            if not InputDataCount.required_columns_exist(df_input_data_count):
+                logger.error(
+                    "引数`--input_data_count_csv`のCSVには以下の列が存在しないので、終了します。\n`project_id`, `task_id`, `input_data_count`"
+                )
+                sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+            input_data_count = InputDataCount(df_annotation_count)
+        else:
+            input_data_count = None
+
         custom_production_volume = (
             create_custom_production_volume(args.custom_production_volume) if args.custom_production_volume is not None else None
         )
@@ -603,6 +623,7 @@ class VisualizeStatistics(CommandLine):
                     user_id_list=user_id_list,
                     actual_worktime=actual_worktime,
                     annotation_count=annotation_count,
+                    input_data_count=input_data_count,
                     custom_production_volume=custom_production_volume,
                     download_latest=args.latest,
                     is_get_task_histories_one_of_each=args.get_task_histories_one_of_each,
@@ -622,6 +643,7 @@ class VisualizeStatistics(CommandLine):
                 user_id_list=user_id_list,
                 actual_worktime=actual_worktime,
                 annotation_count=annotation_count,
+                input_data_count=input_data_count,
                 custom_production_volume=custom_production_volume,
                 download_latest=args.latest,
                 is_get_task_histories_one_of_each=args.get_task_histories_one_of_each,

--- a/docs/command_reference/statistics/visualize.rst
+++ b/docs/command_reference/statistics/visualize.rst
@@ -156,6 +156,31 @@ CSVには以下の列が存在している必要があります。
 * ``annotation_count``
 
 
+.. _input_data_count_csv:
+
+入力データ数を変更する
+----------------------------------------------
+タスクに作業しない参照用のフレームが含まれている場合に有用なオプションです。
+
+``--input_data_count_csv`` に実際に作業したフレーム数（入力データ数）が記載されたCSVファイルを指定します。
+
+以下はCSVファイルのサンプルです。
+
+.. code-block::
+    :caption: annotation_count.csv
+
+    project_id,task_id,input_data_count
+    prj1,task1,5
+    prj1,task2,6
+
+
+CSVには以下の列が存在している必要があります。
+
+* ``project_id``
+* ``task_id``
+* ``input_data_count``
+
+
 .. _custom_project_volume:
 
 独自の生産量を指定する

--- a/tests/statistics/visualization/dataframe/test_task.py
+++ b/tests/statistics/visualization/dataframe/test_task.py
@@ -6,6 +6,7 @@ import pandas
 import pytest
 
 from annofabcli.statistics.visualization.dataframe.annotation_count import AnnotationCount
+from annofabcli.statistics.visualization.dataframe.input_data_count import InputDataCount
 from annofabcli.statistics.visualization.dataframe.inspection_comment_count import InspectionCommentCount
 from annofabcli.statistics.visualization.dataframe.task import Task
 from annofabcli.statistics.visualization.model import ProductionVolumeColumn
@@ -41,19 +42,37 @@ class TestTask:
             }
         )
         inspection_comment_count = InspectionCommentCount(df_inspection_comment_count)
-        actual = Task.from_api_content(
+        actual1 = Task.from_api_content(
+            tasks,
+            task_histories,
+            annotation_count=annotation_count,
+            input_data_count=None,
+            inspection_comment_count=inspection_comment_count,
+            project_id=project_id,
+            annofab_service=annofabapi.build(),
+        )
+        actual1.df.to_csv("out/df.csv")
+        assert len(actual1.df) == 2
+        row1 = actual1.df.iloc[0]
+        assert row1["annotation_count"] == 10
+        assert row1["inspection_comment_count"] == 5
+        assert row1["input_data_count"] == 2
+
+        input_data_count = InputDataCount(
+            pandas.DataFrame({"project_id": [project_id, project_id], "task_id": ["sample_0", "sample_1"], "input_data_count": [1, 1]})
+        )
+        actual2 = Task.from_api_content(
             tasks,
             task_histories,
             annotation_count=annotation_count,
             inspection_comment_count=inspection_comment_count,
             project_id=project_id,
             annofab_service=annofabapi.build(),
+            input_data_count=input_data_count,
         )
-        actual.df.to_csv("out/df.csv")
-        assert len(actual.df) == 2
-        row = actual.df.iloc[0]
-        assert row["annotation_count"] == 10
-        assert row["inspection_comment_count"] == 5
+        assert len(actual2.df) == 2
+        row2 = actual2.df.iloc[0]
+        assert row2["input_data_count"] == 1
 
     def test__from_csv__and__to_csv(cls) -> None:
         actual = Task.from_csv(data_dir / "task.csv")


### PR DESCRIPTION
close #1327

タスクに作業しない参照用のフレームが含まれている場合、生産した入力データ数が正しくないため、入力データ数をカスタマイズできるオプションを作りました。