### PR TITLE
`annotation import` : `--annotation`にZIPファイルを指定した場合は、並列度を指定できないようにする

### DIFF
--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -618,7 +618,7 @@ class ImportAnnotation(CommandLine):
             print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
             return False
 
-        if args.parallelism is not None and zipfile.is_zipfile(str(annotation_path)):
+        if args.parallelism is not None and annotation_path.is_file() and zipfile.is_zipfile(annotation_path):
             print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--annotation'にZIPファイルを指定した場合は、'--parallelism'を指定できません。",
                 file=sys.stderr,

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -573,7 +573,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
             with multiprocessing.Pool(parallelism) as pool:
                 func = partial(self.execute_task_wrapper, converter=converter)
                 result_bool_list = pool.map(func, enumerate(iter_task_parser))
-                success_count = len([e for e in result_bool_list if e])
+                success_count = sum(1 for e in result_bool_list if e)
                 task_count = len(result_bool_list)
 
         else:

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -618,6 +618,13 @@ class ImportAnnotation(CommandLine):
             print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
             return False
 
+        if args.parallelism is not None and zipfile.is_zipfile(str(annotation_path)):
+            print(  # noqa: T201
+                f"{COMMON_MESSAGE} argument --parallelism: '--annotation'にZIPファイルを指定した場合は、'--parallelism'を指定できません。",
+                file=sys.stderr,
+            )
+            return False
+
         if args.parallelism is not None and not args.yes:
             print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
@@ -717,7 +724,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--parallelism",
         type=int,
         choices=PARALLELISM_CHOICES,
-        help="並列度。指定しない場合は、逐次的に処理します。指定した場合は、``--yes`` も指定してください。",
+        help="並列度。指定しない場合は、逐次的に処理します。"
+        "ただし ``--annotation`` にZIPファイルを指定した場合は、``--parallelism`` を指定できません。"
+        "また、``--parallelism`` を指定した場合は、``--yes`` も指定してください。",
     )
 
     parser.set_defaults(subcommand_func=main)


### PR DESCRIPTION
`--annotation`にZIPファイルを指定したときに、`--parallelism 2`を指定すると、以下のエラーが発生します。

```
TypeError: cannot pickle '_thread.RLock' object
```

事前にメモリに共有したり、ZIPファイルを展開すれば、multiprocessingで処理できますが、そこまでやる必要はなさそうなので、コマンドライン引数のバリデーションではじくようにしました。
