### PR TITLE
`statistics visualize` : `--project_id`に複数のIDを指定したときに、出力先のディレクトリ名がプロジェクト名だったのをプロジェクトIDに変更しました。

### DIFF
--- a/annofabcli/statistics/visualize_statistics.py
+++ b/annofabcli/statistics/visualize_statistics.py
@@ -4,7 +4,6 @@ import argparse
 import functools
 import json
 import logging.handlers
-import re
 import sys
 import tempfile
 from multiprocessing import Pool
@@ -62,10 +61,6 @@ from annofabcli.statistics.visualization.project_dir import ProjectDir, ProjectI
 from annofabcli.statistics.visualization.visualization_source_files import VisualizationSourceFiles
 
 logger = logging.getLogger(__name__)
-
-
-def get_project_output_dir(project_title: str) -> str:
-    return re.sub(r'[\\/:*?"<>|]+', "__", project_title)
 
 
 class WriteCsvGraph:
@@ -408,8 +403,7 @@ class VisualizingStatisticsMain:
         root_output_dir: Path,
     ) -> Optional[Path]:
         try:
-            project_title = self.facade.get_project_title(project_id)
-            output_project_dir = root_output_dir / get_project_output_dir(project_title)
+            output_project_dir = root_output_dir / project_id
             self.visualize_statistics(
                 project_id=project_id,
                 output_project_dir=output_project_dir,

--- a/docs/command_reference/statistics/visualize.rst
+++ b/docs/command_reference/statistics/visualize.rst
@@ -299,16 +299,16 @@ CSVには以下の列が存在している必要があります。
 
     $ annofabcli statistics visualize --project_id prj1 prj2 --output_dir out_dir --minimal
 
-プロジェクトごとにディレクトリが生成されます。
+プロジェクトごとにディレクトリが生成されます。ディレクトリ名は project_id です。
 
 .. code-block::
 
     out_dir/
-    ├── prj_title1
+    ├── project_id1/
     │   ├── タスクlist.csv
     │   ├── メンバごとの生産性と品質.csv
     │   └── ...
-    ├── prj_title2
+    ├── project_id2/
     │   ├── タスクlist.csv
     │   ├── メンバごとの生産性と品質.csv
     │   └── ...
@@ -328,11 +328,11 @@ prj1とprj2の出力結果をマージしたファイルが、``merge`` ディ�
 .. code-block::
 
     out_dir/
-    ├── prj_title1
+    ├── project_id1/
     │   ├── タスクlist.csv
     │   ├── メンバごとの生産性と品質.csv
     │   └── ...
-    ├── prj_title2
+    ├── project_id2/
     │   ├── タスクlist.csv
     │   ├── メンバごとの生産性と品質.csv
     │   └── ...


### PR DESCRIPTION
プロジェクト名をディレクトリ名にすると、エスケープ処理が必要になる。
またはプロジェクト名は変わる可能性がある。
プロジェクトIDで出力した方が、長期的に見ると扱いやすいため。