### PR TITLE
`annotation remove_segmentation_overlap`コマンドを作成

### DIFF
--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+import numpy
+import argparse
+import copy
+import logging
+import multiprocessing
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import annofabapi
+from annofabapi.utils import can_put_annotation
+
+import annofabcli
+from annofabcli.common.cli import (
+    COMMAND_LINE_ERROR_STATUS_CODE,
+    PARALLELISM_CHOICES,
+    ArgumentParser,
+    CommandLine,
+    CommandLineWithConfirm,
+    build_annofabapi_resource_and_login,
+    get_list_from_args,
+)
+from annofabcli.common.facade import AnnofabApiFacade
+from pathlib import Path
+from annofabapi.segmentation import read_binary_image
+import numpy as np
+logger = logging.getLogger(__name__)
+
+def remove_overlap_of_binary_image_array(binary_image_array_by_annotation:dict[str,np.ndarray], annotation_id_list:list[str])->dict[str,np.ndarray]:
+    """
+    塗りつぶし画像の重なりを除去したbool配列をdictで返します。
+    
+    Args:
+        binary_image_array_by_annotation: annotation_idをkeyとし、塗りつぶし画像のbool配列をvalueとするdict
+        annotation_id_list: 塗りつぶし画像のannotation_idのlist。背面から前面の順に格納されている
+        
+    Returns:
+        重なりを除去した塗りつぶし画像のbool配列が格納されているdict。keyはannotation_id
+    
+    """
+    assert set(binary_image_array_by_annotation.keys()) == set(annotation_id_list)
+    
+    whole_2d_array = None  # 複数の塗りつぶしアノテーションを1枚に重ね合わせた状態。各要素はannotation_id
+
+    # 背面から塗りつぶしアノテーションのbool配列を重ねていく    
+    for annotation_id in annotation_id_list:
+        input_binary_image_array = binary_image_array_by_annotation[annotation_id]
+        if whole_2d_array is not None:
+           whole_2d_array = numpy.full(input_binary_image_array.shape, '', dtype=str)
+        
+        whole_2d_array = np.where(input_binary_image_array, annotation_id, whole_2d_array)
+    
+    output_binary_image_array_by_annotation = {}
+    for annotation_id in annotation_id_list:        
+        output_binary_image_array = (whole_2d_array == annotation_id)
+        output_binary_image_array_by_annotation[annotation_id] = output_binary_image_array
+    
+    return output_binary_image_array_by_annotation
+        
+def foo(details:list[dict[str,Any]], output_dir:Path):
+    original_2d_array = {}
+    result_2d_array = None
+    for detail in details:
+        if detail["body"]["_type"] != "Outer":
+            continue
+        
+        # download
+        bool_2d_array = read_binary_image(fp)
+        original_2d_array[detail["annotation_id"]] = bool_2d_array
+        
+        # 重なり
+        if result_2d_array is not None:
+           result_2d_array = numpy.full(bool_2d_array.shape, '', dtype=str)
+        
+        result_2d_array = np.where(bool_2d_array, detail["annotation_id"], result_2d_array)
+    
+    for annotation_id, _ in original_2d_array.items():
+        bool_2d_array = (result_2d_array == annotation_id)
+        
+        cv2.imwrite(output_fp, bool_2d_array)
+    
+
+def parse_copy_target(str_copy_target: str) -> CopyTarget:
+    """
+    コピー対象の文字列をパースします。
+    以下の文字列をサポートします。
+    * `task1:task2`
+    * `task1/input5:task2/input6`
+    """
+
+    def _parse_with_slash(target: str) -> tuple[str, Optional[str]]:
+        tmp = target.split("/")
+        if len(tmp) == 1:
+            return (tmp[0], None)
+        elif len(tmp) == 2:
+            return (tmp[0], tmp[1])
+        else:
+            raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
+
+    tmp_array = str_copy_target.split(":")
+    if len(tmp_array) != 2:
+        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
+
+    str_src = tmp_array[0]
+    str_dest = tmp_array[1]
+
+    src_task_id, src_input_data_id = _parse_with_slash(str_src)
+    dest_task_id, dest_input_data_id = _parse_with_slash(str_dest)
+
+    if src_input_data_id is not None and dest_input_data_id is not None:
+        return CopyTargetByInputData(
+            src_task_id=src_task_id,
+            src_input_data_id=src_input_data_id,
+            dest_task_id=dest_task_id,
+            dest_input_data_id=dest_input_data_id,
+        )
+    elif src_input_data_id is None and dest_input_data_id is None:
+        return CopyTargetByTask(src_task_id=src_task_id, dest_task_id=dest_task_id)
+    else:
+        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
+
+
+def get_copy_target_list(str_copy_target_list: list[str]) -> list[CopyTarget]:
+    """コマンドラインから受けとった文字列のlistから、コピー対象のlistを取得する。"""
+    copy_target_list: list[CopyTarget] = []
+
+    for str_copy_target in str_copy_target_list:
+        try:
+            copy_target = parse_copy_target(str_copy_target)
+            copy_target_list.append(copy_target)
+        except ValueError as e:
+            logger.warning(e)
+    return copy_target_list
+
+
+class CopyAnnotationMain(CommandLineWithConfirm):
+    def __init__(self, service: annofabapi.Resource, *, project_id: str, all_yes: bool, overwrite: bool, merge: bool, force: bool) -> None:
+        self.service = service
+        self.project_id = project_id
+        self.overwrite = overwrite
+        self.merge = merge
+        self.force = force
+
+        CommandLineWithConfirm.__init__(self, all_yes)
+
+    def copy_annotation_by_task(self, copy_target: CopyTargetByTask) -> bool:
+        """
+        タスク単位でアノテーションをコピーする
+
+        Returns:
+            1フレーム以上のアノテーションをコピーしたどうか
+        """
+        src_task = self.service.wrapper.get_task_or_none(project_id=self.project_id, task_id=copy_target.src_task_id)
+        dest_task = self.service.wrapper.get_task_or_none(project_id=self.project_id, task_id=copy_target.dest_task_id)
+
+        if src_task is None:
+            logger.warning(f"コピー元のタスク '{copy_target.src_task_id}' は存在しません。")
+            return False
+
+        if dest_task is None:
+            logger.warning(f"コピー先のタスク '{copy_target.dest_task_id}' は存在しません。")
+            return False
+
+        src_input_data_id_list = src_task["input_data_id_list"]
+        dest_input_data_id_list = dest_task["input_data_id_list"]
+
+        if len(src_input_data_id_list) != len(dest_input_data_id_list):
+            max_frame_number = min(len(src_input_data_id_list), len(dest_input_data_id_list))
+            logger.debug(
+                f"コピー元タスク'{copy_target.src_task_id}'の1〜{max_frame_number}フレームのアノテーションを、"
+                f"コピー先タスク'{copy_target.dest_task_id}'の1〜{max_frame_number}フレームにコピーします。"
+            )
+
+        copy_count = 0
+
+        for src_input_data_id, dest_input_data_id in zip(src_input_data_id_list, dest_input_data_id_list):
+            try:
+                result = self.copy_annotation_by_input_data(
+                    CopyTargetByInputData(
+                        src_task_id=copy_target.src_task_id,
+                        dest_task_id=copy_target.dest_task_id,
+                        src_input_data_id=src_input_data_id,
+                        dest_input_data_id=dest_input_data_id,
+                    ),
+                )
+                if result:
+                    copy_count += 1
+            except Exception:  # pylint: disable=broad-except
+                logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'にコピーするのに失敗しました。", exc_info=True)
+
+        logger.debug(f"'{copy_target.src_task_id}'の{copy_count}フレームのアノテーションを、'{copy_target.dest_task_id}'にコピーしました。")
+        return copy_count > 0
+
+    @staticmethod
+    def _merge_annotation(src_details: list[dict[str, Any]], dest_details: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        details = copy.deepcopy(dest_details)
+
+        # annotation_idが重複してたときに上書きできるように、annotation_idからindexを取得できるようにする
+        dest_annotation_id_dict = {e["annotation_id"]: i for i, e in enumerate(details)}
+
+        for src_anno in src_details:
+            annotation_id = src_anno["annotation_id"]
+
+            if src_anno["annotation_id"] in dest_annotation_id_dict:
+                index = dest_annotation_id_dict[annotation_id]
+                details[index] = src_anno
+            else:
+                details.append(src_anno)
+        return details
+
+    def copy_annotation_by_input_data(self, copy_target: CopyTargetByInputData) -> bool:
+        """
+        入力データ単位でアノテーションをコピーする。
+
+        Returns:
+            アノテーションをコピーしたかどうか。
+
+        """
+        src_annotation = self.service.wrapper.get_editor_annotation_or_none(
+            project_id=self.project_id, task_id=copy_target.src_task_id, input_data_id=copy_target.src_input_data_id
+        )
+        if src_annotation is None:
+            logger.warning(
+                f"task_id='{copy_target.src_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.src_task_id}'のタスクにinput_data_id='{copy_target.src_input_data_id}'の入力データが存在しません。"
+            )
+            return False
+
+        src_anno_details = src_annotation["details"]
+
+        dest_annotation = self.service.wrapper.get_editor_annotation_or_none(
+            project_id=self.project_id, task_id=copy_target.dest_task_id, input_data_id=copy_target.dest_input_data_id
+        )
+        if dest_annotation is None:
+            logger.warning(
+                f"task_id='{copy_target.dest_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.dest_task_id}'のタスクにinput_data_id='{copy_target.dest_input_data_id}'の入力データが存在しません。"
+            )
+            return False
+
+        dest_anno_details = dest_annotation["details"]
+
+        anno_details = []
+        if self.overwrite or len(dest_anno_details) == 0:
+            # `--overwrite`が指定されたか、コピー先のアノテーションが0件のとき
+            anno_details = src_anno_details
+        elif self.merge:
+            anno_details = self._merge_annotation(src_anno_details, dest_anno_details)
+        else:
+            logger.debug(
+                f"コピー先 '{copy_target.dest}' にアノテーションが存在するため、アノテーションのコピーをスキップします。"
+                f"アノテーションをコピーする場合は、`--overwrite` または '--merge' を指定してください。"
+            )
+            return False
+
+        request_body = self.service.wrapper._create_request_body_for_copy_annotation(  # noqa: SLF001
+            self.project_id,
+            copy_target.dest_task_id,
+            copy_target.dest_input_data_id,
+            src_details=anno_details,
+            account_id=self.service.api.account_id,
+        )
+        request_body["updated_datetime"] = dest_annotation["updated_datetime"]
+        self.service.api.put_annotation(self.project_id, copy_target.dest_task_id, copy_target.dest_input_data_id, request_body=request_body)
+        logger.debug(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'にコピーしました。")
+        return True
+
+    def copy_annotation(self, copy_target: CopyTarget) -> bool:
+        dest_task = self.service.wrapper.get_task_or_none(self.project_id, copy_target.dest_task_id)
+        if dest_task is None:
+            logger.warning(f"コピー先のタスク '{copy_target.dest_task_id}' は存在しません。")
+            return False
+
+        if not self.confirm_processing(f"'{copy_target.src}'のアノテーションを、'{copy_target.dest}'にコピーしますか？"):
+            return False
+
+        # 担当者割り当て変更チェック
+        changed_operator = False
+        original_operator = dest_task["account_id"]
+        if not can_put_annotation(dest_task, self.service.api.account_id):
+            if self.force:
+                logger.debug(f"`--force` が指定されているため，コピー先タスク'{copy_target.dest_task_id}' の担当者を自分自身に変更します。")
+                changed_operator = True
+                dest_task = self.service.wrapper.change_task_operator(
+                    self.project_id,
+                    copy_target.dest_task_id,
+                    self.service.api.account_id,
+                    last_updated_datetime=dest_task["updated_datetime"],
+                )
+            else:
+                logger.debug(
+                    f"コピー先タスク'{copy_target.dest_task_id}'は、過去に誰かに割り当てられたタスクで、"
+                    f"現在の担当者が自分自身でないため、アノテーションのコピーをスキップします。"
+                    f"担当者を自分自身に変更してアノテーションをコピーする場合は `--force` を指定してください。"
+                )
+                return False
+
+        result = False
+        if isinstance(copy_target, CopyTargetByTask):
+            result = self.copy_annotation_by_task(copy_target)
+
+        elif isinstance(copy_target, CopyTargetByInputData):
+            result = self.copy_annotation_by_input_data(copy_target)
+
+        # 担当者を元に戻す
+        if changed_operator:
+            self.service.wrapper.change_task_operator(
+                self.project_id,
+                copy_target.dest_task_id,
+                original_operator,
+                last_updated_datetime=dest_task["updated_datetime"],
+            )
+
+        return result
+
+    def copy_annotation_wrapper(self, copy_target: CopyTarget) -> bool:
+        try:
+            return self.copy_annotation(copy_target)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'へコピーするのに失敗しました。", exc_info=True)
+            return False
+
+    def copy_annotations(self, copy_target_list: list[CopyTarget], *, parallelism: Optional[int] = None):  # noqa: ANN201
+        if parallelism is not None:
+            with multiprocessing.Pool(parallelism) as pool:
+                result_bool_list = pool.map(self.copy_annotation_wrapper, copy_target_list)
+                success_count = len([e for e in result_bool_list if e])
+
+        else:
+            # 逐次処理
+            success_count = 0
+            for copy_target in copy_target_list:
+                try:
+                    result = self.copy_annotation(
+                        copy_target,
+                    )
+                    if result:
+                        success_count += 1
+                except Exception:  # pylint: disable=broad-except
+                    logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'へコピーするのに失敗しました。", exc_info=True)
+                    continue
+
+        logger.info(f"{success_count} / {len(copy_target_list)} 件のタスクまたは入力データに対して、アノテーションをコピーしました。")
+
+
+class CopyAnnotation(CommandLine):
+    COMMON_MESSAGE = "annofabcli annotation copy: error:"
+
+    def validate(self, args: argparse.Namespace) -> bool:
+        if args.parallelism is not None and not args.yes:
+            print(  # noqa: T201
+                f"{self.COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、'--yes' を指定してください。",
+                file=sys.stderr,
+            )
+            return False
+
+        return True
+
+    def main(self) -> None:
+        args = self.args
+        if not self.validate(args):
+            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+
+        project_id = args.project_id
+        str_copy_target_list = get_list_from_args(args.input)
+
+        copy_target_list = get_copy_target_list(str_copy_target_list)
+        if len(str_copy_target_list) != len(copy_target_list):
+            print(f"{self.COMMON_MESSAGE} argument '--input' の値が不正です。", file=sys.stderr)  # noqa: T201
+            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+
+        main_obj = CopyAnnotationMain(
+            self.service,
+            project_id=project_id,
+            all_yes=self.all_yes,
+            overwrite=args.overwrite,
+            merge=args.merge,
+            force=args.force,
+        )
+        main_obj.copy_annotations(copy_target_list, parallelism=args.parallelism)
+
+
+def main(args: argparse.Namespace) -> None:
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    CopyAnnotation(service, facade, args).main()
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    argument_parser = ArgumentParser(parser)
+    argument_parser.add_project_id()
+
+    INPUT_HELP_MESSAGE = """
+    アノテーションのコピー元とコピー先を':'で区切って指定します。
+
+    タスク単位でコピーする場合の例： ``src_task_id:dest_task_id``
+    入力データ単位でコピーする場合： ``src_task_id/src_input_data_id:dest_task_id/dest_input_data_id``
+    ``file://`` を先頭に付けると、コピー元とコピー先が記載されているファイルを指定できます。
+    """  # noqa: N806
+    parser.add_argument("--input", type=str, nargs="+", required=True, help=INPUT_HELP_MESSAGE)
+
+    overwrite_merge_group = parser.add_mutually_exclusive_group()
+    overwrite_merge_group.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="コピー先にアノテーションが存在する場合、 ``--overwrite`` を指定していれば、すでに存在するアノテーションを削除してコピーします。"
+        "指定しなければ、アノテーションのコピーをスキップします。",
+    )
+    overwrite_merge_group.add_argument(
+        "--merge",
+        action="store_true",
+        help="コピー先にアノテーションが存在する場合、 ``--merge`` を指定していればアノテーションをannotation_id単位でマージしながらコピーします。"
+        "annotation_idが一致すればアノテーションを上書き、一致しなければアノテーションを追加します。"
+        "指定しなければ、アノテーションのコピーをスキップします。",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="過去に割り当てられていて現在の担当者が自分自身でない場合、タスクの担当者を一時的に自分自身に変更してからアノテーションをコピーします。",
+    )
+
+    parser.add_argument(
+        "--parallelism",
+        type=int,
+        choices=PARALLELISM_CHOICES,
+        help="並列度。指定しない場合は、逐次的に処理します。指定した場合は、``--yes`` も指定してください。",
+    )
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
+    subcommand_name = "fix_segmentation_overlap"
+    subcommand_help = "塗りつぶしアノテーションの重なりを除去します。"
+    description = "塗りつぶしアノテーションの重なりを除去します。インスタンスセグメンテーションは重ねることができてしまいます。この重なりを除去できます。"
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
+    parse_args(parser)
+    return parser

--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -135,7 +135,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
 
             logger.debug(
                 f"{log_message_prefix}{len(updated_annotation_id_list)} 件の塗りつぶしアノテーションを更新します。 :: "
-                f"task_id='{task_id}, input_data_id='{input_data_id}', annotation_id_list={updated_annotation_id_list}"
+                f"task_id='{task_id}', input_data_id='{input_data_id}', annotation_id_list={updated_annotation_id_list}"
             )
             new_details = []
             for detail in old_details:

--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -181,17 +181,17 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
         task = self.annofab_service.wrapper.get_task_or_none(project_id=self.project_id, task_id=task_id)
         if task is None:
             logger.warning(f"{log_message_prefix}task_id='{task_id}'であるタスクは存在しません。")
-            return False
+            return 0
 
         if task["status"] in {TaskStatus.WORKING.value, TaskStatus.COMPLETE.value}:
             logger.debug(
                 f"{log_message_prefix}task_id='{task_id}'のタスクの状態は「作業中」または「完了」であるため、"
                 f"アノテーションの更新をスキップします。  :: status='{task['status']}'"
             )
-            return False
+            return 0
 
         if not self.confirm_processing(f"task_id='{task_id}'の塗りつぶしアノテーションの重なりを除去しますか？"):
-            return False
+            return 0
 
         # 担当者割り当て変更チェック
         changed_operator = False
@@ -212,7 +212,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
                     f"現在の担当者が自分自身でないため、アノテーションの更新をスキップします。"
                     f"担当者を自分自身に変更してアノテーションを更新する場合は、コマンドライン引数 '--force' を指定してください。"
                 )
