### PR TITLE
`stat_visualization write_performance_rating_csv`：出力結果のCSVのヘッダ行を2行から3行に変えました。

### DIFF
--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -444,7 +444,7 @@ def create_deviation_df(
     df_rank["count_of_project"] = df_rank[project_columns].count(axis=1)
     df = df_rank[[*list(user_columns), ("mean_of_deviation", "", ""), ("count_of_project", "", ""), *list(project_columns)]]
     if user_ids is not None:
-        return df[df[("user_id", "")].isin(user_ids)]
+        return df[df[("user_id", "", "")].isin(user_ids)]
     else:
         return df
 

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -178,10 +178,10 @@ class CollectingPerformanceInfo:
         self.productivity_indicator_by_directory = productivity_indicator_by_directory if productivity_indicator_by_directory is not None else {}
         self.quality_indicator_by_directory = quality_indicator_by_directory if quality_indicator_by_directory is not None else {}
 
-    def get_threshold_info(self, project_title: str, productivity_type: ProductivityType) -> ThresholdInfo:
+    def get_threshold_info(self, dirname: str, productivity_type: ProductivityType) -> ThresholdInfo:
         """指定したプロジェクト名に対応する、閾値情報を取得する。"""
         global_info = self.threshold_info
-        local_info = self.threshold_infos_by_directory.get((project_title, productivity_type))
+        local_info = self.threshold_infos_by_directory.get((dirname, productivity_type))
         if local_info is None:
             return global_info
 
@@ -190,7 +190,7 @@ class CollectingPerformanceInfo:
 
         return ThresholdInfo(threshold_worktime=worktime, threshold_task_count=task_count)
 
-    def filter_df_with_threshold(self, df: pandas.DataFrame, phase: TaskPhase, project_title: str):  # noqa: ANN201
+    def filter_df_with_threshold(self, df: pandas.DataFrame, phase: TaskPhase, dirname: str):  # noqa: ANN201
         """
         引数`df`をインタンスとして持っている閾値情報でフィルタリングする。
         """
@@ -201,7 +201,7 @@ class CollectingPerformanceInfo:
         else:
             raise RuntimeError(f"未対応のフェーズです。phase={phase}")
 
-        threshold_info = self.get_threshold_info(project_title, productivity_type)
+        threshold_info = self.get_threshold_info(dirname, productivity_type)
         if threshold_info.threshold_worktime is not None:
             df = df[df[(self.productivity_indicator.worktime_type.value, phase.value)] > threshold_info.threshold_worktime]
 
@@ -210,42 +210,42 @@ class CollectingPerformanceInfo:
 
         return df
 
-    def join_annotation_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str) -> pandas.DataFrame:
+    def join_annotation_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str) -> pandas.DataFrame:
         """
         引数`df_performance`から教師付生産性を抽出して引数`df`にjoinした結果を返す
 
         Args:
             df: 教師付生産性が格納されたDataFrame。行方向にユーザー、列方向にプロジェクトが並んでいる。
-            project_title: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
-            df_performance: 引数`project_title`のユーザーごとの生産性と品質が格納されたDataFrame。
+            dirname: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
+            df_performance: 引数`dirname`のユーザーごとの生産性と品質が格納されたDataFrame。
         """
         phase = TaskPhase.ANNOTATION
 
         df_joined = df_performance
 
-        df_joined = self.filter_df_with_threshold(df_joined, phase, project_title=project_title)
+        df_joined = self.filter_df_with_threshold(df_joined, phase, dirname=dirname)
 
-        productivity_indicator = self.productivity_indicator_by_directory.get(project_title, self.productivity_indicator)
+        productivity_indicator = self.productivity_indicator_by_directory.get(dirname, self.productivity_indicator)
         column = (productivity_indicator.column, phase.value)
         if column in df_joined.columns:
             df_tmp = df_joined[[column]]
         else:
-            logger.warning(f"'{project_title}'に生産性の指標である'{column}'の列が存在しませんでした。")
+            logger.warning(f"'{dirname}'に生産性の指標である'{column}'の列が存在しませんでした。")
             df_tmp = pandas.DataFrame(index=df_joined.index, columns=[column])
