### PR TITLE
`statistics`系コマンドで、`project_id`も出力するようにしました。

### DIFF
--- a/annofabcli/statistics/list_annotation_area.py
+++ b/annofabcli/statistics/list_annotation_area.py
@@ -55,6 +55,7 @@ def lazy_parse_simple_annotation_by_input_data(annotation_path: Path) -> Iterato
 
 @dataclass(frozen=True)
 class AnnotationAreaInfo(DataClassJsonMixin):
+    project_id: str
     task_id: str
     task_status: str
     task_phase: str
@@ -92,6 +93,7 @@ def get_annotation_area_info_list(parser: SimpleAnnotationParser, simple_annotat
 
         result.append(
             AnnotationAreaInfo(
+                project_id=simple_annotation["project_id"],
                 task_id=simple_annotation["task_id"],
                 task_phase=simple_annotation["task_phase"],
                 task_phase_stage=simple_annotation["task_phase_stage"],
@@ -135,6 +137,7 @@ def create_df(
     annotation_area_list: list[AnnotationAreaInfo],
 ) -> pandas.DataFrame:
     columns = [
+        "project_id",
         "task_id",
         "task_status",
         "task_phase",

--- a/annofabcli/statistics/list_annotation_attribute.py
+++ b/annofabcli/statistics/list_annotation_attribute.py
@@ -57,6 +57,7 @@ class AnnotationAttribute(pydantic.BaseModel):
     入力データまたはタスク単位の区間アノテーションの長さ情報。
     """
 
+    project_id: str
     task_id: str
     task_status: str
     task_phase: str
@@ -87,6 +88,7 @@ def get_annotation_attribute_list_from_annotation_json(simple_annotation: dict[s
 
         result.append(
             AnnotationAttribute(
+                project_id=simple_annotation["project_id"],
                 task_id=simple_annotation["task_id"],
                 task_status=simple_annotation["task_status"],
                 task_phase=simple_annotation["task_phase"],
@@ -141,6 +143,7 @@ def print_annotation_attribute_list_as_csv(annotation_attribute_list: list, outp
     df = pandas.json_normalize(annotation_attribute_list)
 
     base_columns = [
+        "project_id",
         "task_id",
         "task_status",
         "task_phase",

--- a/annofabcli/statistics/list_annotation_attribute_filled_count.py
+++ b/annofabcli/statistics/list_annotation_attribute_filled_count.py
@@ -100,6 +100,7 @@ class AnnotationCountByInputData(DataClassJsonMixin, HasAnnotationAttributeCount
     入力データ単位のアノテーション数の情報。
     """
 
+    project_id: str
     task_id: str
     task_status: TaskStatus
     task_phase: TaskPhase
@@ -126,6 +127,7 @@ class AnnotationCountByTask(DataClassJsonMixin, HasAnnotationAttributeCounts):
     タスク単位のアノテーション数の情報。
     """
 
+    project_id: str
     task_id: str
     task_status: TaskStatus
     task_phase: TaskPhase
@@ -174,6 +176,7 @@ def convert_annotation_count_list_by_input_data_to_by_task(annotation_count_list
 
         result.append(
             AnnotationCountByTask(
+                project_id=first_elm.project_id,
                 task_id=task_id,
                 task_status=first_elm.task_status,
                 task_phase=first_elm.task_phase,
@@ -263,6 +266,7 @@ class ListAnnotationCounterByInputData:
             frame_no = self.frame_no_map.get((simple_annotation["task_id"], simple_annotation["input_data_id"]))
 
         return AnnotationCountByInputData(
+            project_id=simple_annotation["project_id"],
             task_id=simple_annotation["task_id"],
             task_phase=TaskPhase(simple_annotation["task_phase"]),
             task_phase_stage=simple_annotation["task_phase_stage"],
@@ -343,6 +347,7 @@ class AnnotationCountCsvByAttribute:
         prior_attribute_columns: Optional[list[tuple[str, str, str]]] = None,
     ) -> list[tuple[str, str, str]]:
         basic_columns = [
+            ("project_id", "", ""),
             ("task_id", "", ""),
             ("task_status", "", ""),
             ("task_phase", "", ""),
@@ -360,6 +365,7 @@ class AnnotationCountCsvByAttribute:
         prior_attribute_columns: Optional[list[tuple[str, str, str]]] = None,
     ) -> list[tuple[str, str, str]]:
         basic_columns = [
+            ("project_id", "", ""),
             ("task_id", "", ""),
             ("task_status", "", ""),
             ("task_phase", "", ""),
@@ -377,6 +383,7 @@ class AnnotationCountCsvByAttribute:
     ) -> pandas.DataFrame:
         def to_cell(c: AnnotationCountByInputData) -> dict[tuple[str, str, str], Any]:
             cell: dict[tuple[str, str, str], Any] = {
+                ("project_id", "", ""): c.project_id,
                 ("task_id", "", ""): c.task_id,
                 ("task_status", "", ""): c.task_status.value,
                 ("task_phase", "", ""): c.task_phase.value,
@@ -405,6 +412,7 @@ class AnnotationCountCsvByAttribute:
     ) -> pandas.DataFrame:
         def to_cell(c: AnnotationCountByTask) -> dict[tuple[str, str, str], Any]:
             cell: dict[tuple[str, str, str], Any] = {
+                ("project_id", "", ""): c.project_id,
                 ("task_id", "", ""): c.task_id,
                 ("task_status", "", ""): c.task_status.value,
                 ("task_phase", "", ""): c.task_phase.value,

--- a/annofabcli/statistics/list_annotation_count.py
+++ b/annofabcli/statistics/list_annotation_count.py
@@ -115,6 +115,7 @@ class AnnotationCounter(abc.ABC):
 
 @dataclass(frozen=True)
 class AnnotationCounterByTask(AnnotationCounter, DataClassJsonMixin):
+    project_id: str
     task_id: str
     task_status: TaskStatus
     task_phase: TaskPhase
@@ -124,6 +125,7 @@ class AnnotationCounterByTask(AnnotationCounter, DataClassJsonMixin):
 
 @dataclass(frozen=True)
 class AnnotationCounterByInputData(AnnotationCounter, DataClassJsonMixin):
+    project_id: str
     task_id: str
     task_status: TaskStatus
     task_phase: TaskPhase
@@ -254,6 +256,7 @@ class ListAnnotationCounterByInputData:
             frame_no = self.frame_no_map.get((task_id, input_data_id))
 
         return AnnotationCounterByInputData(
+            project_id=simple_annotation["project_id"],
             task_id=simple_annotation["task_id"],
             task_phase=TaskPhase(simple_annotation["task_phase"]),
             task_phase_stage=simple_annotation["task_phase_stage"],
@@ -351,6 +354,7 @@ class ListAnnotationCounterByTask:
             raise RuntimeError(f"{task_parser.task_id} ディレクトリにはjsonファイルが1つも含まれていません。")
 
         return AnnotationCounterByTask(
+            project_id=last_simple_annotation["project_id"],
             task_id=last_simple_annotation["task_id"],
             task_status=TaskStatus(last_simple_annotation["task_status"]),
             task_phase=TaskPhase(last_simple_annotation["task_phase"]),
@@ -468,6 +472,7 @@ class AttributeCountCsv:
     ) -> None:
         def get_columns() -> list[AttributeValueKey]:
             basic_columns = [
+                ("project_id", "", ""),
                 ("task_id", "", ""),
                 ("task_status", "", ""),
                 ("task_phase", "", ""),
@@ -480,6 +485,7 @@ class AttributeCountCsv:
 
         def to_cell(c: AnnotationCounterByTask) -> dict[AttributeValueKey, Any]:
             cell = {
+                ("project_id", "", ""): c.project_id,
                 ("task_id", "", ""): c.task_id,
                 ("task_status", "", ""): c.task_status.value,
                 ("task_phase", "", ""): c.task_phase.value,
@@ -506,6 +512,7 @@ class AttributeCountCsv:
     ) -> None:
         def get_columns() -> list[AttributeValueKey]:
             basic_columns = [
+                ("project_id", "", ""),
                 ("task_id", "", ""),
                 ("task_status", "", ""),
                 ("task_phase", "", ""),
@@ -520,6 +527,7 @@ class AttributeCountCsv:
 
         def to_cell(c: AnnotationCounterByInputData) -> dict[tuple[str, str, str], Any]:
             cell = {
+                ("project_id", "", ""): c.project_id,
                 ("input_data_id", "", ""): c.input_data_id,
                 ("input_data_name", "", ""): c.input_data_name,
                 ("frame_no", "", ""): c.frame_no,
@@ -569,6 +577,7 @@ class LabelCountCsv:
     ) -> None:
         def get_columns() -> list[str]:
             basic_columns = [
+                "project_id",
                 "task_id",
                 "task_status",
                 "task_phase",
@@ -581,6 +590,7 @@ class LabelCountCsv:
 
         def to_dict(c: AnnotationCounterByTask) -> dict[str, Any]:
             d = {
+                "project_id": c.project_id,
                 "task_id": c.task_id,
                 "task_status": c.task_status.value,
                 "task_phase": c.task_phase.value,
@@ -607,6 +617,7 @@ class LabelCountCsv:
     ) -> None:
         def get_columns() -> list[str]:
             basic_columns = [
+                "project_id",
                 "task_id",
                 "task_status",
                 "task_phase",
@@ -621,6 +632,7 @@ class LabelCountCsv:
 
         def to_dict(c: AnnotationCounterByInputData) -> dict[str, Any]:
             d = {
+                "project_id": c.project_id,
                 "input_data_id": c.input_data_id,
                 "input_data_name": c.input_data_name,
                 "frame_no": c.frame_no,

--- a/annofabcli/statistics/list_annotation_duration.py
+++ b/annofabcli/statistics/list_annotation_duration.py
@@ -108,6 +108,7 @@ class AnnotationDuration(DataClassJsonMixin):
     入力データまたはタスク単位の区間アノテーションの長さ情報。
     """
 
+    project_id: str
     task_id: str
     task_status: TaskStatus
     task_phase: TaskPhase
@@ -234,6 +235,7 @@ class ListAnnotationDurationByInputData:
             }
 
         return AnnotationDuration(
+            project_id=simple_annotation["project_id"],
             task_id=simple_annotation["task_id"],
             task_phase=TaskPhase(simple_annotation["task_phase"]),
             task_phase_stage=simple_annotation["task_phase_stage"],
@@ -360,6 +362,7 @@ class AnnotationDurationCsvByAttribute:
         prior_attribute_columns: Optional[list[AttributeValueKey]] = None,
     ) -> list[AttributeValueKey]:
         basic_columns = [
+            ("project_id", "", ""),
             ("task_id", "", ""),
             ("task_status", "", ""),
             ("task_phase", "", ""),
@@ -379,6 +382,7 @@ class AnnotationDurationCsvByAttribute:
     ) -> pandas.DataFrame:
         def to_cell(c: AnnotationDuration) -> dict[tuple[str, str, str], Any]:
             cell: dict[AttributeValueKey, Any] = {
+                ("project_id", "", ""): c.project_id,
                 ("input_data_id", "", ""): c.input_data_id,
                 ("input_data_name", "", ""): c.input_data_name,
                 ("task_id", "", ""): c.task_id,
@@ -423,6 +427,7 @@ class AnnotationDurationCsvByLabel:
         prior_label_columns: Optional[list[str]] = None,
     ) -> list[str]:
         basic_columns = [
+            "project_id",
             "task_id",
             "task_status",
             "task_phase",
@@ -442,6 +447,7 @@ class AnnotationDurationCsvByLabel:
     ) -> pandas.DataFrame:
         def to_dict(c: AnnotationDuration) -> dict[str, Any]:
             d: dict[str, Any] = {
+                "project_id": c.project_id,
                 "input_data_id": c.input_data_id,
                 "input_data_name": c.input_data_name,
                 "task_id": c.task_id,

--- a/annofabcli/statistics/list_video_duration.py
+++ b/annofabcli/statistics/list_video_duration.py
@@ -38,7 +38,7 @@ def get_video_duration_list(task_list: list[dict[str, Any]], input_data_list: li
     result = []
     for task in task_list:
         task_id = task["task_id"]
-        elm = {"task_id": task_id, "task_status": task["status"], "task_phase": task["phase"], "task_phase_stage": task["phase_stage"]}
+        elm = {"project_id": task["project_id"], "task_id": task_id, "task_status": task["status"], "task_phase": task["phase"], "task_phase_stage": task["phase_stage"]}
         input_data_id_list = task["input_data_id_list"]
         assert len(input_data_id_list) == 1, f"task_id='{task_id}'には複数の入力データが含まれています。"
         input_data_id = input_data_id_list[0]
@@ -94,6 +94,7 @@ class ListVideoDuration(CommandLine):
         logger.info(f"{len(video_duration_list)} 件のタスクの動画長さを出力します。")
         if output_format == FormatArgument.CSV:
             columns = [
+                "project_id",
                 "task_id",
                 "task_status",
                 "task_phase",

--- a/docs/command_reference/statistics/list_annotation_attribute.rst
+++ b/docs/command_reference/statistics/list_annotation_attribute.rst
@@ -28,6 +28,7 @@ JSON出力
 
     [
     {
+        "project_id": "project1",
         "task_id": "task1",
         "task_status": "not_started",
         "task_phase": "annotation",
@@ -69,5 +70,3 @@ Usage Details
    :prog: annofabcli statistics list_annotation_attribute
    :nosubcommands:
    :nodefaultconst:
-
-   

--- a/docs/command_reference/statistics/list_annotation_attribute/out.csv
+++ b/docs/command_reference/statistics/list_annotation_attribute/out.csv
@@ -1,3 +1,2 @@
-﻿task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,annotation_id,label,attributes.occluded,attributes.type
-task1,not_started,inspection,1,input_data1,input_data1,annotation1,car,true,sedan
-
+﻿project_id,task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,annotation_id,label,attributes.occluded,attributes.type
+project1,task1,not_started,inspection,1,input_data1,input_data1,annotation1,car,true,sedan

--- a/docs/command_reference/statistics/list_annotation_attribute_filled_count.rst
+++ b/docs/command_reference/statistics/list_annotation_attribute_filled_count.rst
@@ -26,6 +26,7 @@ Examples
 
     [
         {
+            "project_id": "project1",
             "task_id": "task--02",
             "task_status": "break",
             "task_phase": "annotation",
@@ -66,6 +67,7 @@ Examples
 
     [
         {
+            "project_id": "project1",
             "task_id": "task--02",
             "task_status": "break",
             "task_phase": "annotation",

--- a/docs/command_reference/statistics/list_annotation_attribute_filled_count/out_by_input_data.csv
+++ b/docs/command_reference/statistics/list_annotation_attribute_filled_count/out_by_input_data.csv
@@ -1,5 +1,5 @@
-﻿task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,car,car
-,,,,,,,direction,direction
-,,,,,,,filled,empty
-sample1,not_started,annotation,1,input1,input1,1,10,4
-sample1,not_started,annotation,1,input2,input2,2,20,3
+﻿project_id,task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,car,car
+,,,,,,,,direction,direction
+,,,,,,,,filled,empty
+project1,sample1,not_started,annotation,1,input1,input1,1,10,4
+project1,sample1,not_started,annotation,1,input2,input2,2,20,3

--- a/docs/command_reference/statistics/list_annotation_attribute_filled_count/out_by_task.csv
+++ b/docs/command_reference/statistics/list_annotation_attribute_filled_count/out_by_task.csv
@@ -1,5 +1,5 @@
-﻿task_id,task_status,task_phase,task_phase_stage,input_data_count,car,car
-,,,,,direction,direction
-,,,,,filled,empty
-20250325_0,not_started,annotation,1,1,10,4
-20250327_00,not_started,annotation,1,1,20,3
+﻿project_id,task_id,task_status,task_phase,task_phase_stage,input_data_count,car,car
+,,,,,,,direction,direction
+,,,,,,,filled,empty
+project1,20250325_0,not_started,annotation,1,1,10,4
+project1,20250327_00,not_started,annotation,1,1,20,3

--- a/docs/command_reference/statistics/list_annotation_count.rst
+++ b/docs/command_reference/statistics/list_annotation_count.rst
@@ -50,6 +50,7 @@ Examples
                 }
             }
         },
+        "project_id": "project1",
         "task_id": "task1",
         "task_status": "complete",
         "task_phase": "acceptance",
@@ -132,6 +133,7 @@ JSON出力
                 }
             }
         },
+        "project_id": "project1",
         "task_id": "task1",
         "task_status": "complete",
         "task_phase": "acceptance",
@@ -180,6 +182,7 @@ JSON出力
                 }
             }
         },
+        "project_id": "project1",
         "task_id": "task1",
         "status": "complete",
         "phase": "acceptance",

--- a/docs/command_reference/statistics/list_annotation_count/out_by_input_data_attribute.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_input_data_attribute.csv
@@ -1,4 +1,4 @@
-task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,car
-,,,,,,,,occlusion,occlusion
-,,,,,,,,true,false
-task2,complete,acceptance,1,input2,input2,1,80,12,5
+project_id,task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,car
+,,,,,,,,,occlusion,occlusion
+,,,,,,,,,true,false
+project1,task2,complete,acceptance,1,input2,input2,1,80,12,5

--- a/docs/command_reference/statistics/list_annotation_count/out_by_input_data_label.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_input_data_label.csv
@@ -1,3 +1,3 @@
-task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,bike
-task1,break,annotation,1,input1,input1,1,100,20,10
-task2,complete,acceptance,1,input2,input2,1,80,12,5
+project_id,task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,frame_no,annotation_count,car,bike
+project1,task1,break,annotation,1,input1,input1,1,100,20,10
+project1,task2,complete,acceptance,1,input2,input2,1,80,12,5

--- a/docs/command_reference/statistics/list_annotation_count/out_by_task_attribute.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_task_attribute.csv
@@ -1,4 +1,4 @@
-task_id,task_status,task_phase,task_phase_stage,input_data_count,annotation_count,car,car
-,,,,,,occlusion,occlusion
-,,,,,,true,false
-task2,complete,acceptance,1,10,80,12,5
+project_id,task_id,task_status,task_phase,task_phase_stage,input_data_count,annotation_count,car,car
+,,,,,,,occlusion,occlusion
+,,,,,,,true,false
+project1,task2,complete,acceptance,1,10,80,12,5

--- a/docs/command_reference/statistics/list_annotation_count/out_by_task_label.csv
+++ b/docs/command_reference/statistics/list_annotation_count/out_by_task_label.csv
@@ -1,3 +1,3 @@
-task_id,task_status,task_phase,task_phase_stage,input_data_count,annotation_count,car,bike
-task1,break,annotation,1,5,100,20,10
-task2,complete,acceptance,1,5,80,12,5
+project_id,task_id,task_status,task_phase,task_phase_stage,input_data_count,annotation_count,car,bike
+project1,task1,break,annotation,1,5,100,20,10
+project1,task2,complete,acceptance,1,5,80,12,5

--- a/docs/command_reference/statistics/list_annotation_duration.rst
+++ b/docs/command_reference/statistics/list_annotation_duration.rst
@@ -30,6 +30,7 @@ JSON出力
 
     [
     {
+        "project_id": "project1",
         "task_id": "sample_task_00",
         "task_status": "not_started",
         "task_phase": "annotation",

--- a/docs/command_reference/statistics/list_annotation_duration/out_by_attribute.csv
+++ b/docs/command_reference/statistics/list_annotation_duration/out_by_attribute.csv
@@ -1,5 +1,5 @@
-﻿task_id,status,phase,phase_stage,input_data_id,input_data_name,video_duration_second,annotation_duration_second,label-A,label-A,label-B,label-B,label-B
-,,,,,,,,is_lighted,is_lighted,color,color,color
-,,,,,,,,true,false,red,green,yellow
-task1,not_started,acceptance,1,input_data1,input_data1,100,73,10,1,40,20,2
-task2,on_hold,inspection,1,input_data2,input_data2,100,62,20,1,30,10,1
+﻿project_id,task_id,status,phase,phase_stage,input_data_id,input_data_name,video_duration_second,annotation_duration_second,label-A,label-A,label-B,label-B,label-B
+,,,,,,,,,,is_lighted,is_lighted,color,color,color
+,,,,,,,,,,true,false,red,green,yellow
+project1,task1,not_started,acceptance,1,input_data1,input_data1,100,73,10,1,40,20,2
+project1,task2,on_hold,inspection,1,input_data2,input_data2,100,62,20,1,30,10,1

--- a/docs/command_reference/statistics/list_annotation_duration/out_by_label.csv
+++ b/docs/command_reference/statistics/list_annotation_duration/out_by_label.csv
@@ -1,3 +1,3 @@
-﻿task_id,status,phase,phase_stage,input_data_id,input_data_name,video_duration_second,annotation_duration_second,label-A,label-B,label-C
-task1,not_started,acceptance,1,input_data1,input_data1,200,170,43,77,50
-task2,complete,acceptance,1,input_data2,input_data2,100,64,35,9,20
+﻿project_id,task_id,status,phase,phase_stage,input_data_id,input_data_name,video_duration_second,annotation_duration_second,label-A,label-B,label-C
+project1,task1,not_started,acceptance,1,input_data1,input_data1,200,170,43,77,50
+project1,task2,complete,acceptance,1,input_data2,input_data2,100,64,35,9,20

--- a/docs/command_reference/statistics/list_video_duration.rst
+++ b/docs/command_reference/statistics/list_video_duration.rst
@@ -54,6 +54,7 @@ JSON出力
 
     [
     {
+        "project_id": "project1",
         "task_id": "test1",
         "task_status": "complete",
         "task_phase": "acceptance",

--- a/docs/command_reference/statistics/list_video_duration/out.csv
+++ b/docs/command_reference/statistics/list_video_duration/out.csv
@@ -1,3 +1,3 @@
-﻿task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,video_duration_second,input_data_updated_datetime
-sample_task_03,complete,acceptance,1,sample_video_03.mp4,sample_video_03.mp4,25,2024-10-04T09:18:02.416+09:00
-sample_task_04,complete,acceptance,1,sample_video_04.mp4,sample_video_04.mp4,18.7,2024-10-05T09:18:02.416+09:00
+﻿project_id,task_id,task_status,task_phase,task_phase_stage,input_data_id,input_data_name,video_duration_second,input_data_updated_datetime
+project1,sample_task_03,complete,acceptance,1,sample_video_03.mp4,sample_video_03.mp4,25,2024-10-04T09:18:02.416+09:00
+project1,sample_task_04,complete,acceptance,1,sample_video_04.mp4,sample_video_04.mp4,18.7,2024-10-05T09:18:02.416+09:00

--- a/tests/statistics/test_list_annotation_attribute_filled_count.py
+++ b/tests/statistics/test_list_annotation_attribute_filled_count.py
@@ -63,6 +63,7 @@ class TestListAnnotationCounterByInputData:
 def test_convert_annotation_count_list_by_input_data_to_by_task():
     input_data_list = [
         AnnotationCountByInputData(
+            project_id="project1",
             task_id="task1",
             task_status=TaskStatus.COMPLETE,
             task_phase=TaskPhase.ACCEPTANCE,
@@ -75,6 +76,7 @@ def test_convert_annotation_count_list_by_input_data_to_by_task():
             },
         ),
         AnnotationCountByInputData(
+            project_id="project1",
             task_id="task1",
             task_status=TaskStatus.COMPLETE,
             task_phase=TaskPhase.ACCEPTANCE,
@@ -92,6 +94,7 @@ def test_convert_annotation_count_list_by_input_data_to_by_task():
     task = task_list[0]
 
     assert task == AnnotationCountByTask(
+        project_id="project1",
         task_id="task1",
         task_status=TaskStatus.COMPLETE,
         task_phase=TaskPhase.ACCEPTANCE,

--- a/tests/statistics/test_list_annotation_attribute_filled_count.py
+++ b/tests/statistics/test_list_annotation_attribute_filled_count.py
@@ -19,6 +19,7 @@ output_dir.mkdir(exist_ok=True, parents=True)
 class TestListAnnotationCounterByInputData:
     def test_get_annotation_count(self):
         annotation = {
+            "project_id": "project1",
             "task_id": "task1",
             "task_phase": "acceptance",
             "task_phase_stage": 1,

--- a/tests/statistics/test_list_annotation_count.py
+++ b/tests/statistics/test_list_annotation_count.py
@@ -16,6 +16,7 @@ output_dir.mkdir(exist_ok=True, parents=True)
 class TestListAnnotationCounterByInputData:
     def test_get_annotation_counter(self):
         annotation = {
+            "project_id": "project1",
             "task_id": "task1",
             "task_phase": "acceptance",
             "task_phase_stage": 1,

--- a/tests/statistics/test_list_annotation_duration.py
+++ b/tests/statistics/test_list_annotation_duration.py
@@ -11,6 +11,7 @@ data_dir = Path("./tests/data/statistics/")
 output_dir.mkdir(exist_ok=True, parents=True)
 
 ANNOTATION = {
+    "project_id": "project1",
     "task_id": "task1",
     "task_phase": "acceptance",
     "task_phase_stage": 1,
@@ -110,6 +111,7 @@ class Test__AnnotationDurationCsvByLabel:
         assert len(df) == 1
         row = df.iloc[0]
         assert row.to_dict() == {
+            "project_id": "project1",
             "task_id": "task1",
             "task_phase": "acceptance",
             "task_phase_stage": 1,
@@ -130,6 +132,7 @@ class Test__AnnotationDurationCsvByAttribute:
         assert len(df) == 1
         row = df.iloc[0]
         assert row.to_dict() == {
+            ("project_id", "", ""): "project1",
             ("task_id", "", ""): "task1",
             ("task_phase", "", ""): "acceptance",
             ("task_phase_stage", "", ""): 1,

--- a/tests/statistics/test_visualize_annotation_duration.py
+++ b/tests/statistics/test_visualize_annotation_duration.py
@@ -14,6 +14,7 @@ output_dir.mkdir(exist_ok=True, parents=True)
 
 ANNOTATIONS = [
     {
+        "project_id": "project1",
         "task_id": "task1",
         "task_phase": "acceptance",
         "task_phase_stage": 1,
@@ -44,6 +45,7 @@ ANNOTATIONS = [
         ],
     },
     {
+        "project_id": "project1",
         "task_id": "task2",
         "task_phase": "acceptance",
         "task_phase_stage": 1,


### PR DESCRIPTION
`list_annotation_count`コマンドなどは、`--project_id`を指定しなくても実行できます。
出力結果をあとから見返した際、どのプロジェクトに関するものか知りたい場合があるので、`project_id`も出力するようにしました。
