### PR TITLE
`statistics list_annotation_count`,`statistics list_annotation_duration`コマンドの出力結果の一部の名前を変更しました。

### DIFF
--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -116,18 +116,18 @@ class AnnotationCounter(abc.ABC):
 @dataclass(frozen=True)
 class AnnotationCounterByTask(AnnotationCounter, DataClassJsonMixin):
     task_id: str
-    status: TaskStatus
-    phase: TaskPhase
-    phase_stage: int
+    task_status: TaskStatus
+    task_phase: TaskPhase
+    task_phase_stage: int
     input_data_count: int
 
 
 @dataclass(frozen=True)
 class AnnotationCounterByInputData(AnnotationCounter, DataClassJsonMixin):
     task_id: str
-    status: TaskStatus
-    phase: TaskPhase
-    phase_stage: int
+    task_status: TaskStatus
+    task_phase: TaskPhase
+    task_phase_stage: int
 
     input_data_id: str
     input_data_name: str
@@ -259,9 +259,9 @@ class ListAnnotationCounterByInputData:
 
         return AnnotationCounterByInputData(
             task_id=simple_annotation["task_id"],
-            phase=TaskPhase(simple_annotation["task_phase"]),
-            phase_stage=simple_annotation["task_phase_stage"],
-            status=TaskStatus(simple_annotation["task_status"]),
+            task_phase=TaskPhase(simple_annotation["task_phase"]),
+            task_phase_stage=simple_annotation["task_phase_stage"],
+            task_status=TaskStatus(simple_annotation["task_status"]),
             input_data_id=simple_annotation["input_data_id"],
             input_data_name=simple_annotation["input_data_name"],
             annotation_count=sum(annotation_count_by_label.values()),
@@ -356,9 +356,9 @@ class ListAnnotationCounterByTask:
 
         return AnnotationCounterByTask(
             task_id=last_simple_annotation["task_id"],
-            status=TaskStatus(last_simple_annotation["task_status"]),
-            phase=TaskPhase(last_simple_annotation["task_phase"]),
-            phase_stage=last_simple_annotation["task_phase_stage"],
+            task_status=TaskStatus(last_simple_annotation["task_status"]),
+            task_phase=TaskPhase(last_simple_annotation["task_phase"]),
+            task_phase_stage=last_simple_annotation["task_phase_stage"],
             input_data_count=input_data_count,
             annotation_count=sum(annotation_count_by_label.values()),
             annotation_count_by_label=annotation_count_by_label,
@@ -484,9 +484,9 @@ class AttributeCountCsv:
         def get_columns() -> list[AttributeValueKey]:
             basic_columns = [
                 ("task_id", "", ""),
-                ("status", "", ""),
-                ("phase", "", ""),
-                ("phase_stage", "", ""),
+                ("task_status", "", ""),
+                ("task_phase", "", ""),
+                ("task_phase_stage", "", ""),
                 ("input_data_count", "", ""),
                 ("annotation_count", "", ""),
             ]
@@ -496,9 +496,9 @@ class AttributeCountCsv:
         def to_cell(c: AnnotationCounterByTask) -> dict[AttributeValueKey, Any]:
             cell = {
                 ("task_id", "", ""): c.task_id,
-                ("status", "", ""): c.status.value,
-                ("phase", "", ""): c.phase.value,
-                ("phase_stage", "", ""): c.phase_stage,
+                ("task_status", "", ""): c.task_status.value,
+                ("task_phase", "", ""): c.task_phase.value,
+                ("task_phase_stage", "", ""): c.task_phase_stage,
                 ("input_data_count", "", ""): c.input_data_count,
                 ("annotation_count", "", ""): c.annotation_count,
             }
@@ -522,9 +522,9 @@ class AttributeCountCsv:
         def get_columns() -> list[AttributeValueKey]:
             basic_columns = [
                 ("task_id", "", ""),
-                ("status", "", ""),
-                ("phase", "", ""),
-                ("phase_stage", "", ""),
+                ("task_status", "", ""),
+                ("task_phase", "", ""),
+                ("task_phase_stage", "", ""),
                 ("input_data_id", "", ""),
                 ("input_data_name", "", ""),
                 ("frame_no", "", ""),
@@ -539,9 +539,9 @@ class AttributeCountCsv:
                 ("input_data_name", "", ""): c.input_data_name,
                 ("frame_no", "", ""): c.frame_no,
                 ("task_id", "", ""): c.task_id,
-                ("status", "", ""): c.status.value,
-                ("phase", "", ""): c.phase.value,
-                ("phase_stage", "", ""): c.phase_stage,
+                ("task_status", "", ""): c.task_status.value,
+                ("task_phase", "", ""): c.task_phase.value,
+                ("task_phase_stage", "", ""): c.task_phase_stage,
                 ("annotation_count", "", ""): c.annotation_count,
             }
             cell.update(c.annotation_count_by_attribute)
@@ -588,9 +588,9 @@ class LabelCountCsv:
         def get_columns() -> list[str]:
             basic_columns = [
                 "task_id",
-                "status",
-                "phase",
-                "phase_stage",
+                "task_status",
+                "task_phase",
+                "task_phase_stage",
                 "input_data_count",
                 "annotation_count",
             ]
@@ -600,9 +600,9 @@ class LabelCountCsv:
         def to_dict(c: AnnotationCounterByTask) -> dict[str, Any]:
             d = {
                 "task_id": c.task_id,
-                "status": c.status.value,
-                "phase": c.phase.value,
-                "phase_stage": c.phase_stage,
+                "task_status": c.task_status.value,
+                "task_phase": c.task_phase.value,
+                "task_phase_stage": c.task_phase_stage,
                 "input_data_count": c.input_data_count,
                 "annotation_count": c.annotation_count,
             }
@@ -626,9 +626,9 @@ class LabelCountCsv:
         def get_columns() -> list[str]:
             basic_columns = [
                 "task_id",
-                "status",
-                "phase",
-                "phase_stage",
+                "task_status",
+                "task_phase",
+                "task_phase_stage",
                 "input_data_id",
                 "input_data_name",
                 "frame_no",
@@ -643,9 +643,9 @@ class LabelCountCsv:
                 "input_data_name": c.input_data_name,
                 "frame_no": c.frame_no,
                 "task_id": c.task_id,
-                "status": c.status.value,
-                "phase": c.phase.value,
-                "phase_stage": c.phase_stage,
+                "task_status": c.task_status.value,
+                "task_phase": c.task_phase.value,
+                "task_phase_stage": c.task_phase_stage,
                 "annotation_count": c.annotation_count,
             }
             d.update(c.annotation_count_by_label)

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -109,9 +109,9 @@ class AnnotationDuration(DataClassJsonMixin):
     """
 
     task_id: str
-    status: TaskStatus
-    phase: TaskPhase
-    phase_stage: int
+    task_status: TaskStatus
+    task_phase: TaskPhase
+    task_phase_stage: int
 
     input_data_id: str
     input_data_name: str
@@ -239,9 +239,9 @@ class ListAnnotationDurationByInputData:
 
         return AnnotationDuration(
             task_id=simple_annotation["task_id"],
-            phase=TaskPhase(simple_annotation["task_phase"]),
-            phase_stage=simple_annotation["task_phase_stage"],
-            status=TaskStatus(simple_annotation["task_status"]),
+            task_phase=TaskPhase(simple_annotation["task_phase"]),
+            task_phase_stage=simple_annotation["task_phase_stage"],
+            task_status=TaskStatus(simple_annotation["task_status"]),
             input_data_id=simple_annotation["input_data_id"],
             input_data_name=simple_annotation["input_data_name"],
             video_duration_second=video_duration_second,
@@ -375,9 +375,9 @@ class AnnotationDurationCsvByAttribute:
     ) -> list[AttributeValueKey]:
         basic_columns = [
             ("task_id", "", ""),
-            ("status", "", ""),
-            ("phase", "", ""),
-            ("phase_stage", "", ""),
+            ("task_status", "", ""),
+            ("task_phase", "", ""),
+            ("task_phase_stage", "", ""),
             ("input_data_id", "", ""),
             ("input_data_name", "", ""),
             ("video_duration_second", "", ""),
@@ -396,9 +396,9 @@ class AnnotationDurationCsvByAttribute:
                 ("input_data_id", "", ""): c.input_data_id,
                 ("input_data_name", "", ""): c.input_data_name,
                 ("task_id", "", ""): c.task_id,
-                ("status", "", ""): c.status.value,
-                ("phase", "", ""): c.phase.value,
-                ("phase_stage", "", ""): c.phase_stage,
+                ("task_status", "", ""): c.task_status.value,
+                ("task_phase", "", ""): c.task_phase.value,
+                ("task_phase_stage", "", ""): c.task_phase_stage,
                 ("video_duration_second", "", ""): c.video_duration_second,
                 ("annotation_duration_second", "", ""): c.annotation_duration_second,
             }
@@ -438,9 +438,9 @@ class AnnotationDurationCsvByLabel:
     ) -> list[str]:
         basic_columns = [
             "task_id",
-            "status",
-            "phase",
-            "phase_stage",
+            "task_status",
+            "task_phase",
+            "task_phase_stage",
             "input_data_id",
             "input_data_name",
             "video_duration_second",
@@ -459,9 +459,9 @@ class AnnotationDurationCsvByLabel:
                 "input_data_id": c.input_data_id,
                 "input_data_name": c.input_data_name,
                 "task_id": c.task_id,
-                "status": c.status.value,
-                "phase": c.phase.value,
-                "phase_stage": c.phase_stage,
+                "task_status": c.task_status.value,
+                "task_phase": c.task_phase.value,
+                "task_phase_stage": c.task_phase_stage,
                 "video_duration_second": c.video_duration_second,
                 "annotation_duration_second": c.annotation_duration_second,
             }

--- a/docs/command_reference/statistics/list_annotation_count.rst
+++ b/docs/command_reference/statistics/list_annotation_count.rst
@@ -51,9 +51,9 @@ Examples
             }
         },
         "task_id": "task1",
-        "status": "complete",
-        "phase": "acceptance",
-        "phase_stage": 1,
+        "task_status": "complete",
+        "task_phase": "acceptance",
+        "task_phase_stage": 1,
         "input_data_count": 10,
     }
     ]  
@@ -133,9 +133,9 @@ JSON出力
             }
         },
         "task_id": "task1",
-        "status": "complete",
-        "phase": "acceptance",
-        "phase_stage": 1,
+        "task_status": "complete",
+        "task_phase": "acceptance",
+        "task_phase_stage": 1,
         "input_data_count": 10,
         "frame_no": 1        
     }
@@ -262,4 +262,3 @@ Usage Details
    :prog: annofabcli statistics list_annotation_count
    :nosubcommands:
    :nodefaultconst:
-

--- a/docs/command_reference/statistics/list_annotation_count/out_by_input_data_attribute.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_input_data_attribute.csv
@@ -1,4 +1,4 @@
-task_id,status,phase,phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,car
+task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,car
 ,,,,,,,,occlusion,occlusion
 ,,,,,,,,true,false
 task2,complete,acceptance,1,input2,input2,1,80,12,5

--- a/docs/command_reference/statistics/list_annotation_count/out_by_input_data_label.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_input_data_label.csv
@@ -1,3 +1,3 @@
-task_id,status,phase,phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,bike
+task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,bike
 task1,break,annotation,1,input1,input1,1,100,20,10
 task2,complete,acceptance,1,input2,input2,1,80,12,5

--- a/docs/command_reference/statistics/list_annotation_count/out_by_task_attribute.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_task_attribute.csv
@@ -1,4 +1,4 @@
-task_id,status,phase,phase_stage,input_data_count,annotation_count,car,car
+task_id,task_status,task_phase,task_phase_stage,input_data_count,annotation_count,car,car
 ,,,,,,occlusion,occlusion
 ,,,,,,true,false
 task2,complete,acceptance,1,10,80,12,5

--- a/docs/command_reference/statistics/list_annotation_count/out_by_task_label.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_task_label.csv
@@ -1,3 +1,3 @@
-task_id,status,phase,phase_stage,input_data_count,annotation_count,car,bike
+task_id,task_status,task_phase,task_phase_stage,input_data_count,annotation_count,car,bike
 task1,break,annotation,1,5,100,20,10
 task2,complete,acceptance,1,5,80,12,5

--- a/docs/command_reference/statistics/list_annotation_duration.rst
+++ b/docs/command_reference/statistics/list_annotation_duration.rst
@@ -31,9 +31,9 @@ JSON出力
     [
     {
         "task_id": "sample_task_00",
-        "status": "not_started",
-        "phase": "annotation",
-        "phase_stage": 1,
+        "task_status": "not_started",
+        "task_phase": "annotation",
+        "task_phase_stage": 1,
         "input_data_id": "sample_video_00.mp4",
         "input_data_name": "sample_video_00.mp4",
         "video_duration_second": 30,
@@ -104,4 +104,3 @@ Usage Details
    :prog: annofabcli statistics list_annotation_duration
    :nosubcommands:
    :nodefaultconst:
-

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -115,9 +115,9 @@ class Test__AnnotationDurationCsvByLabel:
         row = df.iloc[0]
         assert row.to_dict() == {
             "task_id": "task1",
-            "phase": "acceptance",
-            "phase_stage": 1,
-            "status": "complete",
+            "task_phase": "acceptance",
+            "task_phase_stage": 1,
+            "task_status": "complete",
             "input_data_id": "input1",
             "input_data_name": "input1",
             "video_duration_second": None,
@@ -135,9 +135,9 @@ class Test__AnnotationDurationCsvByAttribute:
         row = df.iloc[0]
         assert row.to_dict() == {
             ("task_id", "", ""): "task1",
-            ("phase", "", ""): "acceptance",
-            ("phase_stage", "", ""): 1,
-            ("status", "", ""): "complete",
+            ("task_phase", "", ""): "acceptance",
+            ("task_phase_stage", "", ""): 1,
+            ("task_status", "", ""): "complete",
             ("input_data_id", "", ""): "input1",
             ("input_data_name", "", ""): "input1",
             ("video_duration_second", "", ""): None,


### PR DESCRIPTION
以下のコマンドに対して、出力結果を次のように変更しました。

* `statistics list_annotation_count`
* `statistics list_annotation_duration`

アノテーションZIP内のJSONに従い、出力結果を修正しました。
* `phase` -> `task_phase`
* `phase_stage` -> `task_phase_stage`
* `status` -> `task_status`

タスク情報の出力がメインでないコマンドでは、「タスクの情報」であることを示すため、`task_`というプレフィックスを付けるようにしました。
