### PR TITLE
Add support for specifying annotation attribute changes via CSV

### DIFF
--- a/docs/command_reference/annotation/change_attributes_per_annotation.rst
+++ b/docs/command_reference/annotation/change_attributes_per_annotation.rst
@@ -12,10 +12,14 @@ Description
 Examples
 =================================
 
+変更する属性値をJSON形式で指定する
+---------------------------------------
+
 
 引数 ``--json`` に、変更対象のアノテーションの情報（ ``task_id`` , ``input_data_id`` , ``annotation_id`` ）と変更後の属性値（ ``attributes`` ）をJSON形式で指定します。
 
 ``attributes`` のフォーマットは、 `Command line options <../../user_guide/command_line_options.html#annotation-query-aq>`_ の ``attributes`` キーの値と同じフォーマットです。
+変更したい属性名と値を指定します。
 
 .. code-block:: json
     :caption: annotations.json
@@ -37,6 +41,42 @@ Examples
      --backup backup_dir/ \
 
 
+変更する属性値をCSVで指定する
+---------------------------------------
+引数 ``--csv`` に、変更対象のアノテーションの情報と変更後の属性値が記載されたCSVファイルのパスを指定します。
+
+CSVのフォーマットは以下の通りです。
+
+* ヘッダ行あり
+* カンマ区切り
+
+.. csv-table::
+   :header: 列名,必須,備考
+
+    task_id,Yes,
+    input_data_id,Yes,
+    annotation_id,Yes,
+    attributes,Yes,変更したい属性名と値のオブジェクト（JSON形式）
+
+以下はCSVファイルのサンプルです。
+
+.. code-block::
+    :caption: annotations.csv
+
+    task_id,input_data_id,annotation_id,attributes
+    t1,i1,a1,"{""comment"":""bar"",""number"":3}"
+
+
+.. code-block::
+
+    $ annofabcli annotation change_attributes_per_annotation --project_id p1 \
+     --csv annotations.csv \
+     --backup backup_dir/ \
+
+
+その他のオプション
+---------------------------------------
+
 ``--backup`` にディレクトリを指定すると、変更対象のフレームに含まれるアノテーション情報を、指定したディレクトリに保存します。
 アノテーション情報の復元は、 `annofabcli annotation restore <../annotation/restore.html>`_ コマンドで実現できます。
 
@@ -48,6 +88,7 @@ Examples
 
 デフォルトでは完了状態のタスクに含まれるアノテーションは変更できません。完了状態のタスクに含まれるアノテーションも変更する場合は、 ``--force`` を指定してください。
 ただし、オーナーロールのユーザーで実行する必要があります。
+
 
 
 Usage Details


### PR DESCRIPTION
- Allow users to input annotation changes using a CSV file with --csv option, in addition to existing JSON support.
- Update CLI argument parsing to require either --json or --csv.
- Document CSV input format and usage examples in the command reference.
- Improve error handling for missing or invalid input files.