### PR TITLE
`input_data put` : input_data_idが未指定のときに、input_data_nameの拡張子を除かないようにする

### DIFF
--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -56,7 +56,7 @@ class InputDataForPut(DataClassJsonMixin):
 def convert_input_data_name_to_input_data_id(input_data_name: str) -> str:
     """
     入力データ名から、入力データIDを生成します。
-    * IDに使えない文字以外は`__`に変換する。 
+    * IDに使えない文字以外は`__`に変換する。
     """
     return re.sub(r"[^a-zA-Z0-9_.-]", "__", input_data_name)
 

--- a/annofabcli/input_data/put_input_data.py
+++ b/annofabcli/input_data/put_input_data.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import re
 import sys
 from dataclasses import dataclass
@@ -57,13 +56,9 @@ class InputDataForPut(DataClassJsonMixin):
 def convert_input_data_name_to_input_data_id(input_data_name: str) -> str:
     """
     入力データ名から、入力データIDを生成します。
-    * IDに使えない文字以外は`__`に変換する。
-    * 拡張子を取り除きます。アノテーションZIP内のJSONは、`{input_data_id}.json`として保存されるため、input_data_idから拡張子を除きます。
+    * IDに使えない文字以外は`__`に変換する。 
     """
-    # 拡張子を取り除く
-    # pathlibを使うと、"https://example"が"https:/example"になってしまうので、`os.path`で拡張子を取り除く
-    tmp, _ = os.path.splitext(input_data_name)  # noqa: PTH122
-    return re.sub(r"[^a-zA-Z0-9_.-]", "__", tmp)
+    return re.sub(r"[^a-zA-Z0-9_.-]", "__", input_data_name)
 
 
 def read_input_data_csv(csv_file: Path) -> pandas.DataFrame:

--- a/tests/input_data/test_put_input_data.py
+++ b/tests/input_data/test_put_input_data.py
@@ -17,6 +17,6 @@ def test_get_input_data_list_from_csv():
 
 
 def test__convert_input_data_name_to_input_data_id():
-    assert convert_input_data_name_to_input_data_id("a/b/c.png") == "a__b__c"
-    assert convert_input_data_name_to_input_data_id("s3://foo.png") == "s3______foo"
-    assert convert_input_data_name_to_input_data_id("あ.png") == "__"
+    assert convert_input_data_name_to_input_data_id("a/b/c.png") == "a__b__c.png"
+    assert convert_input_data_name_to_input_data_id("s3://foo.png") == "s3______foo.png"
+    assert convert_input_data_name_to_input_data_id("あ.png") == "__.png"


### PR DESCRIPTION
#1347 では、input_data_nameから拡張子を除いたものをinput_data_idにしました。

input_data_idはファイル名に使われるため、拡張子が含まれていない方がよいと考えたためです。

しかし、拡張子が含まれていても特に問題はありません。
また機械的な変更の方が、ユーザーが予測しやすくなると考え、拡張子を除去しないようにしました。