### PR TITLE
`supplementary put` : `--csv`に渡すCSVファイルのフォーマットを「ヘッダなし」から「ヘッダあり」に変更しました。

### DIFF
--- a/annofabcli/project_member/put_project_members.py
+++ b/annofabcli/project_member/put_project_members.py
@@ -184,7 +184,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         required=True,
         help=(
-            "プロジェクトメンバが記載されたCVファイルのパスを指定してください。"
+            "プロジェクトメンバが記載されたCSVファイルのパスを指定してください。"
             "CSVのフォーマットは、「1列目:user_id(required), 2列目:member_role(required), "
             "3列目:sampling_inspection_rate, 4列目:sampling_acceptance_rate, ヘッダ行なし, カンマ区切り」です。"
             "member_roleは ``owner``, ``worker``, ``accepter``, ``training_data_user`` のいずれかです。"

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -371,7 +371,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--csv",
         type=str,
         help=(
-            "補助情報が記載されたCVファイルのパスを指定してください。CSVのフォーマットは、以下の通りです。\n"
+            "補助情報が記載されたCSVファイルのパスを指定してください。CSVのフォーマットは、以下の通りです。\n"
             "\n"
             " * ヘッダ行あり, カンマ区切り\n"
             " * input_data_id (required)\n"

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -374,13 +374,13 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "補助情報が記載されたCVファイルのパスを指定してください。CSVのフォーマットは、以下の通りです。\n"
             "\n"
-            " * ヘッダ行なし, カンマ区切り\n"
-            " * 1列目: input_data_id (required)\n"
-            " * 2列目: supplementary_data_number (required)\n"
-            " * 3列目: supplementary_data_name (required)\n"
-            " * 4列目: supplementary_data_path (required)\n"
-            " * 5列目: supplementary_data_id\n"
-            " * 6列目: supplementary_data_type\n"
+            " * ヘッダ行あり, カンマ区切り\n"
+            " * input_data_id (required)\n"
+            " * supplementary_data_name (required)\n"
+            " * supplementary_data_path (required)\n"
+            " * supplementary_data_id\n"
+            " * supplementary_data_type\n"
+            " * supplementary_data_number\n"
             "\n"
             "各項目の詳細は https://annofab-cli.readthedocs.io/ja/latest/command_reference/supplementary/put.html を参照してください。"
         ),
@@ -389,7 +389,6 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     JSON_SAMPLE = [  # noqa: N806
         {
             "input_data_id": "input1",
-            "supplementary_data_number": 1,
             "supplementary_data_name": "foo",
             "supplementary_data_path": "file://foo.jpg",
         }
@@ -410,7 +409,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="指定した場合、supplementary_data_id（省略時はsupplementary_data_number）がすでに存在していたら上書きします。指定しなければ、スキップします。",
+        help="指定した場合、supplementary_data_idがすでに存在していたら上書きします。指定しなければ、スキップします。",
     )
 
     parser.add_argument(
@@ -427,7 +426,7 @@ def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argpa
     subcommand_name = "put"
     subcommand_help = "補助情報を登録します。"
     description = "補助情報を登録します。"
-    epilog = "オーナロールを持つユーザで実行してください。"
+    epilog = "オーナーロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)
     parse_args(parser)

--- a/annofabcli/supplementary/put_supplementary_data.py
+++ b/annofabcli/supplementary/put_supplementary_data.py
@@ -308,7 +308,6 @@ class PutSupplementaryData(CommandLine):
                 "supplementary_data_number": "Int64",
             },
         )
-        print(df.dtypes)
         supplementary_data_list = [CliSupplementaryData.from_dict(e) for e in df.to_dict("records")]
         return supplementary_data_list
 

--- a/docs/command_reference/supplementary/put.rst
+++ b/docs/command_reference/supplementary/put.rst
@@ -19,30 +19,31 @@ CSVから補助情報を登録する
 
 CSVのフォーマットは以下の通りです。
 
+* ヘッダ行あり
 * カンマ区切り
-* ヘッダ行なし
 
 .. csv-table::
-   :header: 列番号,名前,必須,備考
+   :header: 列名,必須,備考
 
-    1列目,input_data_id,Yes,
-    2列目,supplementary_data_number,Yes,表示順を表す数値を指定してください。
-    3列目,supplementary_data_name,Yes,
-    4列目,supplementary_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
-    5列目,supplementary_data_id,No,省略した場合はsupplementary_data_nameに近い値（IDに使えない文字を加工した値）になります。
-    6列目,supplementary_data_type,No,``image`` 、 ``text`` または ``custom`` を指定ください。省略した場合は、ファイル名から推測します。
+    input_data_id,Yes,
+    supplementary_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
+    supplementary_data_name,Yes,
+    supplementary_data_id,No,省略した場合はsupplementary_data_nameに近い値（IDに使えない文字を加工した値）になります。
+    supplementary_data_type,No,補助情報の種類。 ``image`` 、 ``text`` または ``custom`` のいずれかを指定ください。省略した場合は、ファイル名から推測します。
+    supplementary_data_number,Yes,補助情報の表示順
 
 以下はCSVファイルのサンプルです。
 
 .. code-block::
     :caption: supplementary_data.csv
 
-    input1,1,data1-1,s3://example.com/data1,id1,
-    input1,2,data1-2,s3://example.com/data2,id2,image
-    input1,3,data1-3,s3://example.com/data3,id3,text
-    input2,1,data2-1,https://example.com/data4,,
-    input2,2,data2-2,file://sample.jpg,,
-    input2,3,data2-3,file:///tmp/sample.jpg,,
+    input_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_id,supplementary_data_type,supplementary_data_number
+    input1,data1-1,s3://example.com/data1,id1,
+    input1,data1-2,s3://example.com/data2,id2,image,1
+    input1,data1-3,s3://example.com/data3,id3,text,2
+    input2,data2-1,https://example.com/data4,,
+    input2,data2-2,file://sample.jpg,,
+    input2,data2-3,file:///tmp/sample.jpg,,
 
 
 .. warning::

--- a/tests/test_supplementary.py
+++ b/tests/test_supplementary.py
@@ -46,7 +46,6 @@ class TestCommandLine:
         json_args = [
             {
                 "input_data_id": input_data_id,
-                "supplementary_data_number": 1,
                 "supplementary_data_name": "foo-data",
                 "supplementary_data_path": "file://tests/data/small-lenna.png",
             }


### PR DESCRIPTION
`--csv`に渡すCSVファイルのフォーマットはヘッダなしでした。
以前は`supplementary_data_number`は必須でしたが、自動的に決めることができるためオプショナルにしたいです。

しかし、CSVは「ヘッダなし」であるため、`supplementary_data_number`をオプショナルに変更できません。
そこで、CSVのフォーマットを破壊的に変更して、「ヘッダあり」にしました。

-----
### 補足
他のコマンドも、ヘッダなしCSVからヘッダありCSVに変更する予定です。