-                return False
+                return 0
 
         success_input_data_count = 0
         for input_data_id in task["input_data_id_list"]:
@@ -253,6 +253,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
         task_ids: Collection[str],
         parallelism: Optional[int] = None,
     ) -> None:
+        logger.info(f"{len(task_ids)} 件のタスク塗りつぶしアノテーションの重なりを除去します。")
         success_input_data_count = 0
         if parallelism is not None:
             with multiprocessing.Pool(parallelism) as pool:
@@ -268,7 +269,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
                     logger.warning(f"task_id='{task_id}' のアノテーションの更新に失敗しました。", exc_info=True)
                     continue
 
-        logger.info(f"{task_ids} 件のタスクに含まれる入力データ {success_input_data_count} 件の塗りつぶしアノテーションを更新しました。")
+        logger.info(f"{len(task_ids)} 件のタスクに含まれる入力データ {success_input_data_count} 件の塗りつぶしアノテーションを更新しました。")
 
 
 class CopyAnnotation(CommandLine):

--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -165,7 +165,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
         self.annofab_service.api.put_annotation(self.project_id, task_id, input_data_id, query_params={"v": "2"}, request_body=request_body)
         logger.debug(
             f"{log_message_prefix}{len(updated_annotation_id_list)} 件の塗りつぶしアノテーションを更新しました。 :: "
-            f"task_id='{task_id}, input_data_id='{input_data_id}'"
+            f"task_id='{task_id}', input_data_id='{input_data_id}'"
         )
         return True
 
