### PR TITLE
`--version`を指定したときに正しくバージョン情報が出力されるようにしました。

### DIFF
--- a/annofabcli/__init__.py
+++ b/annofabcli/__init__.py
@@ -1,5 +1,7 @@
-from .__version__ import __version__
+from importlib.metadata import PackageNotFoundError, version
 
-__all__ = [
-    "__version__",
-]
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    # `uv run annofabcli --version`では、メタデータからバージョン情報を取得できないため、fallbackしたバージョンを設定する
+    __version__ = "0.0.0"

--- a/annofabcli/__version__.py
+++ b/annofabcli/__version__.py
@@ -1,7 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    # `uv run annofabcli --version`では、メタデータからバージョン情報を取得できないため、fallbackしたバージョンを設定する
-    __version__ = "0.0.0"

--- a/annofabcli/__version__.py
+++ b/annofabcli/__version__.py
@@ -1,0 +1,1 @@
+__version__ = "1.100.4.post1.dev0+5a40ec9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ classifiers = [
     "Environment :: Console",
     "Topic :: Utilities",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,3 +177,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
+
+[tool.hatch.build.hooks.version]
+# https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/version_source.md#version-build-hook 参照
+path = "annofabcli/__version__.py"
+template = '''
+__version__ = "{version}"
+'''


### PR DESCRIPTION
* `uv build`ではPythonバージョンに関するclassifierが出力されないので、自分自身で記載するようにしました。