### PR TITLE
`annotation_specs list_attribute_restriction` : 選択肢IDが空文字でも警告メッセージなく出力するようにしました。

### DIFF
--- a/annofabcli/annotation_specs/attribute_restriction.py
+++ b/annofabcli/annotation_specs/attribute_restriction.py
@@ -74,21 +74,26 @@ class AttributeRestrictionMessage:
         属性の種類がドロップダウンかセレクトボックスのときは、選択肢の名前を返す。
 
         Args:
-            value (str): _description_
-            attribute (Optional[dict[str,Any]]): _description_
+            value: 制約条件の値
+            attribute: 属性情報
 
         Returns:
-            str: _description_
+            valueが'foo'の場合：
+            -  属性の種類が排他選択でない場合： `'foo'` （valueを返す）
+            -  属性の種類が排他選択である場合： `'FOO'` （選択肢の名前を返す）
+            -  `OutputFormat.DETAILED_TEXT` AND 属性の種類が排他選択である場合： `'FOO' (id='foo')` （選択肢の名前とIDを返す）
+
         """
         if attribute is not None and attribute["type"] in ["choice", "select"]:
             # ラジオボタンかドロップダウンのとき
             choices = attribute["choices"]
             choice = first_true(choices, pred=lambda e: e["choice_id"] == value)
-            if choice is not None:
-                choice_name = AnnofabApiFacade.get_choice_name_en(choice)
-                tmp = f"'{value}'"
+            if value == "" or choice is not None:
+                # `value == ""`を判定条件に加える理由：「排他選択属性が空である/空でない」という制約の場合、`value`は空文字列になるため。
+                choice_name = AnnofabApiFacade.get_choice_name_en(choice) if choice is not None else ""
+                tmp = f"'{choice_name}'"
                 if self.output_format == OutputFormat.DETAILED_TEXT:
-                    tmp = f"{tmp} (name='{choice_name}')"
+                    tmp = f"{tmp} (id='{value}')"
                 return tmp
 
             else:

--- a/docs/command_reference/annotation_specs/list_attribute_restriction.rst
+++ b/docs/command_reference/annotation_specs/list_attribute_restriction.rst
@@ -23,11 +23,11 @@ Examples
     'comment' DOES NOT EQUAL ''
     'comment' MATCHES '[abc]+'
     'comment' MATCHES '[0-9]' IF 'unclear' EQUALS 'true'
-    'type' EQUALS 'b690fa1a-7b3d-4181-95d8-f5c75927c3fc' IF 'unclear' EQUALS 'true'
+    'type' EQUALS 'medium' IF 'unclear' EQUALS 'true'
     'link' HAS LABEL 'bike', 'bus'
 
 
-``--format detaield_text`` を指定すると、属性IDなどの詳細情報も出力されます。
+``--format detailed_text`` を指定すると、属性IDなどの詳細情報も出力されます。
 
 .. code-block::
 
@@ -35,7 +35,7 @@ Examples
     'comment' (id='54fa5e97-6f88-49a4-aeb0-a91a15d11528', type='comment') DOES NOT EQUAL ''
     'comment' (id='54fa5e97-6f88-49a4-aeb0-a91a15d11528', type='comment') MATCHES '[abc]+'
     'comment' (id='54fa5e97-6f88-49a4-aeb0-a91a15d11528', type='comment') MATCHES '[0-9]' IF 'unclear' (id='f12a0b59-dfce-4241-bb87-4b2c0259fc6f', type='flag') EQUALS 'true'
-    'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS 'b690fa1a-7b3d-4181-95d8-f5c75927c3fc'(name='medium') IF 'unclear' (id='f12a0b59-dfce-4241-bb87-4b2c0259fc6f', type='flag') EQUALS 'true'
+    'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS 'medium'(id='b690fa1a-7b3d-4181-95d8-f5c75927c3fc') IF 'unclear' (id='f12a0b59-dfce-4241-bb87-4b2c0259fc6f', type='flag') EQUALS 'true'
     'link' (id='15235360-4f46-42ac-927d-0e046bf52ddd', type='link') HAS LABEL 'bike' (id='40f7796b-3722-4eed-9c0c-04a27f9165d2'), 'bus' (id='22b5189b-af7b-4d9c-83a5-b92f122170ec')
 
 

--- a/tests/annotation_specs/test_attribute_restriction.py
+++ b/tests/annotation_specs/test_attribute_restriction.py
@@ -72,7 +72,7 @@ class Test__AttributeRestrictionMessage:
         attribute_id = "71620647-98cf-48ad-b43b-4af425a24f32"
         condition = {"value": "b690fa1a-7b3d-4181-95d8-f5c75927c3fc", "_type": "Equals"}
         actual = self.obj.get_restriction_text(attribute_id, condition)
-        assert actual == "'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS 'b690fa1a-7b3d-4181-95d8-f5c75927c3fc' (name='medium')"
+        assert actual == "'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS 'medium' (id='b690fa1a-7b3d-4181-95d8-f5c75927c3fc')"
 
     def test_get_restriction_text__caninput(self):
         attribute_id = "54fa5e97-6f88-49a4-aeb0-a91a15d11528"
@@ -120,7 +120,7 @@ class Test__AttributeRestrictionMessage:
         condition = {"value": "", "_type": "Equals"}
 
         actual = self.obj.get_restriction_text(attribute_id, condition)
-        assert actual == "'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS ''"
+        assert actual == "'type' (id='71620647-98cf-48ad-b43b-4af425a24f32', type='select') EQUALS '' (id='')"
 
     def test_get_restriction_text_list(self):
         actual1 = self.obj.get_restriction_text_list(self.annotation_specs["restrictions"], target_attribute_names=["link"])


### PR DESCRIPTION
# 変更1
排他選択属性の場合は、`EQUALS '選択肢ID'`で出力していました。
知りたいのは選択肢IDではなく選択肢名なので、`EQUALS '選択肢名'`と出力するようにしました。

# 変更2
選択肢IDが空文字列でも警告なく出力するようにしました。