@@ -176,7 +176,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
         Returns:
             アノテーションを更新した入力データ数（フレーム数）
         """
-        log_message_prefix = f"{task_index+1} 件目 :: " if task_index is not None else ""
+        log_message_prefix = f"{task_index + 1} 件目 :: " if task_index is not None else ""
 
         task = self.annofab_service.wrapper.get_task_or_none(project_id=self.project_id, task_id=task_id)
         if task is None:

--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
-import numpy
+
 import argparse
-import copy
 import logging
-import multiprocessing
 import sys
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional
 
-import annofabapi
-from annofabapi.utils import can_put_annotation
+import numpy
+import numpy as np
+from annofabapi.segmentation import read_binary_image
 
 import annofabcli
 from annofabcli.common.cli import (
@@ -18,329 +16,63 @@ from annofabcli.common.cli import (
     PARALLELISM_CHOICES,
     ArgumentParser,
     CommandLine,
-    CommandLineWithConfirm,
     build_annofabapi_resource_and_login,
-    get_list_from_args,
 )
 from annofabcli.common.facade import AnnofabApiFacade
-from pathlib import Path
-from annofabapi.segmentation import read_binary_image
-import numpy as np
+
 logger = logging.getLogger(__name__)
 
-def remove_overlap_of_binary_image_array(binary_image_array_by_annotation:dict[str,np.ndarray], annotation_id_list:list[str])->dict[str,np.ndarray]:
+
+def remove_overlap_of_binary_image_array(
+    binary_image_array_by_annotation: dict[str, np.ndarray], annotation_id_list: list[str]
+) -> dict[str, np.ndarray]:
     """
     塗りつぶし画像の重なりを除去したbool配列をdictで返します。
-    
+
     Args:
         binary_image_array_by_annotation: annotation_idをkeyとし、塗りつぶし画像のbool配列をvalueとするdict
         annotation_id_list: 塗りつぶし画像のannotation_idのlist。背面から前面の順に格納されている
-        
+
     Returns:
         重なりを除去した塗りつぶし画像のbool配列が格納されているdict。keyはannotation_id
