### PR TITLE
`annotation import` : バルク系APIを使用して、API実行回数を減らしました

### DIFF
--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -539,12 +539,7 @@ class ImportAnnotationMain(CommandLineWithConfirm):
         success_annotation_count = 0
         for parser in parsers_list:
             try:
-                old_annotation = annotations_dict.get(parser.input_data_id)
-                if old_annotation is None:
-                    # バルク取得で取得できなかった場合は、個別に取得
-                    logger.debug(f"task_id='{parser.task_id}', input_data_id='{parser.input_data_id}' :: バルク取得で取得できなかったため、個別に取得します。")
-                    old_annotation, _ = self.service.api.get_editor_annotation(self.project_id, parser.task_id, parser.input_data_id, query_params={"v": "2"})
-
+                old_annotation = annotations_dict[parser.input_data_id]
                 tmp_success_annotation_count = self.put_annotation_for_input_data(parser, old_annotation=old_annotation)
                 if tmp_success_annotation_count > 0:
                     success_input_data_count += 1


### PR DESCRIPTION
- put_annotation_for_input_dataメソッドにold_annotation引数を追加し、既存アノテーション情報を外部から渡せるように変更
- put_annotation_for_taskメソッドを改修し、_get_annotations_in_bulkメソッドを追加
- タスク内の全入力データのアノテーション情報を10件ずつバルク取得するように実装
- バルク取得APIのfailureレスポンスに対して個別にget_editor_annotationで再取得する処理を追加
- バルク取得API全体が失敗した場合のフォールバック処理を実装

AIによる自動生成コード