### PR TITLE
`input_data put` : input_data_idが指定されないときに、UUIDではなくinput_data_nameに近い値が設定されるようにしました。

### DIFF
--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
+import re
 import sys
-import uuid
 from dataclasses import dataclass
 from functools import partial
 from multiprocessing import Pool
@@ -51,6 +51,14 @@ class InputDataForPut(DataClassJsonMixin):
     input_data_name: str
     input_data_path: str
     input_data_id: str
+
+
+def convert_input_data_name_to_input_data_id(input_data_name: str) -> str:
+    """
+    入力データ名から、入力データIDを生成する。
+    IDに使えない文字以外は`__`に変換する。
+    """
+    return re.sub(r"[^a-zA-Z0-9_.-]", "__", input_data_name)
 
 
 def read_input_data_csv(csv_file: Path) -> pandas.DataFrame:
@@ -180,11 +188,13 @@ class SubPutInputData:
 
         return self.confirm_processing(message_for_confirm)
 
-    def put_input_data_main(self, project_id: str, csv_input_data: CsvInputData, overwrite: bool = False) -> bool:  # noqa: FBT001, FBT002
+    def put_input_data_main(self, project_id: str, csv_input_data: CsvInputData, *, overwrite: bool = False) -> bool:
         input_data = InputDataForPut(
             input_data_name=csv_input_data.input_data_name,
             input_data_path=csv_input_data.input_data_path,
-            input_data_id=csv_input_data.input_data_id if csv_input_data.input_data_id is not None else str(uuid.uuid4()),
+            input_data_id=csv_input_data.input_data_id
+            if csv_input_data.input_data_id is not None
+            else convert_input_data_name_to_input_data_id(csv_input_data.input_data_name),
         )
 
         last_updated_datetime = None

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -55,10 +55,13 @@ class InputDataForPut(DataClassJsonMixin):
 
 def convert_input_data_name_to_input_data_id(input_data_name: str) -> str:
     """
-    入力データ名から、入力データIDを生成する。
-    IDに使えない文字以外は`__`に変換する。
+    入力データ名から、入力データIDを生成します。
+    * IDに使えない文字以外は`__`に変換する。
+    * 拡張子を取り除きます。アノテーションZIP内のJSONは、`{input_data_id}.json`として保存さるため、input_data_idから拡張子を除きます。
     """
-    return re.sub(r"[^a-zA-Z0-9_.-]", "__", input_data_name)
+    # 拡張子を取り除く
+    tmp = str(Path(input_data_name).with_suffix(""))
+    return re.sub(r"[^a-zA-Z0-9_.-]", "__", tmp)
 
 
 def read_input_data_csv(csv_file: Path) -> pandas.DataFrame:

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -60,7 +61,8 @@ def convert_input_data_name_to_input_data_id(input_data_name: str) -> str:
     * 拡張子を取り除きます。アノテーションZIP内のJSONは、`{input_data_id}.json`として保存さるため、input_data_idから拡張子を除きます。
     """
     # 拡張子を取り除く
-    tmp = str(Path(input_data_name).with_suffix(""))
+    # pathlibを使うと、"https://example"が"https:/example"になってしまうので、`os.path`で拡張子を取り除く
+    tmp, _ = os.path.splitext(input_data_name)  # noqa: PTH122
     return re.sub(r"[^a-zA-Z0-9_.-]", "__", tmp)
 
 

--- a/docs/command_reference/input_data/put.rst
+++ b/docs/command_reference/input_data/put.rst
@@ -27,7 +27,7 @@ CSVのフォーマットは以下の通りです。
 
     1列目,input_data_name,Yes,
     2列目,input_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを入力データに使用します。
-    3列目,input_data_id,No,省略した場合はUUID(v4)になります。
+    3列目,input_data_id,No,省略した場合はinput_data_nameに近い値（IDに使えない文字を加工した値）になります。
 
 各項目の詳細は `AnnofabのWebAPIドキュメント <https://annofab.com/docs/api/#operation/putInputData>`_ を参照してください。
 
@@ -43,6 +43,11 @@ CSVのフォーマットは以下の通りです。
     data5,file://sample.jpg,,
     data6,file:///tmp/sample.jpg,,
 
+.. warning::
+
+    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``input_data_path`` に ``https`` または ``s3`` スキームを利用できません。
+    プライベートストレージを利用するには、Annofabサポート窓口への問い合わせが必要です。
+    詳細は https://annofab.readme.io/docs/external-storage を参照してください。
 
 
 ``--csv`` に、CSVファイルのパスを指定してください。

--- a/tests/input_data/test_put_input_data.py
+++ b/tests/input_data/test_put_input_data.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from annofabcli.input_data.put_input_data import CsvInputData, PutInputData, read_input_data_csv
+from annofabcli.input_data.put_input_data import CsvInputData, PutInputData, convert_input_data_name_to_input_data_id, read_input_data_csv
 
 test_dir = Path("./tests/data/input_data")
 
@@ -14,3 +14,9 @@ def test_get_input_data_list_from_csv():
     assert actual_members[2] == CsvInputData(input_data_name="data3", input_data_path="s3://example.com/data3", input_data_id="id3")
 
     assert actual_members[3].input_data_id is None
+
+
+def test__convert_input_data_name_to_input_data_id():
+    convert_input_data_name_to_input_data_id("a/b/c.png") == "a__b__c"
+    convert_input_data_name_to_input_data_id("s3://foo.png") == "s3______foo"
+    convert_input_data_name_to_input_data_id("あ.png") == "__"

--- a/tests/input_data/test_put_input_data.py
+++ b/tests/input_data/test_put_input_data.py
@@ -17,6 +17,7 @@ def test_get_input_data_list_from_csv():
 
 
 def test__convert_input_data_name_to_input_data_id():
-    convert_input_data_name_to_input_data_id("a/b/c.png") == "a__b__c"
-    convert_input_data_name_to_input_data_id("s3://foo.png") == "s3______foo"
-    convert_input_data_name_to_input_data_id("あ.png") == "__"
+    assert convert_input_data_name_to_input_data_id("a/b/c.png") == "a__b__c"
+    assert convert_input_data_name_to_input_data_id("s3://foo.png") == "s3______foo"
+    "s3____foo"
+    assert convert_input_data_name_to_input_data_id("あ.png") == "__"


### PR DESCRIPTION
close #1265

# 変更前
`input_data_id`が指定されないときは、UUID v4が設定されます。
これは、Annofabの画面と同じ挙動です。

# 問題点
input_data_idはアノテーションZIP内のJSONファイル名に使われます。`{input_data_id}.json`というフォーマットです。

input_data_idがUUIDだと、JSONファイルをプログラムで扱いにくいです。
ある画像に対するJSONファイルを取得するには、まずinput_data_nameを特定して、その後入力データを取得して、input_data_idを知る必要があります。
したがって、input_data_idには、input_data_nameと同じ値を設定するプロジェクトが多いです。

# 変更後
input_data_idが指定されないときは、UUIDでなくinput_data_nameに近い値を設定するようにしました。
具体的には以下のように変換します。

* `input_data_name`から拡張子を除く（`{input_data_id}.json`というように使われるため、拡張子があると少し分かりくにため。問題ではない）
* IDに使えない文字以外は`__`に変換する

# 補足
補助情報の登録も同様の処理が必要です。