-    
+
     """
     assert set(binary_image_array_by_annotation.keys()) == set(annotation_id_list)
-    
+
     whole_2d_array = None  # 複数の塗りつぶしアノテーションを1枚に重ね合わせた状態。各要素はannotation_id
 
-    # 背面から塗りつぶしアノテーションのbool配列を重ねていく    
+    # 背面から塗りつぶしアノテーションのbool配列を重ねていく
     for annotation_id in annotation_id_list:
         input_binary_image_array = binary_image_array_by_annotation[annotation_id]
-        if whole_2d_array is not None:
-           whole_2d_array = numpy.full(input_binary_image_array.shape, '', dtype=str)
-        
+        if whole_2d_array is None:
+            whole_2d_array = numpy.full(input_binary_image_array.shape, "", dtype=str)
+
         whole_2d_array = np.where(input_binary_image_array, annotation_id, whole_2d_array)
-    
+
     output_binary_image_array_by_annotation = {}
-    for annotation_id in annotation_id_list:        
-        output_binary_image_array = (whole_2d_array == annotation_id)
+    for annotation_id in annotation_id_list:
+        output_binary_image_array = whole_2d_array == annotation_id
         output_binary_image_array_by_annotation[annotation_id] = output_binary_image_array
-    
+
     return output_binary_image_array_by_annotation
-        
-def foo(details:list[dict[str,Any]], output_dir:Path):
+
+
+def foo(details: list[dict[str, Any]], output_dir: Path):
     original_2d_array = {}
     result_2d_array = None
     for detail in details:
         if detail["body"]["_type"] != "Outer":
             continue
-        
+
         # download
         bool_2d_array = read_binary_image(fp)
         original_2d_array[detail["annotation_id"]] = bool_2d_array
-        
+
         # 重なり
         if result_2d_array is not None:
-           result_2d_array = numpy.full(bool_2d_array.shape, '', dtype=str)
-        
+            result_2d_array = numpy.full(bool_2d_array.shape, "", dtype=str)
+
         result_2d_array = np.where(bool_2d_array, detail["annotation_id"], result_2d_array)
-    
-    for annotation_id, _ in original_2d_array.items():
-        bool_2d_array = (result_2d_array == annotation_id)
-        
-        cv2.imwrite(output_fp, bool_2d_array)
-    
-
-def parse_copy_target(str_copy_target: str) -> CopyTarget:
-    """
-    コピー対象の文字列をパースします。
-    以下の文字列をサポートします。
-    * `task1:task2`
-    * `task1/input5:task2/input6`
-    """
-
-    def _parse_with_slash(target: str) -> tuple[str, Optional[str]]:
-        tmp = target.split("/")
-        if len(tmp) == 1:
-            return (tmp[0], None)
-        elif len(tmp) == 2:
-            return (tmp[0], tmp[1])
-        else:
-            raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
-
-    tmp_array = str_copy_target.split(":")
-    if len(tmp_array) != 2:
-        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
-
-    str_src = tmp_array[0]
-    str_dest = tmp_array[1]
-
-    src_task_id, src_input_data_id = _parse_with_slash(str_src)
-    dest_task_id, dest_input_data_id = _parse_with_slash(str_dest)
-
-    if src_input_data_id is not None and dest_input_data_id is not None:
-        return CopyTargetByInputData(
-            src_task_id=src_task_id,
-            src_input_data_id=src_input_data_id,
-            dest_task_id=dest_task_id,
-            dest_input_data_id=dest_input_data_id,
-        )
-    elif src_input_data_id is None and dest_input_data_id is None:
-        return CopyTargetByTask(src_task_id=src_task_id, dest_task_id=dest_task_id)
-    else:
-        raise ValueError(f"'{str_copy_target}' の形式が間違っています。")
-
-
-def get_copy_target_list(str_copy_target_list: list[str]) -> list[CopyTarget]:
-    """コマンドラインから受けとった文字列のlistから、コピー対象のlistを取得する。"""
-    copy_target_list: list[CopyTarget] = []
-
-    for str_copy_target in str_copy_target_list:
-        try:
-            copy_target = parse_copy_target(str_copy_target)
-            copy_target_list.append(copy_target)
-        except ValueError as e:
-            logger.warning(e)
-    return copy_target_list
-
-
-class CopyAnnotationMain(CommandLineWithConfirm):
-    def __init__(self, service: annofabapi.Resource, *, project_id: str, all_yes: bool, overwrite: bool, merge: bool, force: bool) -> None:
-        self.service = service
-        self.project_id = project_id
-        self.overwrite = overwrite
-        self.merge = merge
-        self.force = force
-
-        CommandLineWithConfirm.__init__(self, all_yes)
-
-    def copy_annotation_by_task(self, copy_target: CopyTargetByTask) -> bool:
-        """
-        タスク単位でアノテーションをコピーする
-
-        Returns:
-            1フレーム以上のアノテーションをコピーしたどうか
-        """
-        src_task = self.service.wrapper.get_task_or_none(project_id=self.project_id, task_id=copy_target.src_task_id)
-        dest_task = self.service.wrapper.get_task_or_none(project_id=self.project_id, task_id=copy_target.dest_task_id)
-
-        if src_task is None:
-            logger.warning(f"コピー元のタスク '{copy_target.src_task_id}' は存在しません。")
-            return False
-
-        if dest_task is None:
-            logger.warning(f"コピー先のタスク '{copy_target.dest_task_id}' は存在しません。")
-            return False
-
-        src_input_data_id_list = src_task["input_data_id_list"]
-        dest_input_data_id_list = dest_task["input_data_id_list"]
-
-        if len(src_input_data_id_list) != len(dest_input_data_id_list):
-            max_frame_number = min(len(src_input_data_id_list), len(dest_input_data_id_list))
-            logger.debug(
-                f"コピー元タスク'{copy_target.src_task_id}'の1〜{max_frame_number}フレームのアノテーションを、"
-                f"コピー先タスク'{copy_target.dest_task_id}'の1〜{max_frame_number}フレームにコピーします。"
-            )
-
-        copy_count = 0
-
-        for src_input_data_id, dest_input_data_id in zip(src_input_data_id_list, dest_input_data_id_list):
-            try:
-                result = self.copy_annotation_by_input_data(
-                    CopyTargetByInputData(
-                        src_task_id=copy_target.src_task_id,
-                        dest_task_id=copy_target.dest_task_id,
-                        src_input_data_id=src_input_data_id,
-                        dest_input_data_id=dest_input_data_id,
-                    ),
-                )
-                if result:
-                    copy_count += 1
-            except Exception:  # pylint: disable=broad-except
-                logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'にコピーするのに失敗しました。", exc_info=True)
-
-        logger.debug(f"'{copy_target.src_task_id}'の{copy_count}フレームのアノテーションを、'{copy_target.dest_task_id}'にコピーしました。")
-        return copy_count > 0
-
-    @staticmethod
-    def _merge_annotation(src_details: list[dict[str, Any]], dest_details: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        details = copy.deepcopy(dest_details)
-
-        # annotation_idが重複してたときに上書きできるように、annotation_idからindexを取得できるようにする
-        dest_annotation_id_dict = {e["annotation_id"]: i for i, e in enumerate(details)}
-
-        for src_anno in src_details:
-            annotation_id = src_anno["annotation_id"]
-
-            if src_anno["annotation_id"] in dest_annotation_id_dict:
-                index = dest_annotation_id_dict[annotation_id]
-                details[index] = src_anno
-            else:
-                details.append(src_anno)
-        return details
-
-    def copy_annotation_by_input_data(self, copy_target: CopyTargetByInputData) -> bool:
-        """
-        入力データ単位でアノテーションをコピーする。
-
-        Returns:
-            アノテーションをコピーしたかどうか。
-
-        """
-        src_annotation = self.service.wrapper.get_editor_annotation_or_none(
-            project_id=self.project_id, task_id=copy_target.src_task_id, input_data_id=copy_target.src_input_data_id
-        )
-        if src_annotation is None:
-            logger.warning(
-                f"task_id='{copy_target.src_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.src_task_id}'のタスクにinput_data_id='{copy_target.src_input_data_id}'の入力データが存在しません。"
-            )
-            return False
-
-        src_anno_details = src_annotation["details"]
-
-        dest_annotation = self.service.wrapper.get_editor_annotation_or_none(
-            project_id=self.project_id, task_id=copy_target.dest_task_id, input_data_id=copy_target.dest_input_data_id
-        )
-        if dest_annotation is None:
-            logger.warning(
-                f"task_id='{copy_target.dest_task_id}'のタスクが存在しないか、またはtask_id='{copy_target.dest_task_id}'のタスクにinput_data_id='{copy_target.dest_input_data_id}'の入力データが存在しません。"
-            )
-            return False
-
-        dest_anno_details = dest_annotation["details"]
-
-        anno_details = []
-        if self.overwrite or len(dest_anno_details) == 0:
-            # `--overwrite`が指定されたか、コピー先のアノテーションが0件のとき
-            anno_details = src_anno_details
-        elif self.merge:
-            anno_details = self._merge_annotation(src_anno_details, dest_anno_details)
-        else:
-            logger.debug(
-                f"コピー先 '{copy_target.dest}' にアノテーションが存在するため、アノテーションのコピーをスキップします。"
-                f"アノテーションをコピーする場合は、`--overwrite` または '--merge' を指定してください。"
-            )
-            return False
-
-        request_body = self.service.wrapper._create_request_body_for_copy_annotation(  # noqa: SLF001
-            self.project_id,
-            copy_target.dest_task_id,
-            copy_target.dest_input_data_id,
-            src_details=anno_details,
-            account_id=self.service.api.account_id,
-        )
-        request_body["updated_datetime"] = dest_annotation["updated_datetime"]
-        self.service.api.put_annotation(self.project_id, copy_target.dest_task_id, copy_target.dest_input_data_id, request_body=request_body)
-        logger.debug(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'にコピーしました。")
-        return True
-
-    def copy_annotation(self, copy_target: CopyTarget) -> bool:
-        dest_task = self.service.wrapper.get_task_or_none(self.project_id, copy_target.dest_task_id)
-        if dest_task is None:
-            logger.warning(f"コピー先のタスク '{copy_target.dest_task_id}' は存在しません。")
-            return False
-
-        if not self.confirm_processing(f"'{copy_target.src}'のアノテーションを、'{copy_target.dest}'にコピーしますか？"):
-            return False
-
-        # 担当者割り当て変更チェック
-        changed_operator = False
-        original_operator = dest_task["account_id"]
-        if not can_put_annotation(dest_task, self.service.api.account_id):
-            if self.force:
-                logger.debug(f"`--force` が指定されているため，コピー先タスク'{copy_target.dest_task_id}' の担当者を自分自身に変更します。")
-                changed_operator = True
-                dest_task = self.service.wrapper.change_task_operator(
-                    self.project_id,
-                    copy_target.dest_task_id,
-                    self.service.api.account_id,
-                    last_updated_datetime=dest_task["updated_datetime"],
-                )
-            else:
-                logger.debug(
-                    f"コピー先タスク'{copy_target.dest_task_id}'は、過去に誰かに割り当てられたタスクで、"
-                    f"現在の担当者が自分自身でないため、アノテーションのコピーをスキップします。"
-                    f"担当者を自分自身に変更してアノテーションをコピーする場合は `--force` を指定してください。"
-                )
-                return False
-
-        result = False
-        if isinstance(copy_target, CopyTargetByTask):
-            result = self.copy_annotation_by_task(copy_target)
-
-        elif isinstance(copy_target, CopyTargetByInputData):
-            result = self.copy_annotation_by_input_data(copy_target)
-
-        # 担当者を元に戻す
-        if changed_operator:
-            self.service.wrapper.change_task_operator(
-                self.project_id,
-                copy_target.dest_task_id,
-                original_operator,
-                last_updated_datetime=dest_task["updated_datetime"],
-            )
-
-        return result
-
-    def copy_annotation_wrapper(self, copy_target: CopyTarget) -> bool:
-        try:
-            return self.copy_annotation(copy_target)
-        except Exception:  # pylint: disable=broad-except
-            logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'へコピーするのに失敗しました。", exc_info=True)
-            return False
-
-    def copy_annotations(self, copy_target_list: list[CopyTarget], *, parallelism: Optional[int] = None):  # noqa: ANN201
-        if parallelism is not None:
-            with multiprocessing.Pool(parallelism) as pool:
-                result_bool_list = pool.map(self.copy_annotation_wrapper, copy_target_list)
-                success_count = len([e for e in result_bool_list if e])
-
-        else:
-            # 逐次処理
-            success_count = 0
-            for copy_target in copy_target_list:
-                try:
-                    result = self.copy_annotation(
-                        copy_target,
-                    )
-                    if result:
-                        success_count += 1
-                except Exception:  # pylint: disable=broad-except
-                    logger.warning(f"'{copy_target.src}'のアノテーションを'{copy_target.dest}'へコピーするのに失敗しました。", exc_info=True)
-                    continue
-
-        logger.info(f"{success_count} / {len(copy_target_list)} 件のタスクまたは入力データに対して、アノテーションをコピーしました。")
 
 
 class CopyAnnotation(CommandLine):
@@ -362,22 +94,16 @@ class CopyAnnotation(CommandLine):
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
         project_id = args.project_id
-        str_copy_target_list = get_list_from_args(args.input)
 
-        copy_target_list = get_copy_target_list(str_copy_target_list)
-        if len(str_copy_target_list) != len(copy_target_list):
-            print(f"{self.COMMON_MESSAGE} argument '--input' の値が不正です。", file=sys.stderr)  # noqa: T201
-            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
-
-        main_obj = CopyAnnotationMain(
-            self.service,
-            project_id=project_id,
-            all_yes=self.all_yes,
-            overwrite=args.overwrite,
-            merge=args.merge,
-            force=args.force,
-        )
-        main_obj.copy_annotations(copy_target_list, parallelism=args.parallelism)
+        # main_obj = CopyAnnotationMain(
+        #     self.service,
+        #     project_id=project_id,
+        #     all_yes=self.all_yes,
+        #     overwrite=args.overwrite,
+        #     merge=args.merge,
+        #     force=args.force,
+        # )
+        # main_obj.copy_annotations(copy_target_list, parallelism=args.parallelism)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -432,7 +158,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 def add_parser(subparsers: Optional[argparse._SubParsersAction] = None) -> argparse.ArgumentParser:
     subcommand_name = "fix_segmentation_overlap"
     subcommand_help = "塗りつぶしアノテーションの重なりを除去します。"
-    description = "塗りつぶしアノテーションの重なりを除去します。インスタンスセグメンテーションは重ねることができてしまいます。この重なりを除去できます。"
+    description = (
+        "塗りつぶしアノテーションの重なりを除去します。インスタンスセグメンテーションは重ねることができてしまいます。この重なりを除去できます。"
+    )
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description)
     parse_args(parser)
     return parser

--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -274,6 +274,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
 
 class CopyAnnotation(CommandLine):
     COMMON_MESSAGE = "annofabcli annotation remove_segmentation_overlap: error:"
+
     def validate(self, args: argparse.Namespace) -> bool:
         if args.parallelism is not None and not args.yes:
             print(  # noqa: T201

--- a/annofabcli/annotation/remove_segmentation_overlap.py
+++ b/annofabcli/annotation/remove_segmentation_overlap.py
@@ -92,7 +92,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
                 continue
 
             segmentation_response = self.annofab_service.wrapper.execute_http_get(detail["body"]["url"], stream=True)
-            segmentation_response.raw.decode_content = True
+            # segmentation_response.raw.decode_content = True
             input_binary_image_array_by_annotation[detail["annotation_id"]] = read_binary_image(segmentation_response.raw)
             segmentation_annotation_id_list.append(detail["annotation_id"])
 
@@ -135,7 +135,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
 
             logger.debug(
                 f"{log_message_prefix}{len(updated_annotation_id_list)} 件の塗りつぶしアノテーションを更新します。 :: "
-                f"task_id='{task_id}, input_data_id='{input_data_id}', {updated_annotation_id_list}"
+                f"task_id='{task_id}, input_data_id='{input_data_id}', annotation_id_list={updated_annotation_id_list}"
             )
             new_details = []
             for detail in old_details:
@@ -176,7 +176,7 @@ class RemoveSegmentationOverlapMain(CommandLineWithConfirm):
         Returns:
             アノテーションを更新した入力データ数（フレーム数）
         """