-        df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{productivity_indicator.column}__{phase.value}")])
+        df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{productivity_indicator.column}__{phase.value}")])
         return df.join(df_tmp)
 
-    def join_inspection_acceptance_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str) -> pandas.DataFrame:
+    def join_inspection_acceptance_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str) -> pandas.DataFrame:
         """
         引数`df_performance`から検査/受入の生産性を抽出して引数`df`にjoinした結果を返す
 
         Args:
             df: 検査/受入の生産性が格納されたDataFrame。行方向にユーザー、列方向にプロジェクトが並んでいる。
-            project_title: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
-            df_performance: 引数`project_title`のユーザーごとの生産性と品質が格納されたDataFrame。
+            dirname: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
+            df_performance: 引数`dirname`のユーザーごとの生産性と品質が格納されたDataFrame。
         """
 
-        productivity_indicator = self.productivity_indicator_by_directory.get(project_title, self.productivity_indicator)
+        productivity_indicator = self.productivity_indicator_by_directory.get(dirname, self.productivity_indicator)
 
         def _join_inspection() -> pandas.DataFrame:
             phase = TaskPhase.INSPECTION
@@ -253,10 +253,10 @@ class CollectingPerformanceInfo:
                 return df
 
             df_joined = df_performance
-            df_joined = self.filter_df_with_threshold(df_joined, phase, project_title=project_title)
+            df_joined = self.filter_df_with_threshold(df_joined, phase, dirname=dirname)
 
             df_tmp = df_joined[[(productivity_indicator.column, phase.value)]]
-            df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{productivity_indicator.column}__{phase.value}")])
+            df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{productivity_indicator.column}__{phase.value}")])
 
             return df.join(df_tmp)
 
@@ -266,10 +266,10 @@ class CollectingPerformanceInfo:
                 return df
 
             df_joined = df_performance
-            df_joined = self.filter_df_with_threshold(df_joined, phase, project_title=project_title)
+            df_joined = self.filter_df_with_threshold(df_joined, phase, dirname=dirname)
 
             df_tmp = df_joined[[(productivity_indicator.column, phase.value)]]
-            df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{productivity_indicator.column}__{phase.value}")])
+            df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{productivity_indicator.column}__{phase.value}")])
 
             return df.join(df_tmp)
 
@@ -278,30 +278,30 @@ class CollectingPerformanceInfo:
 
         return df
 
-    def join_annotation_quality(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, project_title: str) -> pandas.DataFrame:
+    def join_annotation_quality(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str) -> pandas.DataFrame:
         """
         引数`df_performance`から教師付の品質を抽出して引数`df`にjoinした結果を返す
 
         Args:
             df: 教師付の品質が格納されたDataFrame。行方向にユーザー、列方向にプロジェクトが並んでいる。
-            project_title: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
-            df_performance: 引数`project_title`のユーザーごとの生産性と品質が格納されたDataFrame。
+            dirname: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
+            df_performance: 引数`dirname`のユーザーごとの生産性と品質が格納されたDataFrame。
         """
         phase = TaskPhase.ANNOTATION
         df_joined = df_performance
 
-        df_joined = self.filter_df_with_threshold(df_joined, phase=TaskPhase.ANNOTATION, project_title=project_title)
+        df_joined = self.filter_df_with_threshold(df_joined, phase=TaskPhase.ANNOTATION, dirname=dirname)
 
-        quality_indicator = self.quality_indicator_by_directory.get(project_title, self.quality_indicator)
+        quality_indicator = self.quality_indicator_by_directory.get(dirname, self.quality_indicator)
 
         column = (quality_indicator.column, phase.value)
         if column in df_joined.columns:
             df_tmp = df_joined[[column]]
         else:
-            logger.warning(f"'{project_title}'に品質の指標である'{column}'の列が存在しませんでした。")
+            logger.warning(f"'{dirname}'に品質の指標である'{column}'の列が存在しませんでした。")
             df_tmp = pandas.DataFrame(index=df_joined.index, columns=[column])
 
