### PR TITLE
`annotation import` : `--annotation`にZIPファイルを指定したときに並列度を指定できないようにする

### DIFF
--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -608,6 +608,13 @@ class ImportAnnotation(CommandLine):
             print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
             return False
 
+        if args.parallelism is not None and annotation_path.is_file() and zipfile.is_zipfile(annotation_path):
+            print(  # noqa: T201
+                f"{COMMON_MESSAGE} argument --parallelism: '--annotation'にZIPファイルを指定した場合は、'--parallelism'を指定できません。",
+                file=sys.stderr,
+            )
+            return False
+
         if args.parallelism is not None and not args.yes:
             print(  # noqa: T201
                 f"{COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず '--yes' を指定してください。",
@@ -632,7 +639,7 @@ class ImportAnnotation(CommandLine):
         # Simpleアノテーションの読み込み
         if annotation_path.is_dir():
             iter_task_parser = lazy_parse_simple_annotation_dir_by_task(annotation_path)
-        elif zipfile.is_zipfile(str(annotation_path)):
+        elif zipfile.is_zipfile(annotation_path):
             iter_task_parser = lazy_parse_simple_annotation_zip_by_task(annotation_path)
         else:
             logger.warning(f"annotation_path: '{annotation_path}' は、zipファイルまたはディレクトリではありませんでした。")
@@ -708,7 +715,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--parallelism",
         type=int,
         choices=PARALLELISM_CHOICES,
-        help="並列度。指定しない場合は、逐次的に処理します。指定した場合は、``--yes`` も指定してください。",
+        help="並列度。指定しない場合は、逐次的に処理します。"
+        "ただし ``--annotation`` にZIPファイルを指定した場合は、``--parallelism`` を指定できません。"
+        "また、``--parallelism`` を指定した場合は、``--yes`` も指定してください。",
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -540,7 +540,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
             logger.warning(f"task_id='{task_parser.task_id}' のアノテーションのインポートに失敗しました。", exc_info=True)
             return False
 
-    def main(  
+    def main(
         self,
         iter_task_parser: Iterator[SimpleAnnotationParserByTask],
         target_task_ids: Optional[set[str]] = None,

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -9,7 +9,6 @@ import uuid
 import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -408,6 +407,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
         is_force: bool,
         is_merge: bool,
         is_overwrite: bool,
+        converter: AnnotationConverter,
     ) -> None:
         self.service = service
         self.facade = AnnofabApiFacade(service)
@@ -417,8 +417,9 @@ class ImportAnnotationMain(CommandLineWithConfirm):
         self.is_force = is_force
         self.is_merge = is_merge
         self.is_overwrite = is_overwrite
+        self.converter = converter
 
-    def put_annotation_for_input_data(self, parser: SimpleAnnotationParser, converter: AnnotationConverter) -> bool:
+    def put_annotation_for_input_data(self, parser: SimpleAnnotationParser) -> bool:
         task_id = parser.task_id
         input_data_id = parser.input_data_id
 
@@ -444,18 +445,18 @@ class ImportAnnotationMain(CommandLineWithConfirm):
 
         logger.info(f"task_id='{task_id}', input_data_id='{input_data_id}' :: {len(simple_annotation.details)} 件のアノテーションを登録します。")
         if self.is_merge:
-            request_body = converter.convert_annotation_details(parser, simple_annotation.details, old_details=old_annotation["details"], updated_datetime=old_annotation["updated_datetime"])
+            request_body = self.converter.convert_annotation_details(parser, simple_annotation.details, old_details=old_annotation["details"], updated_datetime=old_annotation["updated_datetime"])
         else:
-            request_body = converter.convert_annotation_details(parser, simple_annotation.details, old_details=[], updated_datetime=old_annotation["updated_datetime"])
+            request_body = self.converter.convert_annotation_details(parser, simple_annotation.details, old_details=[], updated_datetime=old_annotation["updated_datetime"])
 
         self.service.api.put_annotation(self.project_id, task_id, input_data_id, request_body=request_body, query_params={"v": "2"})
         return True
 
-    def put_annotation_for_task(self, task_parser: SimpleAnnotationParserByTask, converter: AnnotationConverter) -> int:
+    def put_annotation_for_task(self, task_parser: SimpleAnnotationParserByTask) -> int:
         success_count = 0
         for parser in task_parser.lazy_parse():
             try:
-                if self.put_annotation_for_input_data(parser, converter):
+                if self.put_annotation_for_input_data(parser):
                     success_count += 1
             except Exception:  # pylint: disable=broad-except
                 logger.warning(
@@ -465,7 +466,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
 
         return success_count
 
-    def execute_task(self, task_parser: SimpleAnnotationParserByTask, converter: AnnotationConverter, task_index: Optional[int] = None) -> bool:
+    def execute_task(self, task_parser: SimpleAnnotationParserByTask, task_index: Optional[int] = None) -> bool:
         """
         1個のタスクに対してアノテーションを登録する。
 
@@ -514,7 +515,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
                 )
                 return False
 
-        result_count = self.put_annotation_for_task(task_parser, converter)
+        result_count = self.put_annotation_for_task(task_parser)
         logger.info(f"{logger_prefix}タスク'{task_parser.task_id}'の入力データ {result_count} 個に対してアノテーションをインポートしました。")
 
         if changed_operator:
@@ -531,30 +532,20 @@ class ImportAnnotationMain(CommandLineWithConfirm):
     def execute_task_wrapper(
         self,
         tpl: tuple[int, SimpleAnnotationParserByTask],
-        converter: AnnotationConverter,
     ) -> bool:
         task_index, task_parser = tpl
         try:
-            return self.execute_task(task_parser, converter=converter, task_index=task_index)
+            return self.execute_task(task_parser, task_index=task_index)
         except Exception:  # pylint: disable=broad-except
             logger.warning(f"task_id='{task_parser.task_id}' のアノテーションのインポートに失敗しました。", exc_info=True)
             return False
 
-    def main(
+    def main(  # noqa: ANN201
         self,
         iter_task_parser: Iterator[SimpleAnnotationParserByTask],
-        converter: AnnotationConverter,
         target_task_ids: Optional[set[str]] = None,
         parallelism: Optional[int] = None,
-    ) -> None:
-        """
-        アノテーションのインポート処理を実行するメイン関数です。
-
-        Notes:
-            `converter`をインスタンス変数でなく引数として渡している理由：
-            `multiprocessing.Pool`でシリアライズ化する際、"TypeError: cannot pickle '_thread.RLock' object"というエラーが発生するため
-        """
-
+    ):
         def get_iter_task_parser_from_task_ids(_iter_task_parser: Iterator[SimpleAnnotationParserByTask], _target_task_ids: set[str]) -> Iterator[SimpleAnnotationParserByTask]:
             for task_parser in _iter_task_parser:
                 if task_parser.task_id in _target_task_ids:
@@ -571,15 +562,14 @@ class ImportAnnotationMain(CommandLineWithConfirm):
         task_count = 0
         if parallelism is not None:
             with multiprocessing.Pool(parallelism) as pool:
-                func = partial(self.execute_task_wrapper, converter=converter)
-                result_bool_list = pool.map(func, enumerate(iter_task_parser))
+                result_bool_list = pool.map(self.execute_task_wrapper, enumerate(iter_task_parser))
                 success_count = len([e for e in result_bool_list if e])
                 task_count = len(result_bool_list)
 
         else:
             for task_index, task_parser in enumerate(iter_task_parser):
                 try:
-                    result = self.execute_task(task_parser, converter=converter, task_index=task_index)
+                    result = self.execute_task(task_parser, task_index=task_index)
                     if result:
                         success_count += 1
                 except Exception:
@@ -659,9 +649,10 @@ class ImportAnnotation(CommandLine):
             is_merge=args.merge,
             is_overwrite=args.overwrite,
             is_force=args.force,
+            converter=converter,
         )
 
-        main_obj.main(iter_task_parser, target_task_ids=target_task_ids, converter=converter, parallelism=args.parallelism)
+        main_obj.main(iter_task_parser, target_task_ids=target_task_ids, parallelism=args.parallelism)
 
 
 def main(args: argparse.Namespace) -> None:

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -540,12 +540,12 @@ class ImportAnnotationMain(CommandLineWithConfirm):
             logger.warning(f"task_id='{task_parser.task_id}' のアノテーションのインポートに失敗しました。", exc_info=True)
             return False
 
-    def main(  # noqa: ANN201
+    def main(  
         self,
         iter_task_parser: Iterator[SimpleAnnotationParserByTask],
         target_task_ids: Optional[set[str]] = None,
         parallelism: Optional[int] = None,
-    ):
+    ) -> None:
         def get_iter_task_parser_from_task_ids(_iter_task_parser: Iterator[SimpleAnnotationParserByTask], _target_task_ids: set[str]) -> Iterator[SimpleAnnotationParserByTask]:
             for task_parser in _iter_task_parser:
                 if task_parser.task_id in _target_task_ids:


### PR DESCRIPTION
`--annotation`にZIPファイルを指定したときに、`--parallelism 2`を指定すると、以下のエラーが発生します。

```
TypeError: cannot pickle '_thread.RLock' object
```

事前にメモリに共有したり、ZIPファイルを展開すれば、multiprocessingで処理できますが、そこまでやる必要はなさそうなので、コマンドライン引数のバリデーションではじくようにしました。


また、This reverts commit 2167e183757b56fa2dee38674c5416de13068673. を実施しました。