-        log_message_prefix = f"{task_index} 件目 :: " if task_index is not None else ""
+        log_message_prefix = f"{task_index+1} 件目 :: " if task_index is not None else ""
 
         task = self.annofab_service.wrapper.get_task_or_none(project_id=self.project_id, task_id=task_id)
         if task is None:

--- a/annofabcli/annotation/subcommand_annotation.py
+++ b/annofabcli/annotation/subcommand_annotation.py
@@ -10,6 +10,7 @@ import annofabcli.annotation.dump_annotation
 import annofabcli.annotation.import_annotation
 import annofabcli.annotation.list_annotation
 import annofabcli.annotation.list_annotation_count
+import annofabcli.annotation.remove_segmentation_overlap
 import annofabcli.annotation.restore_annotation
 import annofabcli.common.cli
 
@@ -27,6 +28,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.annotation.import_annotation.add_parser(subparsers)
     annofabcli.annotation.list_annotation.add_parser(subparsers)
     annofabcli.annotation.list_annotation_count.add_parser(subparsers)
+    annofabcli.annotation.remove_segmentation_overlap.add_parser(subparsers)
     annofabcli.annotation.restore_annotation.add_parser(subparsers)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,14 +48,14 @@ files = [
 
 [[package]]
 name = "annofabapi"
-version = "1.4.1"
-description = "Python Clinet Library of Annofab WebAPI (https://annofab.com/docs/api/)"
+version = "1.4.3"
+description = "Python Client Library of Annofab WebAPI (https://annofab.com/docs/api/)"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "annofabapi-1.4.1-py3-none-any.whl", hash = "sha256:1391e6034ceab578f08f0f169e0e19f2cb45044d517c62a125e6df04a37c2178"},
-    {file = "annofabapi-1.4.1.tar.gz", hash = "sha256:8f3814c7d1a1e98229c2aa00dfe14d5b3e34ef3faa57cb8bf8d314edf3eae847"},
+    {file = "annofabapi-1.4.3-py3-none-any.whl", hash = "sha256:454e42803d4043b23959c1579f5199c5f960a951fccdbf2f711e36bca04fc591"},
+    {file = "annofabapi-1.4.3.tar.gz", hash = "sha256:a26811622b51c5d4c651304a04e6848724b905e3a6eac444c8cc8c3af920854f"},
 ]
 
 [package.dependencies]