-        df_tmp.columns = pandas.MultiIndex.from_tuples([(project_title, f"{quality_indicator.column}__{phase.value}")])
+        df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{quality_indicator.column}__{phase.value}")])
         return df.join(df_tmp)
 
     def create_rating_df(
@@ -321,13 +321,15 @@ class CollectingPerformanceInfo:
                 continue
 
             custom_production_volume_list = custom_production_volume_list_by_directory.get(p_project_dir.name) if custom_production_volume_list_by_directory is not None else None
-            project_title = p_project_dir.name
+            dirname = p_project_dir.name
             project_dir = ProjectDir(
                 p_project_dir,
                 task_completion_criteria=TaskCompletionCriteria.ACCEPTANCE_COMPLETED,
                 custom_production_volume_list=custom_production_volume_list,
             )
             project_dir_list.append(project_dir)
+
+            # project_info = project_dir.read_project_info()
 
             try:
                 user_performance = project_dir.read_user_performance()
@@ -344,19 +346,19 @@ class CollectingPerformanceInfo:
             df_annotation_productivity = self.join_annotation_productivity(
                 df_annotation_productivity,
                 df_performance,
-                project_title=project_title,
+                dirname=dirname,
             )
 
             df_annotation_quality = self.join_annotation_quality(
                 df_annotation_quality,
                 df_performance,
-                project_title=project_title,
+                dirname=dirname,
             )
 
             df_inspection_acceptance_productivity = self.join_inspection_acceptance_productivity(
                 df_inspection_acceptance_productivity,
                 df_performance,
-                project_title=project_title,
+                dirname=dirname,
             )
 
         # プロジェクトの生産性と品質のDataFrameを生成する

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -233,6 +233,7 @@ class CollectingPerformanceInfo:
             logger.warning(f"'{dirname}'に生産性の指標である'{column}'の列が存在しませんでした。")
             df_tmp = pandas.DataFrame(index=df_joined.index, columns=[column])
         df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, project_title, f"{productivity_indicator.column}__{phase.value}")])
+
         return df.join(df_tmp)
 
     def join_inspection_acceptance_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str, project_title: str) -> pandas.DataFrame:
@@ -441,7 +442,7 @@ def create_deviation_df(
 
     df_rank["mean_of_deviation"] = df_rank[project_columns].mean(axis=1)
     df_rank["count_of_project"] = df_rank[project_columns].count(axis=1)
-    df = df_rank[[*list(user_columns), ("mean_of_deviation", ""), ("count_of_project", ""), *list(project_columns)]]
+    df = df_rank[[*list(user_columns), ("mean_of_deviation", "", ""), ("count_of_project", "", ""), *list(project_columns)]]
     if user_ids is not None:
         return df[df[("user_id", "")].isin(user_ids)]
     else:
@@ -461,7 +462,7 @@ def create_user_df(target_dir: Path) -> pandas.DataFrame:
         target_dir:
 
     Returns:
-        ユーザのDataFrame. columnは("username", ""), ("biography", "") , indexが"user_id"
+        ユーザのDataFrame. columnは("username", "", ""), ("biography", "", "") , indexが"user_id"
 
     """
     all_user_list: list[dict[str, Any]] = []
@@ -484,9 +485,11 @@ def create_user_df(target_dir: Path) -> pandas.DataFrame:
         tmp_df_user = user_performance.df[[("user_id", ""), ("username", ""), ("biography", "")]].copy()
         all_user_list.extend(tmp_df_user.to_dict("records"))
 
-    index = pandas.MultiIndex.from_tuples([("user_id", ""), ("username", ""), ("biography", "")])
-    df_user = pandas.DataFrame(all_user_list, columns=index)
+    df_user = pandas.DataFrame(all_user_list, columns=pandas.MultiIndex.from_tuples([("user_id", ""), ("username", ""), ("biography", "")]))
+
     df_user.drop_duplicates(inplace=True)
+    # 出力結果のCSV列に合わせて3行の列名に変更する
+    df_user.columns = pandas.MultiIndex.from_tuples([("user_id", "", ""), ("username", "", ""), ("biography", "", "")])
     return df_user.sort_values("user_id").set_index("user_id")
 
 

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -490,7 +490,7 @@ def create_user_df(target_dir: Path) -> pandas.DataFrame:
     df_user.drop_duplicates(inplace=True)
     # 出力結果のCSV列に合わせて3行の列名に変更する
     df_user.columns = pandas.MultiIndex.from_tuples([("user_id", "", ""), ("username", "", ""), ("biography", "", "")])
-    return df_user.sort_values("user_id").set_index("user_id")
+    return df_user.sort_values(("user_id", "", "")).set_index(("user_id", "", ""))
 
 
 def create_custom_production_volume_by_directory(cli_value: str) -> dict[str, list[ProductionVolumeColumn]]:

--- a/annofabcli/stat_visualization/write_performance_rating_csv.py
+++ b/annofabcli/stat_visualization/write_performance_rating_csv.py
@@ -210,7 +210,7 @@ class CollectingPerformanceInfo:
 
         return df
 
-    def join_annotation_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str, project_title:str) -> pandas.DataFrame:
+    def join_annotation_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str, project_title: str) -> pandas.DataFrame:
         """
         引数`df_performance`から教師付生産性を抽出して引数`df`にjoinした結果を返す
 
@@ -235,13 +235,14 @@ class CollectingPerformanceInfo:
         df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, project_title, f"{productivity_indicator.column}__{phase.value}")])
         return df.join(df_tmp)
 