@@ -1782,20 +1782,21 @@ tests = ["pytest"]
 
 [[package]]
 name = "pydantic"
-version = "2.10.6"
+version = "2.11.0"
 description = "Data validation using Python type hints"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584"},
-    {file = "pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236"},
+    {file = "pydantic-2.11.0-py3-none-any.whl", hash = "sha256:d52535bb7aba33c2af820eaefd866f3322daf39319d03374921cd17fbbdf28f9"},
+    {file = "pydantic-2.11.0.tar.gz", hash = "sha256:d6a287cd6037dee72f0597229256dfa246c4d61567a250e99f86b7b4626e2f41"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.27.2"
+pydantic-core = "2.33.0"
 typing-extensions = ">=4.12.2"
+typing-inspection = ">=0.4.0"
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -1803,112 +1804,111 @@ timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
+version = "2.33.0"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4"},
-    {file = "pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc"},
-    {file = "pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9"},
-    {file = "pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee"},
-    {file = "pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d3e8d504bdd3f10835468f29008d72fc8359d95c9c415ce6e767203db6127506"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:521eb9b7f036c9b6187f0b47318ab0d7ca14bd87f776240b90b21c1f4f149320"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85210c4d99a0114f5a9481b44560d7d1e35e32cc5634c656bc48e590b669b145"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d716e2e30c6f140d7560ef1538953a5cd1a87264c737643d481f2779fc247fe1"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f66d89ba397d92f840f8654756196d93804278457b5fbede59598a1f9f90b228"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:669e193c1c576a58f132e3158f9dfa9662969edb1a250c54d8fa52590045f046"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdbe7629b996647b99c01b37f11170a57ae675375b14b8c13b8518b8320ced5"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d262606bf386a5ba0b0af3b97f37c83d7011439e3dc1a9298f21efb292e42f1a"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cabb9bcb7e0d97f74df8646f34fc76fbf793b7f6dc2438517d7a9e50eee4f14d"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_armv7l.whl", hash = "sha256:d2d63f1215638d28221f664596b1ccb3944f6e25dd18cd3b86b0a4c408d5ebb9"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bca101c00bff0adb45a833f8451b9105d9df18accb8743b08107d7ada14bd7da"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-win32.whl", hash = "sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b"},
-    {file = "pydantic_core-2.27.2-cp38-cp38-win_amd64.whl", hash = "sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c10eb4f1659290b523af58fa7cffb452a61ad6ae5613404519aee4bfbf1df993"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef592d4bad47296fb11f96cd7dc898b92e795032b4894dfb4076cfccd43a9308"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c61709a844acc6bf0b7dce7daae75195a10aac96a596ea1b776996414791ede4"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c5f762659e47fdb7b16956c71598292f60a03aa92f8b6351504359dbdba6cf"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c9775e339e42e79ec99c441d9730fccf07414af63eac2f0e48e08fd38a64d76"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57762139821c31847cfb2df63c12f725788bd9f04bc2fb392790959b8f70f118"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d1e85068e818c73e048fe28cfc769040bb1f475524f4745a5dc621f75ac7630"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:097830ed52fd9e427942ff3b9bc17fab52913b2f50f2880dc4a5611446606a54"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:044a50963a614ecfae59bb1eaf7ea7efc4bc62f49ed594e18fa1e5d953c40e9f"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:4e0b4220ba5b40d727c7f879eac379b822eee5d8fff418e9d3381ee45b3b0362"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e4f4bb20d75e9325cc9696c6802657b58bc1dbbe3022f32cc2b2b632c3fbb96"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-win32.whl", hash = "sha256:cca63613e90d001b9f2f9a9ceb276c308bfa2a43fafb75c8031c4f66039e8c6e"},
-    {file = "pydantic_core-2.27.2-cp39-cp39-win_amd64.whl", hash = "sha256:77d1bca19b0f7021b3a982e6f903dcd5b2b06076def36a652e3907f596e29f67"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9"},
-    {file = "pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c33939a82924da9ed65dab5a65d427205a73181d8098e79b6b426bdf8ad4e656"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c817e2b40aba42bac6f457498dacabc568c3b7a986fc9ba7c8d9d260b71485fb"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:251136cdad0cb722e93732cb45ca5299fb56e1344a833640bf93b2803f8d1bfd"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2088237af596f0a524d3afc39ab3b036e8adb054ee57cbb1dcf8e09da5b29cc"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d4041c0b966a84b4ae7a09832eb691a35aec90910cd2dbe7a208de59be77965b"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8083d4e875ebe0b864ffef72a4304827015cff328a1be6e22cc850753bfb122b"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f141ee28a0ad2123b6611b6ceff018039df17f32ada8b534e6aa039545a3efb2"},
-    {file = "pydantic_core-2.27.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7d0c8399fcc1848491f00e0314bd59fb34a9c008761bcb422a057670c3f65e35"},
-    {file = "pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:71dffba8fe9ddff628c68f3abd845e91b028361d43c5f8e7b3f8b91d7d85413e"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:abaeec1be6ed535a5d7ffc2e6c390083c425832b20efd621562fbb5bff6dc518"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:759871f00e26ad3709efc773ac37b4d571de065f9dfb1778012908bcc36b3a73"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dcfebee69cd5e1c0b76a17e17e347c84b00acebb8dd8edb22d4a03e88e82a207"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b1262b912435a501fa04cd213720609e2cefa723a07c92017d18693e69bf00b"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4726f1f3f42d6a25678c67da3f0b10f148f5655813c5aca54b0d1742ba821b8f"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e790954b5093dff1e3a9a2523fddc4e79722d6f07993b4cd5547825c3cbf97b5"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:34e7fb3abe375b5c4e64fab75733d605dda0f59827752debc99c17cb2d5f3276"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ecb158fb9b9091b515213bed3061eb7deb1d3b4e02327c27a0ea714ff46b0760"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:4d9149e7528af8bbd76cc055967e6e04617dcb2a2afdaa3dea899406c5521faa"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e81a295adccf73477220e15ff79235ca9dcbcee4be459eb9d4ce9a2763b8386c"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-win32.whl", hash = "sha256:f22dab23cdbce2005f26a8f0c71698457861f97fc6318c75814a50c75e87d025"},
+    {file = "pydantic_core-2.33.0-cp310-cp310-win_amd64.whl", hash = "sha256:9cb2390355ba084c1ad49485d18449b4242da344dea3e0fe10babd1f0db7dcfc"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a608a75846804271cf9c83e40bbb4dab2ac614d33c6fd5b0c6187f53f5c593ef"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e1c69aa459f5609dec2fa0652d495353accf3eda5bdb18782bc5a2ae45c9273a"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9ec80eb5a5f45a2211793f1c4aeddff0c3761d1c70d684965c1807e923a588b"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e925819a98318d17251776bd3d6aa9f3ff77b965762155bdad15d1a9265c4cfd"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bf68bb859799e9cec3d9dd8323c40c00a254aabb56fe08f907e437005932f2b"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1b2ea72dea0825949a045fa4071f6d5b3d7620d2a208335207793cf29c5a182d"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1583539533160186ac546b49f5cde9ffc928062c96920f58bd95de32ffd7bffd"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:23c3e77bf8a7317612e5c26a3b084c7edeb9552d645742a54a5867635b4f2453"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7a7f2a3f628d2f7ef11cb6188bcf0b9e1558151d511b974dfea10a49afe192b"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:f1fb026c575e16f673c61c7b86144517705865173f3d0907040ac30c4f9f5915"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:635702b2fed997e0ac256b2cfbdb4dd0bf7c56b5d8fba8ef03489c03b3eb40e2"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-win32.whl", hash = "sha256:07b4ced28fccae3f00626eaa0c4001aa9ec140a29501770a88dbbb0966019a86"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-win_amd64.whl", hash = "sha256:4927564be53239a87770a5f86bdc272b8d1fbb87ab7783ad70255b4ab01aa25b"},
+    {file = "pydantic_core-2.33.0-cp311-cp311-win_arm64.whl", hash = "sha256:69297418ad644d521ea3e1aa2e14a2a422726167e9ad22b89e8f1130d68e1e9a"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6c32a40712e3662bebe524abe8abb757f2fa2000028d64cc5a1006016c06af43"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ec86b5baa36f0a0bfb37db86c7d52652f8e8aa076ab745ef7725784183c3fdd"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4deac83a8cc1d09e40683be0bc6d1fa4cde8df0a9bf0cda5693f9b0569ac01b6"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:175ab598fb457a9aee63206a1993874badf3ed9a456e0654273e56f00747bbd6"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f36afd0d56a6c42cf4e8465b6441cf546ed69d3a4ec92724cc9c8c61bd6ecf4"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0a98257451164666afafc7cbf5fb00d613e33f7e7ebb322fbcd99345695a9a61"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecc6d02d69b54a2eb83ebcc6f29df04957f734bcf309d346b4f83354d8376862"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a69b7596c6603afd049ce7f3835bcf57dd3892fc7279f0ddf987bebed8caa5a"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ea30239c148b6ef41364c6f51d103c2988965b643d62e10b233b5efdca8c0099"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:abfa44cf2f7f7d7a199be6c6ec141c9024063205545aa09304349781b9a125e6"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20d4275f3c4659d92048c70797e5fdc396c6e4446caf517ba5cad2db60cd39d3"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-win32.whl", hash = "sha256:918f2013d7eadea1d88d1a35fd4a1e16aaf90343eb446f91cb091ce7f9b431a2"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-win_amd64.whl", hash = "sha256:aec79acc183865bad120b0190afac467c20b15289050648b876b07777e67ea48"},
+    {file = "pydantic_core-2.33.0-cp312-cp312-win_arm64.whl", hash = "sha256:5461934e895968655225dfa8b3be79e7e927e95d4bd6c2d40edd2fa7052e71b6"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f00e8b59e1fc8f09d05594aa7d2b726f1b277ca6155fc84c0396db1b373c4555"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a73be93ecef45786d7d95b0c5e9b294faf35629d03d5b145b09b81258c7cd6d"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff48a55be9da6930254565ff5238d71d5e9cd8c5487a191cb85df3bdb8c77365"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26a4ea04195638dcd8c53dadb545d70badba51735b1594810e9768c2c0b4a5da"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41d698dcbe12b60661f0632b543dbb119e6ba088103b364ff65e951610cb7ce0"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae62032ef513fe6281ef0009e30838a01057b832dc265da32c10469622613885"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f225f3a3995dbbc26affc191d0443c6c4aa71b83358fd4c2b7d63e2f6f0336f9"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5bdd36b362f419c78d09630cbaebc64913f66f62bda6d42d5fbb08da8cc4f181"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2a0147c0bef783fd9abc9f016d66edb6cac466dc54a17ec5f5ada08ff65caf5d"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:c860773a0f205926172c6644c394e02c25421dc9a456deff16f64c0e299487d3"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:138d31e3f90087f42aa6286fb640f3c7a8eb7bdae829418265e7e7474bd2574b"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-win32.whl", hash = "sha256:d20cbb9d3e95114325780f3cfe990f3ecae24de7a2d75f978783878cce2ad585"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-win_amd64.whl", hash = "sha256:ca1103d70306489e3d006b0f79db8ca5dd3c977f6f13b2c59ff745249431a606"},
+    {file = "pydantic_core-2.33.0-cp313-cp313-win_arm64.whl", hash = "sha256:6291797cad239285275558e0a27872da735b05c75d5237bbade8736f80e4c225"},
+    {file = "pydantic_core-2.33.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7b79af799630af263eca9ec87db519426d8c9b3be35016eddad1832bac812d87"},
+    {file = "pydantic_core-2.33.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eabf946a4739b5237f4f56d77fa6668263bc466d06a8036c055587c130a46f7b"},
+    {file = "pydantic_core-2.33.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8a1d581e8cdbb857b0e0e81df98603376c1a5c34dc5e54039dcc00f043df81e7"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:7c9c84749f5787781c1c45bb99f433402e484e515b40675a5d121ea14711cf61"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:64672fa888595a959cfeff957a654e947e65bbe1d7d82f550417cbd6898a1d6b"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26bc7367c0961dec292244ef2549afa396e72e28cc24706210bd44d947582c59"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ce72d46eb201ca43994303025bd54d8a35a3fc2a3495fac653d6eb7205ce04f4"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14229c1504287533dbf6b1fc56f752ce2b4e9694022ae7509631ce346158de11"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:085d8985b1c1e48ef271e98a658f562f29d89bda98bf120502283efbc87313eb"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31860fbda80d8f6828e84b4a4d129fd9c4535996b8249cfb8c720dc2a1a00bb8"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f200b2f20856b5a6c3a35f0d4e344019f805e363416e609e9b47c552d35fd5ea"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5f72914cfd1d0176e58ddc05c7a47674ef4222c8253bf70322923e73e14a4ac3"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:91301a0980a1d4530d4ba7e6a739ca1a6b31341252cb709948e0aca0860ce0ae"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7419241e17c7fbe5074ba79143d5523270e04f86f1b3a0dff8df490f84c8273a"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-win32.whl", hash = "sha256:7a25493320203005d2a4dac76d1b7d953cb49bce6d459d9ae38e30dd9f29bc9c"},
+    {file = "pydantic_core-2.33.0-cp39-cp39-win_amd64.whl", hash = "sha256:82a4eba92b7ca8af1b7d5ef5f3d9647eee94d1f74d21ca7c21e3a2b92e008358"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e2762c568596332fdab56b07060c8ab8362c56cf2a339ee54e491cd503612c50"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5bf637300ff35d4f59c006fff201c510b2b5e745b07125458a5389af3c0dff8c"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62c151ce3d59ed56ebd7ce9ce5986a409a85db697d25fc232f8e81f195aa39a1"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ee65f0cc652261744fd07f2c6e6901c914aa6c5ff4dcfaf1136bc394d0dd26b"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:024d136ae44d233e6322027bbf356712b3940bee816e6c948ce4b90f18471b3d"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e37f10f6d4bc67c58fbd727108ae1d8b92b397355e68519f1e4a7babb1473442"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:502ed542e0d958bd12e7c3e9a015bce57deaf50eaa8c2e1c439b512cb9db1e3a"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:715c62af74c236bf386825c0fdfa08d092ab0f191eb5b4580d11c3189af9d330"},
+    {file = "pydantic_core-2.33.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:bccc06fa0372151f37f6b69834181aa9eb57cf8665ed36405fb45fbf6cac3bae"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5d8dc9f63a26f7259b57f46a7aab5af86b2ad6fbe48487500bb1f4b27e051e4c"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30369e54d6d0113d2aa5aee7a90d17f225c13d87902ace8fcd7bbf99b19124db"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3eb479354c62067afa62f53bb387827bee2f75c9c79ef25eef6ab84d4b1ae3b"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0310524c833d91403c960b8a3cf9f46c282eadd6afd276c8c5edc617bd705dc9"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eddb18a00bbb855325db27b4c2a89a4ba491cd6a0bd6d852b225172a1f54b36c"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:ade5dbcf8d9ef8f4b28e682d0b29f3008df9842bb5ac48ac2c17bc55771cc976"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2c0afd34f928383e3fd25740f2050dbac9d077e7ba5adbaa2227f4d4f3c8da5c"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:7da333f21cd9df51d5731513a6d39319892947604924ddf2e24a4612975fb936"},
+    {file = "pydantic_core-2.33.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b6d77c75a57f041c5ee915ff0b0bb58eabb78728b69ed967bc5b780e8f701b8"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ba95691cf25f63df53c1d342413b41bd7762d9acb425df8858d7efa616c0870e"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:4f1ab031feb8676f6bd7c85abec86e2935850bf19b84432c64e3e239bffeb1ec"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58c1151827eef98b83d49b6ca6065575876a02d2211f259fb1a6b7757bd24dd8"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a66d931ea2c1464b738ace44b7334ab32a2fd50be023d863935eb00f42be1778"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0bcf0bab28995d483f6c8d7db25e0d05c3efa5cebfd7f56474359e7137f39856"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:89670d7a0045acb52be0566df5bc8b114ac967c662c06cf5e0c606e4aadc964b"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:b716294e721d8060908dbebe32639b01bfe61b15f9f57bcc18ca9a0e00d9520b"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fc53e05c16697ff0c1c7c2b98e45e131d4bfb78068fffff92a82d169cbb4c7b7"},
+    {file = "pydantic_core-2.33.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:68504959253303d3ae9406b634997a2123a0b0c1da86459abbd0ffc921695eac"},
+    {file = "pydantic_core-2.33.0.tar.gz", hash = "sha256:40eb8af662ba409c3cbf4a8150ad32ae73514cd7cb1f1a2113af39763dd616b3"},
 ]
 
 [package.dependencies]
@@ -1997,15 +1997,15 @@ hook-testing = ["execnet (>=1.5.0)", "psutil", "pytest (>=2.7.3)"]
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2025.1"
+version = "2025.2"
 description = "Community maintained hooks for PyInstaller"
 optional = false
 python-versions = ">=3.8"
 groups = ["publish"]
 markers = "python_version == \"3.12\""
 files = [
-    {file = "pyinstaller_hooks_contrib-2025.1-py3-none-any.whl", hash = "sha256:d3c799470cbc0bda60dcc8e6b4ab976777532b77621337f2037f558905e3a8e9"},
-    {file = "pyinstaller_hooks_contrib-2025.1.tar.gz", hash = "sha256:130818f9e9a0a7f2261f1fd66054966a3a50c99d000981c5d1db11d3ad0c6ab2"},
+    {file = "pyinstaller_hooks_contrib-2025.2-py3-none-any.whl", hash = "sha256:0b2bc7697075de5eb071ff13ef4a156d3beae6c19c7cbdcd70f37978d2013e30"},
+    {file = "pyinstaller_hooks_contrib-2025.2.tar.gz", hash = "sha256:ccdd41bc30290f725f3e48f4a39985d11855af81d614d167e3021e303acb9102"},
 ]
 
 [package.dependencies]
@@ -2153,14 +2153,14 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2025.1"
+version = "2025.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["main", "dev-only"]
 files = [
-    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
-    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
 ]
 
 [[package]]
@@ -2311,15 +2311,15 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "77.0.3"
+version = "78.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["publish"]
 markers = "python_version == \"3.12\""
 files = [
-    {file = "setuptools-77.0.3-py3-none-any.whl", hash = "sha256:67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c"},
-    {file = "setuptools-77.0.3.tar.gz", hash = "sha256:583b361c8da8de57403743e756609670de6fb2345920e36dc5c2d914c319c945"},
+    {file = "setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"},
+    {file = "setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54"},
 ]
 
 [package.extras]
@@ -2679,38 +2679,38 @@ files = [
 
 [[package]]
 name = "types-pytz"
-version = "2025.1.0.20250318"
+version = "2025.2.0.20250326"
 description = "Typing stubs for pytz"
 optional = false
 python-versions = ">=3.9"
 groups = ["linter"]
 files = [
-    {file = "types_pytz-2025.1.0.20250318-py3-none-any.whl", hash = "sha256:04dba4907c5415777083f9548693c6d9f80ec53adcaff55a38526a3f8ddcae04"},
-    {file = "types_pytz-2025.1.0.20250318.tar.gz", hash = "sha256:97e0e35184c6fe14e3a5014512057f2c57bb0c6582d63c1cfcc4809f82180449"},
+    {file = "types_pytz-2025.2.0.20250326-py3-none-any.whl", hash = "sha256:3c397fd1b845cd2b3adc9398607764ced9e578a98a5d1fbb4a9bc9253edfb162"},
+    {file = "types_pytz-2025.2.0.20250326.tar.gz", hash = "sha256:deda02de24f527066fc8d6a19e284ab3f3ae716a42b4adb6b40e75e408c08d36"},
 ]
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20241230"
+version = "6.0.12.20250326"
 description = "Typing stubs for PyYAML"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["linter"]
 files = [
-    {file = "types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"},
-    {file = "types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c"},
+    {file = "types_pyyaml-6.0.12.20250326-py3-none-any.whl", hash = "sha256:961871cfbdc1ad8ae3cb6ae3f13007262bcfc168adc513119755a6e4d5d7ed65"},
+    {file = "types_pyyaml-6.0.12.20250326.tar.gz", hash = "sha256:5e2d86d8706697803f361ba0b8188eef2999e1c372cd4faee4ebb0844b8a4190"},
 ]
 
 [[package]]
 name = "types-requests"
-version = "2.32.0.20250306"
+version = "2.32.0.20250328"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.9"
 groups = ["linter"]
 files = [
-    {file = "types_requests-2.32.0.20250306-py3-none-any.whl", hash = "sha256:25f2cbb5c8710b2022f8bbee7b2b66f319ef14aeea2f35d80f18c9dbf3b60a0b"},
-    {file = "types_requests-2.32.0.20250306.tar.gz", hash = "sha256:0962352694ec5b2f95fda877ee60a159abdf84a0fc6fdace599f20acb41a03d1"},
+    {file = "types_requests-2.32.0.20250328-py3-none-any.whl", hash = "sha256:72ff80f84b15eb3aa7a8e2625fffb6a93f2ad5a0c20215fc1dcfa61117bcb2a2"},
+    {file = "types_requests-2.32.0.20250328.tar.gz", hash = "sha256:c9e67228ea103bd811c96984fac36ed2ae8da87a36a633964a21f199d60baf32"},
 ]
 
 [package.dependencies]
@@ -2718,14 +2718,14 @@ urllib3 = ">=2"
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.13.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev", "documentation", "linter"]
 files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5"},
+    {file = "typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b"},
 ]
 markers = {dev = "python_version < \"3.12\"", documentation = "python_version >= \"3.12\"", linter = "python_version >= \"3.12\""}
 
@@ -2746,15 +2746,30 @@ mypy-extensions = ">=0.3.0"
 typing-extensions = ">=3.7.4"
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.0"
+description = "Runtime typing introspection tools"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f"},
+    {file = "typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
+
+[[package]]
 name = "tzdata"
-version = "2025.1"
+version = "2025.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main", "dev-only"]
 files = [
-    {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
-    {file = "tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694"},
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
 
 [[package]]

--- a/tests/annotation/test_remove_segmentation_overlap.py
+++ b/tests/annotation/test_remove_segmentation_overlap.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from annofabcli.annotation.remove_segmentation_overlap import remove_overlap_of_binary_image_array
+
+
+def test_remove_overlap_of_binary_image_array():
+    # テスト用の入力データ
+    binary_image_array_by_annotation = {
+        "a1": np.array([[True, False], [True, True]]),
+        "a2": np.array([[False, True], [True, False]]),
+    }
+
+    expected_output1 = {"a1": np.array([[True, False], [False, True]]), "a2": np.array([[False, True], [True, False]])}
+    actual_output1 = remove_overlap_of_binary_image_array(binary_image_array_by_annotation, ["a1", "a2"])
+    for annotation_id in ["a1", "a2"]:
+        np.testing.assert_array_equal(actual_output1[annotation_id], expected_output1[annotation_id])
+
+    expected_output2 = {"a1": np.array([[True, False], [True, True]]), "a2": np.array([[False, True], [False, False]])}
+    actual_output2 = remove_overlap_of_binary_image_array(binary_image_array_by_annotation, ["a2", "a1"])
+    for annotation_id in ["a1", "a2"]:
+        np.testing.assert_array_equal(actual_output2[annotation_id], expected_output2[annotation_id])


### PR DESCRIPTION
Annofabのインスタンスセグメンテーションは、別のインスタンスセグメンテーションと重ねることができます。
しかし、一般的なセグメンテーションでは「1ピクセルに対して1個のラベル（クラス）」が決まるので、塗りつぶしアノテーションを重ねる需要は少なそうです。

塗りつぶしアノテーションが重なっていても特に問題ありません。ただし、重なりを除去できれば、以下のメリットはあるかもしれません。
* Annofabで塗りつぶしアノテーションを確認しやすくなる。重なっていると見づらい

そこで、コマンドを作成することにしました。