-    def join_inspection_acceptance_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str) -> pandas.DataFrame:
+    def join_inspection_acceptance_productivity(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str, project_title: str) -> pandas.DataFrame:
         """
         引数`df_performance`から検査/受入の生産性を抽出して引数`df`にjoinした結果を返す
 
         Args:
             df: 検査/受入の生産性が格納されたDataFrame。行方向にユーザー、列方向にプロジェクトが並んでいる。
             dirname: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
+            project_title: プロジェクトのタイトル。列名に使用する。
             df_performance: 引数`dirname`のユーザーごとの生産性と品質が格納されたDataFrame。
         """
 
@@ -256,7 +257,7 @@ class CollectingPerformanceInfo:
             df_joined = self.filter_df_with_threshold(df_joined, phase, dirname=dirname)
 
             df_tmp = df_joined[[(productivity_indicator.column, phase.value)]]
-            df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{productivity_indicator.column}__{phase.value}")])
+            df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, project_title, f"{productivity_indicator.column}__{phase.value}")])
 
             return df.join(df_tmp)
 
@@ -269,7 +270,7 @@ class CollectingPerformanceInfo:
             df_joined = self.filter_df_with_threshold(df_joined, phase, dirname=dirname)
 
             df_tmp = df_joined[[(productivity_indicator.column, phase.value)]]
-            df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{productivity_indicator.column}__{phase.value}")])
+            df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, project_title, f"{productivity_indicator.column}__{phase.value}")])
 
             return df.join(df_tmp)
 
@@ -278,13 +279,14 @@ class CollectingPerformanceInfo:
 
         return df
 
-    def join_annotation_quality(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str) -> pandas.DataFrame:
+    def join_annotation_quality(self, df: pandas.DataFrame, df_performance: pandas.DataFrame, dirname: str, project_title: str) -> pandas.DataFrame:
         """
         引数`df_performance`から教師付の品質を抽出して引数`df`にjoinした結果を返す
 
         Args:
             df: 教師付の品質が格納されたDataFrame。行方向にユーザー、列方向にプロジェクトが並んでいる。
             dirname: 引数`df`にjoinする対象のプロジェクト名。列名に使用する。
+            project_title: プロジェクトのタイトル。列名に使用する。
             df_performance: 引数`dirname`のユーザーごとの生産性と品質が格納されたDataFrame。
         """
         phase = TaskPhase.ANNOTATION
@@ -301,7 +303,7 @@ class CollectingPerformanceInfo:
             logger.warning(f"'{dirname}'に品質の指標である'{column}'の列が存在しませんでした。")
             df_tmp = pandas.DataFrame(index=df_joined.index, columns=[column])
 
-        df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, f"{quality_indicator.column}__{phase.value}")])
+        df_tmp.columns = pandas.MultiIndex.from_tuples([(dirname, project_title, f"{quality_indicator.column}__{phase.value}")])
         return df.join(df_tmp)
 
     def create_rating_df(
@@ -349,24 +351,11 @@ class CollectingPerformanceInfo:
             df_performance = user_performance.df.copy()
             df_performance.set_index("user_id", inplace=True)
 
-            df_annotation_productivity = self.join_annotation_productivity(
-                df_annotation_productivity,
-                df_performance,
-                dirname=dirname,
-                project_title=project_title
-            )
+            df_annotation_productivity = self.join_annotation_productivity(df_annotation_productivity, df_performance, dirname=dirname, project_title=project_title)
 
-            df_annotation_quality = self.join_annotation_quality(
-                df_annotation_quality,
-                df_performance,
-                dirname=dirname,
-            )
+            df_annotation_quality = self.join_annotation_quality(df_annotation_quality, df_performance, dirname=dirname, project_title=project_title)
 
-            df_inspection_acceptance_productivity = self.join_inspection_acceptance_productivity(
-                df_inspection_acceptance_productivity,
-                df_performance,
-                dirname=dirname,
-            )
+            df_inspection_acceptance_productivity = self.join_inspection_acceptance_productivity(df_inspection_acceptance_productivity, df_performance, dirname=dirname, project_title=project_title)
 
         # プロジェクトの生産性と品質のDataFrameを生成する
         project_performance = ProjectPerformance.from_project_dirs(project_dir_list)

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -147,7 +147,6 @@ class ProjectWorktimePerMonth:
             # 複数のプロジェクトをマージして生産性情報を出力した場合は、`project_info.json`は存在しないので、このブロックに入る
             logger.info(f"'{project_dir}'からプロジェクト情報を読み込むのに失敗しました。project_titleは空文字にします。", exc_info=True)
             project_title = ""
-        result["dirname"] = project_dir.project_dir.name
         result["project_title"] = project_title
         return result
 

--- a/annofabcli/statistics/visualization/dataframe/project_performance.py
+++ b/annofabcli/statistics/visualization/dataframe/project_performance.py
@@ -139,6 +139,16 @@ class ProjectWorktimePerMonth:
         new_index = [str(dt)[0:7] for dt in series.index]
         result = pandas.Series(series.values, index=new_index)
         result["dirname"] = project_dir.project_dir.name
+
+        try:
+            project_info = project_dir.read_project_info()
+            project_title = project_info.project_title
+        except Exception:
+            # 複数のプロジェクトをマージして生産性情報を出力した場合は、`project_info.json`は存在しないので、このブロックに入る
+            logger.info(f"'{project_dir}'からプロジェクト情報を読み込むのに失敗しました。project_titleは空文字にします。", exc_info=True)
+            project_title = ""
+        result["dirname"] = project_dir.project_dir.name
+        result["project_title"] = project_title
         return result
 
     @classmethod
@@ -170,7 +180,7 @@ class ProjectWorktimePerMonth:
         if not self._validate_df_for_output(output_file):
             return
 
-        header_columns = ["dirname"]
+        header_columns = ["dirname", "project_title"]
         remain_columns = list(self.df.columns)
         for col in header_columns:
             remain_columns.remove(col)

--- a/docs/command_reference/stat_visualization/write_performance_rating_csv.rst
+++ b/docs/command_reference/stat_visualization/write_performance_rating_csv.rst
@@ -74,8 +74,16 @@ Examples
         └── inspection_acceptance_productivity__summary.csv
 
 
-* `annotation_productivity_rank.csv <https://github.com/kurusugawa-computer/annofab-cli/blob/main/docs/command_reference/stat_visualization/write_performance_rating_csv/out/annotation_productivity_rank.csv>`_
-* `annotation_productivity_deviation.csv <https://github.com/kurusugawa-computer/annofab-cli/blob/main/docs/command_reference/stat_visualization/write_performance_rating_csv/out/annotation_productivity_deviation.csv>`_
+
+.. csv-table:: annotation_productivity_rank.csv
+    :header-rows: 3
+    :file: write_performance_rating_csv/out/annotation_productivity_rank.csv
+
+
+.. csv-table:: annotation_productivity_deviation.csv
+    :header-rows: 3
+    :file: write_performance_rating_csv/out/annotation_productivity_deviation.csv
+
 
 
 

--- a/docs/command_reference/stat_visualization/write_performance_rating_csv/out/annotation_productivity_deviation.csv
+++ b/docs/command_reference/stat_visualization/write_performance_rating_csv/out/annotation_productivity_deviation.csv
@@ -1,4 +1,5 @@
 user_id,username,biography,mean_of_deviation,count_of_project,prj1,prj2,prj3
+,,,,,Project Title 1,Project Title 2,Project Title 3
 ,,,,,actual_worktime/annotation_count__annotation,actual_worktime/annotation_count__annotation,actual_worktime/annotation_count__annotation
 user1,user1,,30,1,30,,
 user2,user2,,46,3,40,49,49

--- a/docs/command_reference/stat_visualization/write_performance_rating_csv/out/annotation_productivity_rank.csv
+++ b/docs/command_reference/stat_visualization/write_performance_rating_csv/out/annotation_productivity_rank.csv
@@ -1,4 +1,5 @@
 user_id,username,biography,prj1,prj2,prj3
+,,,Project Title 1,Project Title 2,Project Title 3
 ,,,actual_worktime/annotation_count__annotation,actual_worktime/annotation_count__annotation,actual_worktime/annotation_count__annotation
 user1,user1,,A,A,A
 user2,user2,,B,A,B

--- a/tests/statistics/visualization/test_write_performance_rating_csv.py
+++ b/tests/statistics/visualization/test_write_performance_rating_csv.py
@@ -36,9 +36,9 @@ def test__create_quality_indicator_by_directory():
 
 df_user = pandas.DataFrame(
     {
-        ("user_id", ""): ["QU", "KX", "BH", "NZ"],
-        ("username", ""): ["QU", "KX", "BH", "NZ"],
-        ("biography", ""): ["category-KK", "category-KT", "category-KT", "category-KT"],
+        ("user_id", "",""): ["QU", "KX", "BH", "NZ"],
+        ("username", "",""): ["QU", "KX", "BH", "NZ"],
+        ("biography", "",""): ["category-KK", "category-KT", "category-KT", "category-KT"],
     }
 )
 project_dir = ProjectDir(data_dir / "visualization-dir", TaskCompletionCriteria.ACCEPTANCE_COMPLETED)

--- a/tests/statistics/visualization/test_write_performance_rating_csv.py
+++ b/tests/statistics/visualization/test_write_performance_rating_csv.py
@@ -66,12 +66,12 @@ class TestCollectingPerformanceInfo:
 
     def test__join_annotation_productivity(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_annotation_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual = obj.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual.columns[3] == ("project1", "actual_worktime_hour/annotation_count__annotation")
         assert df_actual.iloc[0][("project1", "actual_worktime_hour/annotation_count__annotation")] == approx(0.00070, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(productivity_indicator=ProductivityIndicator("monitored_worktime_hour/annotation_count"))
-        df_actual2 = obj2.join_annotation_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual2 = obj2.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual2.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__annotation")
 
         # productivity_indicator_by_directoryが優先されることを確認
@@ -79,17 +79,17 @@ class TestCollectingPerformanceInfo:
             productivity_indicator=ProductivityIndicator("actual_worktime_hour/annotation_count"),
             productivity_indicator_by_directory={"project1": ProductivityIndicator("monitored_worktime_hour/annotation_count")},
         )
-        df_actual3 = obj3.join_annotation_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual3 = obj3.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual3.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__annotation")
 
     def test__join_inspection_acceptance_productivity(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual = obj.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual.columns[3] == ("project1", "actual_worktime_hour/annotation_count__acceptance")
         assert df_actual.iloc[1][("project1", "actual_worktime_hour/annotation_count__acceptance")] == approx(0.000145, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(productivity_indicator=ProductivityIndicator("monitored_worktime_hour/annotation_count"))
-        df_actual2 = obj2.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual2 = obj2.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual2.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__acceptance")
 
         # productivity_indicator_by_directoryが優先されることを確認
@@ -97,17 +97,17 @@ class TestCollectingPerformanceInfo:
             productivity_indicator=ProductivityIndicator("actual_worktime_hour/annotation_count"),
             productivity_indicator_by_directory={"project1": ProductivityIndicator("monitored_worktime_hour/annotation_count")},
         )
-        df_actual3 = obj3.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual3 = obj3.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual3.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__acceptance")
 
     def test__join_annotation_quality(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_annotation_quality(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual = obj.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual.columns[3] == ("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")
         assert df_actual.iloc[0][("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")] == approx(0.000854, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(quality_indicator=QualityIndicator("rejected_count/task_count"))
-        df_actual2 = obj2.join_annotation_quality(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual2 = obj2.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual2.columns[3] == ("project1", "rejected_count/task_count__annotation")
 
         # quality_indicator_by_directoryが優先されることを確認
@@ -115,18 +115,18 @@ class TestCollectingPerformanceInfo:
             quality_indicator=QualityIndicator("pointed_out_inspection_comment_count/input_data_count"),
             quality_indicator_by_directory={"project1": QualityIndicator("rejected_count/task_count")},
         )
-        df_actual3 = obj3.join_annotation_quality(df=df_user, df_performance=user_performance.df, project_title="project1")
+        df_actual3 = obj3.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1")
         assert df_actual3.columns[3] == ("project1", "rejected_count/task_count__annotation")
 
     def test__filter_df_with_threshold(self):
         # threshold_worktime で絞り込み
         obj = CollectingPerformanceInfo(threshold_info=ThresholdInfo(threshold_worktime=6, threshold_task_count=None))
-        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1")
+        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, dirname="project1")
         assert list(df_actual["user_id"]) == ["KX"]
 
         # threshold_task_count で絞り込み
         obj = CollectingPerformanceInfo(threshold_info=ThresholdInfo(threshold_worktime=None, threshold_task_count=40))
-        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1")
+        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, dirname="project1")
         assert list(df_actual["user_id"]) == ["BH"]
 
         # threshold_task_count で絞り込み
@@ -134,5 +134,5 @@ class TestCollectingPerformanceInfo:
             threshold_info=ThresholdInfo(threshold_worktime=100, threshold_task_count=100),
             threshold_infos_by_directory={("project1", ProductivityType.ANNOTATION): ThresholdInfo(threshold_worktime=6, threshold_task_count=0)},
         )
-        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, project_title="project1")
+        df_actual = obj.filter_df_with_threshold(df=user_performance.df, phase=TaskPhase.ANNOTATION, dirname="project1")
         assert list(df_actual["user_id"]) == ["KX"]

--- a/tests/statistics/visualization/test_write_performance_rating_csv.py
+++ b/tests/statistics/visualization/test_write_performance_rating_csv.py
@@ -36,9 +36,9 @@ def test__create_quality_indicator_by_directory():
 
 df_user = pandas.DataFrame(
     {
-        ("user_id", "",""): ["QU", "KX", "BH", "NZ"],
-        ("username", "",""): ["QU", "KX", "BH", "NZ"],
-        ("biography", "",""): ["category-KK", "category-KT", "category-KT", "category-KT"],
+        ("user_id", "", ""): ["QU", "KX", "BH", "NZ"],
+        ("username", "", ""): ["QU", "KX", "BH", "NZ"],
+        ("biography", "", ""): ["category-KK", "category-KT", "category-KT", "category-KT"],
     }
 )
 project_dir = ProjectDir(data_dir / "visualization-dir", TaskCompletionCriteria.ACCEPTANCE_COMPLETED)

--- a/tests/statistics/visualization/test_write_performance_rating_csv.py
+++ b/tests/statistics/visualization/test_write_performance_rating_csv.py
@@ -66,57 +66,57 @@ class TestCollectingPerformanceInfo:
 
     def test__join_annotation_productivity(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual.columns[3] == ("project1", "actual_worktime_hour/annotation_count__annotation")
-        assert df_actual.iloc[0][("project1", "actual_worktime_hour/annotation_count__annotation")] == approx(0.00070, rel=1e-2)
+        df_actual = obj.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual.columns[3] == ("project1", "Test Project", "actual_worktime_hour/annotation_count__annotation")
+        assert df_actual.iloc[0][("project1", "Test Project", "actual_worktime_hour/annotation_count__annotation")] == approx(0.00070, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(productivity_indicator=ProductivityIndicator("monitored_worktime_hour/annotation_count"))
-        df_actual2 = obj2.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual2.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__annotation")
+        df_actual2 = obj2.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual2.columns[3] == ("project1", "Test Project", "monitored_worktime_hour/annotation_count__annotation")
 
         # productivity_indicator_by_directoryが優先されることを確認
         obj3 = CollectingPerformanceInfo(
             productivity_indicator=ProductivityIndicator("actual_worktime_hour/annotation_count"),
             productivity_indicator_by_directory={"project1": ProductivityIndicator("monitored_worktime_hour/annotation_count")},
         )
-        df_actual3 = obj3.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual3.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__annotation")
+        df_actual3 = obj3.join_annotation_productivity(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual3.columns[3] == ("project1", "Test Project", "monitored_worktime_hour/annotation_count__annotation")
 
     def test__join_inspection_acceptance_productivity(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual.columns[3] == ("project1", "actual_worktime_hour/annotation_count__acceptance")
-        assert df_actual.iloc[1][("project1", "actual_worktime_hour/annotation_count__acceptance")] == approx(0.000145, rel=1e-2)
+        df_actual = obj.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual.columns[3] == ("project1", "Test Project", "actual_worktime_hour/annotation_count__acceptance")
+        assert df_actual.iloc[1][("project1", "Test Project", "actual_worktime_hour/annotation_count__acceptance")] == approx(0.000145, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(productivity_indicator=ProductivityIndicator("monitored_worktime_hour/annotation_count"))
-        df_actual2 = obj2.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual2.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__acceptance")
+        df_actual2 = obj2.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual2.columns[3] == ("project1", "Test Project", "monitored_worktime_hour/annotation_count__acceptance")
 
         # productivity_indicator_by_directoryが優先されることを確認
         obj3 = CollectingPerformanceInfo(
             productivity_indicator=ProductivityIndicator("actual_worktime_hour/annotation_count"),
             productivity_indicator_by_directory={"project1": ProductivityIndicator("monitored_worktime_hour/annotation_count")},
         )
-        df_actual3 = obj3.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual3.columns[3] == ("project1", "monitored_worktime_hour/annotation_count__acceptance")
+        df_actual3 = obj3.join_inspection_acceptance_productivity(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual3.columns[3] == ("project1", "Test Project", "monitored_worktime_hour/annotation_count__acceptance")
 
     def test__join_annotation_quality(self):
         obj = CollectingPerformanceInfo()
-        df_actual = obj.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual.columns[3] == ("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")
-        assert df_actual.iloc[0][("project1", "pointed_out_inspection_comment_count/annotation_count__annotation")] == approx(0.000854, rel=1e-2)
+        df_actual = obj.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual.columns[3] == ("project1", "Test Project", "pointed_out_inspection_comment_count/annotation_count__annotation")
+        assert df_actual.iloc[0][("project1", "Test Project", "pointed_out_inspection_comment_count/annotation_count__annotation")] == approx(0.000854, rel=1e-2)
 
         obj2 = CollectingPerformanceInfo(quality_indicator=QualityIndicator("rejected_count/task_count"))
-        df_actual2 = obj2.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual2.columns[3] == ("project1", "rejected_count/task_count__annotation")
+        df_actual2 = obj2.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual2.columns[3] == ("project1", "Test Project", "rejected_count/task_count__annotation")
 
         # quality_indicator_by_directoryが優先されることを確認
         obj3 = CollectingPerformanceInfo(
             quality_indicator=QualityIndicator("pointed_out_inspection_comment_count/input_data_count"),
             quality_indicator_by_directory={"project1": QualityIndicator("rejected_count/task_count")},
         )
-        df_actual3 = obj3.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1")
-        assert df_actual3.columns[3] == ("project1", "rejected_count/task_count__annotation")
+        df_actual3 = obj3.join_annotation_quality(df=df_user, df_performance=user_performance.df, dirname="project1", project_title="Test Project")
+        assert df_actual3.columns[3] == ("project1", "Test Project", "rejected_count/task_count__annotation")
 
     def test__filter_df_with_threshold(self):
         # threshold_worktime で絞り込み


### PR DESCRIPTION
### 変更前のCSVヘッダ行
* 1行目：ディレクトリ名
* 2行目：評価指標

### 変更後のCSVヘッダ行
* 1行目：ディレクトリ名
* 2行目：プロジェクト名（`project_info.json`から読み込む）
* 3行目：評価指標
