### PR TITLE
`annotation_specs add_choices_to_attribute`: 選択肢を追加するコマンドを作成

### DIFF
--- a/annofabcli/annotation_specs/add_attribute.py
+++ b/annofabcli/annotation_specs/add_attribute.py
@@ -232,7 +232,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         nargs="+",
         help="属性を追加する対象ラベルのlabel_id。複数指定できます。 ``file://`` を先頭に付けると一覧ファイルを指定できます。",
     )
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/add_attribute_restriction.py
+++ b/annofabcli/annotation_specs/add_attribute_restriction.py
@@ -130,7 +130,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         help=f"追加する属性の制約情報のJSONを指定します。JSON形式は ... を参照してください。\n(例) ``{json.dumps(sample_json)}``\n``file://`` を先頭に付けるとjsonファイルを指定できます。",
     )
 
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/add_choice_attribute.py
+++ b/annofabcli/annotation_specs/add_choice_attribute.py
@@ -460,7 +460,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         nargs="+",
         help="属性を追加する対象ラベルのlabel_id。複数指定できます。 ``file://`` を先頭に付けると一覧ファイルを指定できます。",
     )
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/add_choice_attribute.py
+++ b/annofabcli/annotation_specs/add_choice_attribute.py
@@ -167,6 +167,11 @@ def validate_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput]) -> Non
         duplicated_text = ", ".join(sorted(duplicated_choice_ids))
         raise ValueError(f"入力された選択肢に重複した `choice_id` があります。 :: {duplicated_text}")
 
+    duplicated_choice_names = duplicated_set([choice.choice_name_en for choice in choice_inputs])
+    if duplicated_choice_names:
+        duplicated_text = ", ".join(sorted(duplicated_choice_names))
+        raise ValueError(f"入力された選択肢に重複した `choice_name_en` があります。 :: {duplicated_text}")
+
     default_count = len([choice for choice in choice_inputs if choice.is_default])
     if default_count > 1:
         raise ValueError("`is_default=true` を指定できる選択肢は0件または1件です。")
@@ -444,7 +449,12 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     choice_group.add_argument(
         "--choices_csv",
         type=Path,
-        help="追加する選択肢情報のCSVファイルを指定します。 CSVには ``choice_name_en`` 列が必要です。 任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。",
+        help=(
+            "追加する選択肢情報のCSVファイルを指定します。 "
+            "CSVには ``choice_name_en`` 列が必要です。 "
+            "``choice_id`` と ``choice_name_en`` はユニークになるように指定してください。 "
+            "任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。"
+        ),
     )
 
     label_group = parser.add_mutually_exclusive_group(required=True)

--- a/annofabcli/annotation_specs/add_choice_attribute.py
+++ b/annofabcli/annotation_specs/add_choice_attribute.py
@@ -167,11 +167,6 @@ def validate_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput]) -> Non
         duplicated_text = ", ".join(sorted(duplicated_choice_ids))
         raise ValueError(f"入力された選択肢に重複した `choice_id` があります。 :: {duplicated_text}")
 
-    duplicated_choice_names = duplicated_set([choice.choice_name_en for choice in choice_inputs])
-    if duplicated_choice_names:
-        duplicated_text = ", ".join(sorted(duplicated_choice_names))
-        raise ValueError(f"入力された選択肢に重複した `choice_name_en` があります。 :: {duplicated_text}")
-
     default_count = len([choice for choice in choice_inputs if choice.is_default])
     if default_count > 1:
         raise ValueError("`is_default=true` を指定できる選択肢は0件または1件です。")
@@ -449,12 +444,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     choice_group.add_argument(
         "--choices_csv",
         type=Path,
-        help=(
-            "追加する選択肢情報のCSVファイルを指定します。 "
-            "CSVには ``choice_name_en`` 列が必要です。 "
-            "``choice_id`` と ``choice_name_en`` はユニークになるように指定してください。 "
-            "任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。"
-        ),
+        help="追加する選択肢情報のCSVファイルを指定します。 CSVには ``choice_name_en`` 列が必要です。 任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。",
     )
 
     label_group = parser.add_mutually_exclusive_group(required=True)

--- a/annofabcli/annotation_specs/add_choice_attribute.py
+++ b/annofabcli/annotation_specs/add_choice_attribute.py
@@ -149,7 +149,7 @@ def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
     return result
 
 
-def validate_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput]) -> None:
+def validate_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput], *, min_count: int = 2) -> None:
     """
     選択肢入力一覧の整合性を検証する。
 
@@ -159,8 +159,8 @@ def validate_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput]) -> Non
     Raises:
         ValueError: 件数、重複、既定値の数が不正な場合
     """
-    if len(choice_inputs) <= 1:
-        raise ValueError("選択肢を2件以上指定してください。")
+    if len(choice_inputs) < min_count:
+        raise ValueError(f"選択肢を{min_count}件以上指定してください。")
 
     duplicated_choice_ids = duplicated_set([choice.choice_id for choice in choice_inputs if choice.choice_id is not None])
     if duplicated_choice_ids:
@@ -172,7 +172,7 @@ def validate_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput]) -> Non
         raise ValueError("`is_default=true` を指定できる選択肢は0件または1件です。")
 
 
-def build_choices(choice_inputs: Sequence[ChoiceAttributeInput]) -> tuple[list[dict[str, Any]], str | None]:
+def build_choices(choice_inputs: Sequence[ChoiceAttributeInput], *, min_count: int = 2) -> tuple[list[dict[str, Any]], str | None]:
     """
     選択肢入力からAnnofab API向けのchoices配列を生成する。
 
@@ -185,7 +185,7 @@ def build_choices(choice_inputs: Sequence[ChoiceAttributeInput]) -> tuple[list[d
     Raises:
         ValueError: 選択肢入力の整合性が不正な場合
     """
-    validate_choice_inputs(choice_inputs)
+    validate_choice_inputs(choice_inputs, min_count=min_count)
 
     choices: list[dict[str, Any]] = []
     default_choice_id: str | None = None

--- a/annofabcli/annotation_specs/add_choice_attribute.py
+++ b/annofabcli/annotation_specs/add_choice_attribute.py
@@ -489,7 +489,7 @@ def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse
     """
     subcommand_name = "add_choice_attribute"
     subcommand_help = "アノテーション仕様に選択肢系属性を追加します。"
-    description = "アノテーション仕様に ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の属性を追加し、指定ラベルへ紐付けます。"
+    description = "アノテーション仕様にの選択肢系属性（ラジオボタン/ドロップダウン）を追加し、指定したラベルへ紐付けます。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/add_choice_attribute.py
+++ b/annofabcli/annotation_specs/add_choice_attribute.py
@@ -77,7 +77,7 @@ def parse_choice_input_from_dict(data: dict[str, Any], *, index: int) -> ChoiceA
 
 def read_choices_json(target: str) -> list[ChoiceAttributeInput]:
     """
-    ``--choices_json`` で指定されたJSONから選択肢一覧を読み込む。
+    ``--choice_json`` で指定されたJSONから選択肢一覧を読み込む。
 
     Args:
         target: JSON文字列または ``file://`` 付きファイル指定
@@ -91,7 +91,7 @@ def read_choices_json(target: str) -> list[ChoiceAttributeInput]:
     """
     raw_data = get_json_from_args(target)
     if not isinstance(raw_data, list):
-        raise TypeError("`--choices_json` には選択肢情報の配列を指定してください。")
+        raise TypeError("`--choice_json` には選択肢情報の配列を指定してください。")
 
     result = []
     for index, choice_data in enumerate(raw_data, start=1):
@@ -103,7 +103,7 @@ def read_choices_json(target: str) -> list[ChoiceAttributeInput]:
 
 def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
     """
-    ``--choices_csv`` で指定されたCSVから選択肢一覧を読み込む。
+    ``--choice_csv`` で指定されたCSVから選択肢一覧を読み込む。
 
     Args:
         csv_path: CSVファイルパス
@@ -125,12 +125,12 @@ def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
             },
         )
     except Exception as e:
-        raise ValueError(f"`--choices_csv` の読み込みに失敗しました。 :: {e}") from e
+        raise ValueError(f"`--choice_csv` の読み込みに失敗しました。 :: {e}") from e
 
     required_columns = {"choice_name_en"}
     missing_columns = required_columns - set(df.columns)
     if missing_columns:
-        raise ValueError(f"`--choices_csv` に不足している必須列があります。 :: {sorted(missing_columns)}")
+        raise ValueError(f"`--choice_csv` に不足している必須列があります。 :: {sorted(missing_columns)}")
 
     result = []
     for row in df.to_dict(orient="records"):
@@ -385,14 +385,14 @@ class AddChoiceAttribute(CommandLine):
         """
         args = self.args
 
-        if args.choices_json is not None:
-            choice_inputs = read_choices_json(args.choices_json)
-        elif args.choices_csv is not None:
-            if not args.choices_csv.exists():
-                raise ValueError(f"`--choices_csv` に指定されたファイルが存在しません。 :: {args.choices_csv}")
-            choice_inputs = read_choices_csv(args.choices_csv)
+        if args.choice_json is not None:
+            choice_inputs = read_choices_json(args.choice_json)
+        elif args.choice_csv is not None:
+            if not args.choice_csv.exists():
+                raise ValueError(f"`--choice_csv` に指定されたファイルが存在しません。 :: {args.choice_csv}")
+            choice_inputs = read_choices_csv(args.choice_csv)
         else:
-            raise ValueError("`--choices_json` または `--choices_csv` のいずれかを指定してください。")
+            raise ValueError("`--choice_json` または `--choice_csv` のいずれかを指定してください。")
 
         label_ids = get_list_from_args(args.label_id)
         label_name_ens = get_list_from_args(args.label_name_en)
@@ -437,12 +437,12 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     ]
     choice_group = parser.add_mutually_exclusive_group(required=True)
     choice_group.add_argument(
-        "--choices_json",
+        "--choice_json",
         type=str,
         help=f"追加する選択肢情報のJSON配列を指定します。 ``file://`` を先頭に付けるとJSON形式のファイルを指定できます。\n(例) ``{json.dumps(sample_json, ensure_ascii=False)}``",
     )
     choice_group.add_argument(
-        "--choices_csv",
+        "--choice_csv",
         type=Path,
         help="追加する選択肢情報のCSVファイルを指定します。 CSVには ``choice_name_en`` 列が必要です。 任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。",
     )

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -4,14 +4,17 @@ import argparse
 import copy
 import json
 import logging
+from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 import annofabapi
+import pandas
 from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
 
 import annofabcli.common.cli
-from annofabcli.annotation_specs.add_choice_attribute import build_choices, read_choices_csv, read_choices_json
+from annofabcli.annotation_specs.add_choice_attribute import ChoiceAttributeInput, build_choices, read_choices_json
 from annofabcli.annotation_specs.utils import get_attribute_name_en
 from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login
 from annofabcli.common.facade import AnnofabApiFacade
@@ -32,6 +35,49 @@ def create_comment_from_attribute(attribute_name_en: str, choice_name_ens: list[
     """
     choices_text = ", ".join(choice_name_ens)
     return f"以下の選択肢を属性に追加しました。\n属性名(英語): {attribute_name_en}\n追加した選択肢: {choices_text}"
+
+
+def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
+    """
+    ``--choices_csv`` で指定されたCSVから選択肢一覧を読み込む。
+
+    ``add_choices_to_attribute`` ではデフォルト値を変更しないため、 ``is_default`` 列は読み込まない。
+
+    Args:
+        csv_path: CSVファイルパス
+
+    Returns:
+        選択肢入力の一覧
+
+    Raises:
+        ValueError: CSV読み込みに失敗した場合、または必須列が不足している場合
+    """
+    try:
+        df = pandas.read_csv(
+            csv_path,
+            dtype={
+                "choice_id": "string",
+                "choice_name_en": "string",
+                "choice_name_ja": "string",
+            },
+        )
+    except Exception as e:
+        raise ValueError(f"`--choices_csv` の読み込みに失敗しました。 :: {e}") from e
+
+    required_columns = {"choice_name_en"}
+    missing_columns = required_columns - set(df.columns)
+    if missing_columns:
+        raise ValueError(f"`--choices_csv` に不足している必須列があります。 :: {sorted(missing_columns)}")
+
+    return [
+        ChoiceAttributeInput(
+            choice_name_en=row["choice_name_en"],
+            choice_name_ja=row.get("choice_name_ja"),
+            choice_id=row.get("choice_id"),
+            is_default=False,
+        )
+        for row in df.to_dict(orient="records")
+    ]
 
 
 def get_target_attribute(
@@ -73,7 +119,6 @@ def validate_added_choices(
     target_attribute: dict[str, Any],
     *,
     added_choices: list[dict[str, Any]],
-    added_default_choice_id: str | None,
 ) -> None:
     """
     追加する選択肢が既存の選択肢と衝突しないか検証する。
@@ -81,10 +126,9 @@ def validate_added_choices(
     Args:
         target_attribute: 追加先の属性
         added_choices: 追加予定の選択肢一覧
-        added_default_choice_id: 追加予定のデフォルト選択肢ID
 
     Raises:
-        ValueError: 選択肢ID・選択肢名・デフォルト値が既存の属性情報と衝突する場合
+        ValueError: 選択肢ID・選択肢名が既存の属性情報と衝突する場合
     """
     existing_choices = target_attribute["choices"]
     existing_choice_ids = {choice["choice_id"] for choice in existing_choices}
@@ -99,9 +143,18 @@ def validate_added_choices(
         duplicated_text = ", ".join(sorted(duplicated_choice_name_ens))
         raise ValueError(f"追加先の属性に既に存在する `choice_name_en` が指定されています。 :: {duplicated_text}")
 
-    existing_default_choice_id = target_attribute.get("default")
-    if added_default_choice_id is not None and existing_default_choice_id not in ["", None]:
-        raise ValueError(f"追加先の属性には既にデフォルト選択肢が設定されています。 :: {existing_default_choice_id}")
+
+def ignore_default_choice_inputs(choice_inputs: Sequence[ChoiceAttributeInput]) -> list[ChoiceAttributeInput]:
+    """
+    選択肢追加コマンドではデフォルト値を変更しないため、is_defaultを無視する。
+
+    Args:
+        choice_inputs: コマンドラインから受け取った選択肢一覧
+
+    Returns:
+        ``is_default`` をFalseにした選択肢一覧
+    """
+    return [replace(choice_input, is_default=False) for choice_input in choice_inputs]
 
 
 class AddChoicesToAttributeMain(CommandLineWithConfirm):
@@ -154,7 +207,7 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
         else:
             raise ValueError("`--choices_json` または `--choices_csv` のいずれかを指定してください。")
 
-        added_choices, added_default_choice_id = build_choices(choice_inputs, min_count=1)
+        added_choices, _ = build_choices(ignore_default_choice_inputs(choice_inputs), min_count=1)
 
         old_annotation_specs, _ = self.service.api.get_annotation_specs(self.project_id, query_params={"v": "3"})
         annotation_specs_accessor = AnnotationSpecsAccessor(old_annotation_specs)
@@ -166,15 +219,12 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
         validate_added_choices(
             target_attribute,
             added_choices=added_choices,
-            added_default_choice_id=added_default_choice_id,
         )
 
         resolved_attribute_id = target_attribute["additional_data_definition_id"]
         resolved_attribute_name_en = get_attribute_name_en(target_attribute)
         added_choice_name_ens = [AnnofabApiFacade.get_choice_name_en(choice) for choice in added_choices]
         confirm_message = f"属性名(英語)='{resolved_attribute_name_en}', 属性ID='{resolved_attribute_id}' に {len(added_choices)} 件の選択肢 {added_choice_name_ens} を追加します。よろしいですか？"
-        if added_default_choice_id is not None:
-            confirm_message += f" 追加する選択肢のうち `choice_id`='{added_default_choice_id}' をデフォルト値に設定します。"
         if not self.confirm_processing(confirm_message):
             return False
 
@@ -183,8 +233,6 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
             if attribute["additional_data_definition_id"] != resolved_attribute_id:
                 continue
             attribute["choices"].extend(added_choices)
-            if added_default_choice_id is not None:
-                attribute["default"] = added_default_choice_id
             break
 
         if comment is None:
@@ -246,7 +294,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
             "追加する選択肢情報のCSVファイルを指定します。 "
             "CSVには ``choice_name_en`` 列が必要です。 "
             "``choice_id`` と ``choice_name_en`` はユニークになるように指定してください。 "
-            "任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。"
+            "任意で ``choice_id`` , ``choice_name_ja`` 列を指定できます。 ``is_default`` 列が存在する場合は無視されます。"
         ),
     )
 

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -15,7 +15,7 @@ from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
 
 import annofabcli.common.cli
 from annofabcli.annotation_specs.add_choice_attribute import ChoiceAttributeInput, build_choices, read_choices_json
-from annofabcli.annotation_specs.utils import get_attribute_name_en
+from annofabcli.annotation_specs.utils import get_attribute_name_en, get_target_choice_attribute
 from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login
 from annofabcli.common.facade import AnnofabApiFacade
 
@@ -78,41 +78,6 @@ def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
         )
         for row in df.to_dict(orient="records")
     ]
-
-
-def get_target_attribute(
-    annotation_specs_accessor: AnnotationSpecsAccessor,
-    *,
-    attribute_id: str | None,
-    attribute_name_en: str | None,
-) -> dict[str, Any]:
-    """
-    CLI引数で指定された属性IDまたは属性名から追加対象属性を取得する。
-
-    Args:
-        annotation_specs_accessor: アノテーション仕様アクセサ
-        attribute_id: 指定された属性ID
-        attribute_name_en: 指定された属性英語名
-
-    Returns:
-        追加対象の属性
-
-    Raises:
-        ValueError: 属性指定が不正、属性が見つからない、属性名が曖昧、または選択肢系属性でない場合
-    """
-    if (attribute_id is None) == (attribute_name_en is None):
-        raise ValueError("追加先の属性は `attribute_id` または `attribute_name_en` のどちらか一方だけ指定してください。")
-
-    if attribute_id is not None:
-        attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_id)
-    else:
-        assert attribute_name_en is not None
-        attribute = annotation_specs_accessor.get_attribute(attribute_name=attribute_name_en)
-
-    if attribute["type"] not in ["choice", "select"]:
-        raise ValueError(f"属性ID='{attribute['additional_data_definition_id']}' は選択肢系属性ではありません。")
-
-    return attribute
 
 
 def validate_added_choices(
@@ -211,7 +176,7 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
 
         old_annotation_specs, _ = self.service.api.get_annotation_specs(self.project_id, query_params={"v": "3"})
         annotation_specs_accessor = AnnotationSpecsAccessor(old_annotation_specs)
-        target_attribute = get_target_attribute(
+        target_attribute = get_target_choice_attribute(
             annotation_specs_accessor,
             attribute_id=attribute_id,
             attribute_name_en=attribute_name_en,

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -294,7 +294,7 @@ def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse
     """
     subcommand_name = "add_choices_to_attribute"
     subcommand_help = "既存の選択肢系属性に選択肢を追加します。"
-    description = "既存の ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の属性に、選択肢を追加します。"
+    description = "既存の選択肢系属性（ラジオボタン/ドロップダウン）に、選択肢を追加します。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import annofabapi
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
+
+import annofabcli.common.cli
+from annofabcli.annotation_specs.add_choice_attribute import build_choices, read_choices_csv, read_choices_json
+from annofabcli.annotation_specs.utils import get_attribute_name_en
+from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login
+from annofabcli.common.facade import AnnofabApiFacade
+
+logger = logging.getLogger(__name__)
+
+
+def create_comment_from_attribute(attribute_name_en: str, choice_name_ens: list[str]) -> str:
+    """
+    既存の選択肢系属性に選択肢を追加したときのデフォルトコメントを生成する。
+
+    Args:
+        attribute_name_en: 属性の英語名
+        choice_name_ens: 追加する選択肢の英語名一覧
+
+    Returns:
+        アノテーション仕様変更コメント
+    """
+    choices_text = ", ".join(choice_name_ens)
+    return f"以下の選択肢を属性に追加しました。\n属性名(英語): {attribute_name_en}\n追加した選択肢: {choices_text}"
+
+
+def get_target_attribute(
+    annotation_specs_accessor: AnnotationSpecsAccessor,
+    *,
+    attribute_id: str | None,
+    attribute_name_en: str | None,
+) -> dict[str, Any]:
+    """
+    CLI引数で指定された属性IDまたは属性名から追加対象属性を取得する。
+
+    Args:
+        annotation_specs_accessor: アノテーション仕様アクセサ
+        attribute_id: 指定された属性ID
+        attribute_name_en: 指定された属性英語名
+
+    Returns:
+        追加対象の属性
+
+    Raises:
+        ValueError: 属性指定が不正、属性が見つからない、属性名が曖昧、または選択肢系属性でない場合
+    """
+    if (attribute_id is None) == (attribute_name_en is None):
+        raise ValueError("追加先の属性は `attribute_id` または `attribute_name_en` のどちらか一方だけ指定してください。")
+
+    if attribute_id is not None:
+        attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_id)
+    else:
+        assert attribute_name_en is not None
+        attribute = annotation_specs_accessor.get_attribute(attribute_name=attribute_name_en)
+
+    if attribute["type"] not in ["choice", "select"]:
+        raise ValueError(f"属性ID='{attribute['additional_data_definition_id']}' は選択肢系属性ではありません。")
+
+    return attribute
+
+
+def validate_added_choices(
+    target_attribute: dict[str, Any],
+    *,
+    added_choices: list[dict[str, Any]],
+    added_default_choice_id: str | None,
+) -> None:
+    """
+    追加する選択肢が既存の選択肢と衝突しないか検証する。
+
+    Args:
+        target_attribute: 追加先の属性
+        added_choices: 追加予定の選択肢一覧
+        added_default_choice_id: 追加予定のデフォルト選択肢ID
+
+    Raises:
+        ValueError: 選択肢ID・選択肢名・デフォルト値が既存の属性情報と衝突する場合
+    """
+    existing_choices = target_attribute["choices"]
+    existing_choice_ids = {choice["choice_id"] for choice in existing_choices}
+    duplicated_choice_ids = existing_choice_ids & {choice["choice_id"] for choice in added_choices}
+    if duplicated_choice_ids:
+        duplicated_text = ", ".join(sorted(duplicated_choice_ids))
+        raise ValueError(f"追加先の属性に既に存在する `choice_id` が指定されています。 :: {duplicated_text}")
+
+    existing_choice_name_ens = {AnnofabApiFacade.get_choice_name_en(choice) for choice in existing_choices}
+    duplicated_choice_name_ens = existing_choice_name_ens & {AnnofabApiFacade.get_choice_name_en(choice) for choice in added_choices}
+    if duplicated_choice_name_ens:
+        duplicated_text = ", ".join(sorted(duplicated_choice_name_ens))
+        raise ValueError(f"追加先の属性に既に存在する `choice_name_en` が指定されています。 :: {duplicated_text}")
+
+    existing_default_choice_id = target_attribute.get("default")
+    if added_default_choice_id is not None and existing_default_choice_id not in ["", None]:
+        raise ValueError(f"追加先の属性には既にデフォルト選択肢が設定されています。 :: {existing_default_choice_id}")
+
+
+class AddChoicesToAttributeMain(CommandLineWithConfirm):
+    """
+    既存の選択肢系属性へ選択肢を追加する本体処理。
+    """
+
+    def __init__(
+        self,
+        service: annofabapi.Resource,
+        *,
+        project_id: str,
+        all_yes: bool,
+    ) -> None:
+        self.service = service
+        self.project_id = project_id
+        CommandLineWithConfirm.__init__(self, all_yes)
+
+    def add_choices_to_attribute(
+        self,
+        *,
+        attribute_id: str | None,
+        attribute_name_en: str | None,
+        choices_json: str | None,
+        choices_csv: Path | None,
+        comment: str | None = None,
+    ) -> bool:
+        """
+        既存の選択肢系属性へ選択肢を追加して、アノテーション仕様を更新する。
+
+        Args:
+            attribute_id: 追加先属性ID
+            attribute_name_en: 追加先属性英語名
+            choices_json: 追加する選択肢JSON
+            choices_csv: 追加する選択肢CSV
+            comment: 変更コメント
+
+        Returns:
+            追加を実行した場合はTrue、確認で中断した場合はFalse
+
+        Raises:
+            ValueError: 入力値や既存アノテーション仕様との整合性が不正な場合
+        """
+        if choices_json is not None:
+            choice_inputs = read_choices_json(choices_json)
+        elif choices_csv is not None:
+            if not choices_csv.exists():
+                raise ValueError(f"`--choices_csv` に指定されたファイルが存在しません。 :: {choices_csv}")
+            choice_inputs = read_choices_csv(choices_csv)
+        else:
+            raise ValueError("`--choices_json` または `--choices_csv` のいずれかを指定してください。")
+
+        added_choices, added_default_choice_id = build_choices(choice_inputs, min_count=1)
+
+        old_annotation_specs, _ = self.service.api.get_annotation_specs(self.project_id, query_params={"v": "3"})
+        annotation_specs_accessor = AnnotationSpecsAccessor(old_annotation_specs)
+        target_attribute = get_target_attribute(
+            annotation_specs_accessor,
+            attribute_id=attribute_id,
+            attribute_name_en=attribute_name_en,
+        )
+        validate_added_choices(
+            target_attribute,
+            added_choices=added_choices,
+            added_default_choice_id=added_default_choice_id,
+        )
+
+        resolved_attribute_id = target_attribute["additional_data_definition_id"]
+        resolved_attribute_name_en = get_attribute_name_en(target_attribute)
+        added_choice_name_ens = [AnnofabApiFacade.get_choice_name_en(choice) for choice in added_choices]
+        confirm_message = f"属性名(英語)='{resolved_attribute_name_en}', 属性ID='{resolved_attribute_id}' に {len(added_choices)} 件の選択肢 {added_choice_name_ens} を追加します。よろしいですか？"
+        if added_default_choice_id is not None:
+            confirm_message += f" 追加する選択肢のうち `choice_id`='{added_default_choice_id}' をデフォルト値に設定します。"
+        if not self.confirm_processing(confirm_message):
+            return False
+
+        request_body = copy.deepcopy(old_annotation_specs)
+        for attribute in request_body["additionals"]:
+            if attribute["additional_data_definition_id"] != resolved_attribute_id:
+                continue
+            attribute["choices"].extend(added_choices)
+            if added_default_choice_id is not None:
+                attribute["default"] = added_default_choice_id
+            break
+
+        if comment is None:
+            comment = create_comment_from_attribute(resolved_attribute_name_en, added_choice_name_ens)
+        request_body["comment"] = comment
+        request_body["last_updated_datetime"] = old_annotation_specs["updated_datetime"]
+        self.service.api.put_annotation_specs(self.project_id, query_params={"v": "3"}, request_body=request_body)
+        logger.info(f"属性名(英語)='{resolved_attribute_name_en}', 属性ID='{resolved_attribute_id}' に {len(added_choices)} 件の選択肢を追加しました。")
+        return True
+
+
+class AddChoicesToAttribute(CommandLine):
+    COMMON_MESSAGE = "annofabcli annotation_specs add_choices_to_attribute: error:"
+
+    def main(self) -> None:
+        """
+        コマンドライン引数を解釈し、既存属性への選択肢追加処理を実行する。
+        """
+        args = self.args
+
+        obj = AddChoicesToAttributeMain(self.service, project_id=args.project_id, all_yes=args.yes)
+        obj.add_choices_to_attribute(
+            attribute_id=args.attribute_id,
+            attribute_name_en=args.attribute_name_en,
+            choices_json=args.choices_json,
+            choices_csv=args.choices_csv,
+            comment=args.comment,
+        )
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    """
+    ``add_choices_to_attribute`` サブコマンドの引数を定義する。
+
+    Args:
+        parser: 引数を追加するArgumentParser
+    """
+    argument_parser = ArgumentParser(parser)
+    argument_parser.add_project_id()
+
+    attribute_group = parser.add_mutually_exclusive_group(required=True)
+    attribute_group.add_argument("--attribute_id", type=str, help="選択肢を追加する対象属性の属性ID。")
+    attribute_group.add_argument("--attribute_name_en", type=str, help="選択肢を追加する対象属性の英語名。")
+
+    sample_json = [
+        {"choice_id": "xlarge", "choice_name_en": "xlarge", "choice_name_ja": "特大"},
+        {"choice_id": "tiny", "choice_name_en": "tiny", "choice_name_ja": "極小"},
+    ]
+    choice_group = parser.add_mutually_exclusive_group(required=True)
+    choice_group.add_argument(
+        "--choices_json",
+        type=str,
+        help=f"追加する選択肢情報のJSON配列を指定します。 ``file://`` を先頭に付けるとJSON形式のファイルを指定できます。\n(例) ``{json.dumps(sample_json, ensure_ascii=False)}``",
+    )
+    choice_group.add_argument(
+        "--choices_csv",
+        type=Path,
+        help=(
+            "追加する選択肢情報のCSVファイルを指定します。 "
+            "CSVには ``choice_name_en`` 列が必要です。 "
+            "``choice_id`` と ``choice_name_en`` はユニークになるように指定してください。 "
+            "任意で ``choice_id`` , ``choice_name_ja`` , ``is_default`` 列を指定できます。"
+        ),
+    )
+
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def main(args: argparse.Namespace) -> None:
+    """
+    ``add_choices_to_attribute`` コマンドのエントリポイント。
+
+    Args:
+        args: コマンドライン引数
+    """
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    AddChoicesToAttribute(service, facade, args).main()
+
+
+def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
+    """
+    ``annotation_specs add_choices_to_attribute`` 用のparserを生成する。
+
+    Args:
+        subparsers: 親parserのsubparsers
+
+    Returns:
+        生成したArgumentParser
+    """
+    subcommand_name = "add_choices_to_attribute"
+    subcommand_help = "既存の選択肢系属性に選択肢を追加します。"
+    description = "既存の ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の属性に、選択肢を追加します。"
+
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
+    parse_args(parser)
+    return parser

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -250,7 +250,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
 
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -11,11 +11,11 @@ from typing import Any
 
 import annofabapi
 import pandas
-from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_english_message
 
 import annofabcli.common.cli
 from annofabcli.annotation_specs.add_choice_attribute import ChoiceAttributeInput, build_choices, read_choices_json
-from annofabcli.annotation_specs.utils import get_attribute_name_en, get_target_choice_attribute
+from annofabcli.annotation_specs.utils import get_attribute_name_en
 from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login
 from annofabcli.common.facade import AnnofabApiFacade
 
@@ -102,8 +102,8 @@ def validate_added_choices(
         duplicated_text = ", ".join(sorted(duplicated_choice_ids))
         raise ValueError(f"追加先の属性に既に存在する `choice_id` が指定されています。 :: {duplicated_text}")
 
-    existing_choice_name_ens = {AnnofabApiFacade.get_choice_name_en(choice) for choice in existing_choices}
-    duplicated_choice_name_ens = existing_choice_name_ens & {AnnofabApiFacade.get_choice_name_en(choice) for choice in added_choices}
+    existing_choice_name_ens = {get_english_message(choice["name"]) for choice in existing_choices}
+    duplicated_choice_name_ens = existing_choice_name_ens & {get_english_message(choice["name"]) for choice in added_choices}
     if duplicated_choice_name_ens:
         duplicated_text = ", ".join(sorted(duplicated_choice_name_ens))
         raise ValueError(f"追加先の属性に既に存在する `choice_name_en` が指定されています。 :: {duplicated_text}")
@@ -176,11 +176,13 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
 
         old_annotation_specs, _ = self.service.api.get_annotation_specs(self.project_id, query_params={"v": "3"})
         annotation_specs_accessor = AnnotationSpecsAccessor(old_annotation_specs)
-        target_attribute = get_target_choice_attribute(
-            annotation_specs_accessor,
+        target_attribute = annotation_specs_accessor.get_attribute(
             attribute_id=attribute_id,
-            attribute_name_en=attribute_name_en,
+            attribute_name=attribute_name_en,
         )
+        if target_attribute["type"] not in ["choice", "select"]:
+            raise ValueError(f"属性ID='{target_attribute['additional_data_definition_id']}' は選択肢系属性ではありません。")
+
         validate_added_choices(
             target_attribute,
             added_choices=added_choices,
@@ -188,7 +190,7 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
 
         resolved_attribute_id = target_attribute["additional_data_definition_id"]
         resolved_attribute_name_en = get_attribute_name_en(target_attribute)
-        added_choice_name_ens = [AnnofabApiFacade.get_choice_name_en(choice) for choice in added_choices]
+        added_choice_name_ens = [get_english_message(choice["name"]) for choice in added_choices]
         confirm_message = f"属性名(英語)='{resolved_attribute_name_en}', 属性ID='{resolved_attribute_id}' に {len(added_choices)} 件の選択肢 {added_choice_name_ens} を追加します。よろしいですか？"
         if not self.confirm_processing(confirm_message):
             return False

--- a/annofabcli/annotation_specs/add_choices_to_attribute.py
+++ b/annofabcli/annotation_specs/add_choices_to_attribute.py
@@ -39,7 +39,7 @@ def create_comment_from_attribute(attribute_name_en: str, choice_name_ens: list[
 
 def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
     """
-    ``--choices_csv`` で指定されたCSVから選択肢一覧を読み込む。
+    ``--choice_csv`` で指定されたCSVから選択肢一覧を読み込む。
 
     ``add_choices_to_attribute`` ではデフォルト値を変更しないため、 ``is_default`` 列は読み込まない。
 
@@ -62,12 +62,12 @@ def read_choices_csv(csv_path: Path) -> list[ChoiceAttributeInput]:
             },
         )
     except Exception as e:
-        raise ValueError(f"`--choices_csv` の読み込みに失敗しました。 :: {e}") from e
+        raise ValueError(f"`--choice_csv` の読み込みに失敗しました。 :: {e}") from e
 
     required_columns = {"choice_name_en"}
     missing_columns = required_columns - set(df.columns)
     if missing_columns:
-        raise ValueError(f"`--choices_csv` に不足している必須列があります。 :: {sorted(missing_columns)}")
+        raise ValueError(f"`--choice_csv` に不足している必須列があります。 :: {sorted(missing_columns)}")
 
     return [
         ChoiceAttributeInput(
@@ -143,8 +143,8 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
         *,
         attribute_id: str | None,
         attribute_name_en: str | None,
-        choices_json: str | None,
-        choices_csv: Path | None,
+        choice_json: str | None,
+        choice_csv: Path | None,
         comment: str | None = None,
     ) -> bool:
         """
@@ -153,8 +153,8 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
         Args:
             attribute_id: 追加先属性ID
             attribute_name_en: 追加先属性英語名
-            choices_json: 追加する選択肢JSON
-            choices_csv: 追加する選択肢CSV
+            choice_json: 追加する選択肢JSON
+            choice_csv: 追加する選択肢CSV
             comment: 変更コメント
 
         Returns:
@@ -163,14 +163,14 @@ class AddChoicesToAttributeMain(CommandLineWithConfirm):
         Raises:
             ValueError: 入力値や既存アノテーション仕様との整合性が不正な場合
         """
-        if choices_json is not None:
-            choice_inputs = read_choices_json(choices_json)
-        elif choices_csv is not None:
-            if not choices_csv.exists():
-                raise ValueError(f"`--choices_csv` に指定されたファイルが存在しません。 :: {choices_csv}")
-            choice_inputs = read_choices_csv(choices_csv)
+        if choice_json is not None:
+            choice_inputs = read_choices_json(choice_json)
+        elif choice_csv is not None:
+            if not choice_csv.exists():
+                raise ValueError(f"`--choice_csv` に指定されたファイルが存在しません。 :: {choice_csv}")
+            choice_inputs = read_choices_csv(choice_csv)
         else:
-            raise ValueError("`--choices_json` または `--choices_csv` のいずれかを指定してください。")
+            raise ValueError("`--choice_json` または `--choice_csv` のいずれかを指定してください。")
 
         added_choices, _ = build_choices(ignore_default_choice_inputs(choice_inputs), min_count=1)
 
@@ -224,8 +224,8 @@ class AddChoicesToAttribute(CommandLine):
         obj.add_choices_to_attribute(
             attribute_id=args.attribute_id,
             attribute_name_en=args.attribute_name_en,
-            choices_json=args.choices_json,
-            choices_csv=args.choices_csv,
+            choice_json=args.choice_json,
+            choice_csv=args.choice_csv,
             comment=args.comment,
         )
 
@@ -250,12 +250,12 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     ]
     choice_group = parser.add_mutually_exclusive_group(required=True)
     choice_group.add_argument(
-        "--choices_json",
+        "--choice_json",
         type=str,
         help=f"追加する選択肢情報のJSON配列を指定します。 ``file://`` を先頭に付けるとJSON形式のファイルを指定できます。\n(例) ``{json.dumps(sample_json, ensure_ascii=False)}``",
     )
     choice_group.add_argument(
-        "--choices_csv",
+        "--choice_csv",
         type=Path,
         help=(
             "追加する選択肢情報のCSVファイルを指定します。 "

--- a/annofabcli/annotation_specs/add_existing_attribute.py
+++ b/annofabcli/annotation_specs/add_existing_attribute.py
@@ -256,7 +256,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         help="追加する既存属性の属性ID。複数指定できます。 ``file://`` を先頭に付けると一覧ファイルを指定できます。",
     )
 
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/add_label.py
+++ b/annofabcli/annotation_specs/add_label.py
@@ -309,7 +309,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--label_id", type=str, help="追加するラベルのlabel_id。未指定の場合はUUIDv4を自動生成します。")
     parser.add_argument("--label_name_ja", type=str, help="追加するラベルの日本語名。未指定の場合は英語名と同じ値を使用します。")
     parser.add_argument("--color", type=str, help="追加するラベルの色。 ``#RRGGBB`` 形式の16進数カラーコードを指定してください。未指定の場合は自動設定されます。")
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/add_labels.py
+++ b/annofabcli/annotation_specs/add_labels.py
@@ -171,7 +171,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         help="追加するラベルの英語名。複数指定できます。 ``file://`` を先頭に付けると一覧ファイルを指定できます。",
     )
     parser.add_argument("--annotation_type", type=str, required=True, choices=ANNOTATION_TYPE_CHOICES, help=create_annotation_type_help())
-    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更時に指定できるコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
 
     parser.set_defaults(subcommand_func=main)
 

--- a/annofabcli/annotation_specs/put_label_color.py
+++ b/annofabcli/annotation_specs/put_label_color.py
@@ -124,7 +124,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--comment",
         type=str,
-        help=("変更内容のコメントを指定してください。未指定の場合、自動でコメントが生成されます。"),
+        help=("アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。"),
     )
 
     parser.set_defaults(subcommand_func=main)

--- a/annofabcli/annotation_specs/subcommand_annotation_specs.py
+++ b/annofabcli/annotation_specs/subcommand_annotation_specs.py
@@ -3,6 +3,7 @@ import argparse
 import annofabcli.annotation_specs.add_attribute
 import annofabcli.annotation_specs.add_attribute_restriction
 import annofabcli.annotation_specs.add_choice_attribute
+import annofabcli.annotation_specs.add_choices_to_attribute
 import annofabcli.annotation_specs.add_existing_attribute
 import annofabcli.annotation_specs.add_label
 import annofabcli.annotation_specs.add_labels
@@ -28,6 +29,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.annotation_specs.add_attribute.add_parser(subparsers)
     annofabcli.annotation_specs.add_attribute_restriction.add_parser(subparsers)
     annofabcli.annotation_specs.add_choice_attribute.add_parser(subparsers)
+    annofabcli.annotation_specs.add_choices_to_attribute.add_parser(subparsers)
     annofabcli.annotation_specs.add_existing_attribute.add_parser(subparsers)
     annofabcli.annotation_specs.add_label.add_parser(subparsers)
     annofabcli.annotation_specs.add_labels.add_parser(subparsers)

--- a/annofabcli/annotation_specs/utils.py
+++ b/annofabcli/annotation_specs/utils.py
@@ -39,12 +39,12 @@ def get_target_choice_attribute(
     attribute_name_en: str | None,
 ) -> dict[str, Any]:
     """
-    CLI引数で指定された属性IDまたは属性名から選択肢系属性を取得する。
+    属性IDまたは属性名から選択肢系属性を取得する。
 
     Args:
         annotation_specs_accessor: アノテーション仕様アクセサ
-        attribute_id: 指定された属性ID
-        attribute_name_en: 指定された属性英語名
+        attribute_id: 対象属性ID
+        attribute_name_en: 対象属性英語名
 
     Returns:
         対象の選択肢系属性
@@ -53,7 +53,7 @@ def get_target_choice_attribute(
         ValueError: 属性指定が不正、属性が見つからない、属性名が曖昧、または選択肢系属性でない場合
     """
     if (attribute_id is None) == (attribute_name_en is None):
-        raise ValueError("追加先の属性は `attribute_id` または `attribute_name_en` のどちらか一方だけ指定してください。")
+        raise ValueError("対象属性は `attribute_id` または `attribute_name_en` のどちらか一方だけ指定してください。")
 
     if attribute_id is not None:
         attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_id)

--- a/annofabcli/annotation_specs/utils.py
+++ b/annofabcli/annotation_specs/utils.py
@@ -32,6 +32,41 @@ def get_attribute_name_en(attribute: dict[str, Any]) -> str:
     return get_english_message(attribute["name"])
 
 
+def get_target_choice_attribute(
+    annotation_specs_accessor: AnnotationSpecsAccessor,
+    *,
+    attribute_id: str | None,
+    attribute_name_en: str | None,
+) -> dict[str, Any]:
+    """
+    CLI引数で指定された属性IDまたは属性名から選択肢系属性を取得する。
+
+    Args:
+        annotation_specs_accessor: アノテーション仕様アクセサ
+        attribute_id: 指定された属性ID
+        attribute_name_en: 指定された属性英語名
+
+    Returns:
+        対象の選択肢系属性
+
+    Raises:
+        ValueError: 属性指定が不正、属性が見つからない、属性名が曖昧、または選択肢系属性でない場合
+    """
+    if (attribute_id is None) == (attribute_name_en is None):
+        raise ValueError("追加先の属性は `attribute_id` または `attribute_name_en` のどちらか一方だけ指定してください。")
+
+    if attribute_id is not None:
+        attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_id)
+    else:
+        assert attribute_name_en is not None
+        attribute = annotation_specs_accessor.get_attribute(attribute_name=attribute_name_en)
+
+    if attribute["type"] not in ["choice", "select"]:
+        raise ValueError(f"属性ID='{attribute['additional_data_definition_id']}' は選択肢系属性ではありません。")
+
+    return attribute
+
+
 def create_name(message_en: str, message_ja: str | None = None) -> dict[str, Any]:
     """
     Annofabの多言語メッセージ形式を生成する。

--- a/docs/command_reference/annotation_specs/add_choice_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choice_attribute.rst
@@ -4,7 +4,7 @@ annotation_specs add_choice_attribute
 
 Description
 =================================
-アノテーション仕様に ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の選択肢系属性を追加し、指定したラベルへ紐付けます。
+アノテーション仕様にの選択肢系属性（ラジオボタン/ドロップダウン）を追加し、指定したラベルへ紐付けます。
 
 
 Examples
@@ -18,15 +18,13 @@ JSON形式で指定する場合
 
     [
         {
-            "choice_id": "front",
             "choice_name_en": "front",
-            "choice_name_ja": "前",
-            "is_default": true
         },
         {
+            "choice_id": "c2",
             "choice_name_en": "rear",
             "choice_name_ja": "後ろ",
-            "is_default": false
+            "is_default": true
         }
     ]
 
@@ -48,8 +46,8 @@ CSV形式で指定する場合
     :caption: choices.csv
 
     choice_id,choice_name_en,choice_name_ja,is_default
-    front,front,前,true
-    rear,rear,後ろ,false
+    ,front,,
+    c2,rear,後ろ,true
 
 
 .. code-block::

--- a/docs/command_reference/annotation_specs/add_choice_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choice_attribute.rst
@@ -5,6 +5,7 @@ annotation_specs add_choice_attribute
 Description
 =================================
 アノテーション仕様に ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の選択肢系属性を追加し、指定したラベルへ紐付けます。
+指定する選択肢の ``choice_id`` と ``choice_name_en`` は、それぞれユニークである必要があります。
 
 
 Examples

--- a/docs/command_reference/annotation_specs/add_choice_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choice_attribute.rst
@@ -5,7 +5,6 @@ annotation_specs add_choice_attribute
 Description
 =================================
 アノテーション仕様に ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の選択肢系属性を追加し、指定したラベルへ紐付けます。
-指定する選択肢の ``choice_id`` と ``choice_name_en`` は、それぞれユニークである必要があります。
 
 
 Examples

--- a/docs/command_reference/annotation_specs/add_choice_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choice_attribute.rst
@@ -37,7 +37,7 @@ JSON形式で指定する場合
      --project_id prj1 \
      --attribute_type choice \
      --attribute_name_en direction \
-     --choices_json file://choices.json \
+     --choice_json file://choices.json \
      --label_name_en car bus \
 
 
@@ -58,7 +58,7 @@ CSV形式で指定する場合
      --project_id prj1 \
      --attribute_type select \
      --attribute_name_en direction \
-     --choices_csv choices.csv \
+     --choice_csv choices.csv \
      --label_id l1 l2
 
 

--- a/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
@@ -1,0 +1,68 @@
+==========================================
+annotation_specs add_choices_to_attribute
+==========================================
+
+Description
+=================================
+既存の ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の属性に、選択肢を追加します。
+指定する選択肢の ``choice_id`` と ``choice_name_en`` は、それぞれユニークである必要があります。
+
+
+Examples
+=================================
+
+JSON形式で指定する場合
+----------------------------------------------
+
+.. code-block:: json
+    :caption: choices.json
+
+    [
+        {
+            "choice_id": "xlarge",
+            "choice_name_en": "xlarge",
+            "choice_name_ja": "特大"
+        },
+        {
+            "choice_id": "tiny",
+            "choice_name_en": "tiny",
+            "choice_name_ja": "極小"
+        }
+    ]
+
+
+.. code-block::
+
+    $ annofabcli annotation_specs add_choices_to_attribute \
+     --project_id prj1 \
+     --attribute_name_en type \
+     --choices_json file://choices.json
+
+
+CSV形式で指定する場合
+----------------------------------------------
+
+.. code-block::
+    :caption: choices.csv
+
+    choice_id,choice_name_en,choice_name_ja,is_default
+    xlarge,xlarge,特大,false
+    tiny,tiny,極小,false
+
+
+.. code-block::
+
+    $ annofabcli annotation_specs add_choices_to_attribute \
+     --project_id prj1 \
+     --attribute_id 71620647-98cf-48ad-b43b-4af425a24f32 \
+     --choices_csv choices.csv
+
+
+Usage Details
+=================================
+
+.. argparse::
+    :ref: annofabcli.annotation_specs.add_choices_to_attribute.add_parser
+    :prog: annofabcli annotation_specs add_choices_to_attribute
+    :nosubcommands:
+    :nodefaultconst:

--- a/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
@@ -4,9 +4,7 @@ annotation_specs add_choices_to_attribute
 
 Description
 =================================
-既存の ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の属性に、選択肢を追加します。
-指定する選択肢の ``choice_id`` と ``choice_name_en`` は、それぞれユニークである必要があります。
-このコマンドではデフォルト値を変更しません。 ``is_default`` が指定されていても無視されます。
+既存の選択肢系属性（ラジオボタン/ドロップダウン）に、選択肢を追加します。
 
 
 Examples
@@ -20,12 +18,10 @@ JSON形式で指定する場合
 
     [
         {
-            "choice_id": "xlarge",
             "choice_name_en": "xlarge",
-            "choice_name_ja": "特大"
         },
         {
-            "choice_id": "tiny",
+            "choice_id": "c2",
             "choice_name_en": "tiny",
             "choice_name_ja": "極小"
         }
@@ -47,8 +43,8 @@ CSV形式で指定する場合
     :caption: choices.csv
 
     choice_id,choice_name_en,choice_name_ja
-    xlarge,xlarge,特大
-    tiny,tiny,極小
+    ,xlarge
+    c2,tiny,極小
 
 
 .. code-block::

--- a/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
@@ -43,7 +43,7 @@ CSV形式で指定する場合
     :caption: choices.csv
 
     choice_id,choice_name_en,choice_name_ja
-    ,xlarge
+    ,xlarge,
     c2,tiny,極小
 
 

--- a/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
@@ -6,6 +6,7 @@ Description
 =================================
 既存の ``choice`` （ラジオボタン）または ``select`` （ドロップダウン）の属性に、選択肢を追加します。
 指定する選択肢の ``choice_id`` と ``choice_name_en`` は、それぞれユニークである必要があります。
+このコマンドではデフォルト値を変更しません。 ``is_default`` が指定されていても無視されます。
 
 
 Examples
@@ -45,9 +46,9 @@ CSV形式で指定する場合
 .. code-block::
     :caption: choices.csv
 
-    choice_id,choice_name_en,choice_name_ja,is_default
-    xlarge,xlarge,特大,false
-    tiny,tiny,極小,false
+    choice_id,choice_name_en,choice_name_ja
+    xlarge,xlarge,特大
+    tiny,tiny,極小
 
 
 .. code-block::

--- a/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
+++ b/docs/command_reference/annotation_specs/add_choices_to_attribute.rst
@@ -37,7 +37,7 @@ JSON形式で指定する場合
     $ annofabcli annotation_specs add_choices_to_attribute \
      --project_id prj1 \
      --attribute_name_en type \
-     --choices_json file://choices.json
+     --choice_json file://choices.json
 
 
 CSV形式で指定する場合
@@ -56,7 +56,7 @@ CSV形式で指定する場合
     $ annofabcli annotation_specs add_choices_to_attribute \
      --project_id prj1 \
      --attribute_id 71620647-98cf-48ad-b43b-4af425a24f32 \
-     --choices_csv choices.csv
+     --choice_csv choices.csv
 
 
 Usage Details

--- a/docs/command_reference/annotation_specs/index.rst
+++ b/docs/command_reference/annotation_specs/index.rst
@@ -18,6 +18,7 @@ Available Commands
    add_attribute
    add_attribute_restriction
    add_choice_attribute
+   add_choices_to_attribute
    add_existing_attribute
    add_label
    add_labels

--- a/tests/annotation_specs/test_add_choice_attribute.py
+++ b/tests/annotation_specs/test_add_choice_attribute.py
@@ -82,11 +82,6 @@ class TestReadChoicesJson:
         with pytest.raises(ValueError):
             build_choices(choices)
 
-    def test_build_choices__duplicated_choice_name_en(self) -> None:
-        choices = read_choices_json('[{"choice_id":"front-1","choice_name_en":"front"},{"choice_id":"front-2","choice_name_en":"front"}]')
-        with pytest.raises(ValueError):
-            build_choices(choices)
-
     def test_build_choices__multiple_default(self) -> None:
         choices = read_choices_json('[{"choice_name_en":"front","is_default":true},{"choice_name_en":"rear","is_default":true}]')
         with pytest.raises(ValueError):

--- a/tests/annotation_specs/test_add_choice_attribute.py
+++ b/tests/annotation_specs/test_add_choice_attribute.py
@@ -82,6 +82,11 @@ class TestReadChoicesJson:
         with pytest.raises(ValueError):
             build_choices(choices)
 
+    def test_build_choices__duplicated_choice_name_en(self) -> None:
+        choices = read_choices_json('[{"choice_id":"front-1","choice_name_en":"front"},{"choice_id":"front-2","choice_name_en":"front"}]')
+        with pytest.raises(ValueError):
+            build_choices(choices)
+
     def test_build_choices__multiple_default(self) -> None:
         choices = read_choices_json('[{"choice_name_en":"front","is_default":true},{"choice_name_en":"rear","is_default":true}]')
         with pytest.raises(ValueError):

--- a/tests/annotation_specs/test_add_choices_to_attribute.py
+++ b/tests/annotation_specs/test_add_choices_to_attribute.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from annofabcli.annotation_specs import add_choices_to_attribute
+from annofabcli.annotation_specs.add_choices_to_attribute import AddChoicesToAttributeMain
+
+data_dir = Path("./tests/data/annotation_specs")
+
+
+@pytest.fixture
+def annotation_specs() -> dict:
+    with (data_dir / "annotation_specs.json").open(encoding="utf-8") as f:
+        loaded_annotation_specs = json.load(f)
+    loaded_annotation_specs["updated_datetime"] = "2026-04-24T00:00:00+09:00"
+    return loaded_annotation_specs
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand_name", required=True)
+    add_choices_to_attribute.add_parser(subparsers)
+    return parser
+
+
+class DummyApi:
+    def __init__(self, annotation_specs: dict) -> None:
+        self.annotation_specs = copy.deepcopy(annotation_specs)
+        self.last_put: dict | None = None
+
+    def get_annotation_specs(self, project_id: str, query_params: dict) -> tuple[dict, None]:
+        assert project_id == "prj1"
+        assert query_params == {"v": "3"}
+        return copy.deepcopy(self.annotation_specs), None
+
+    def put_annotation_specs(self, project_id: str, query_params: dict, request_body: dict) -> None:
+        assert project_id == "prj1"
+        assert query_params == {"v": "3"}
+        self.last_put = request_body
+
+
+class DummyService:
+    def __init__(self, annotation_specs: dict) -> None:
+        self.api = DummyApi(annotation_specs)
+
+
+class TestAddChoicesToAttributeMain:
+    def test_add_choices_to_attribute__attribute_id(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        result = main.add_choices_to_attribute(
+            attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
+            attribute_name_en=None,
+            choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","choice_name_ja":"特大"},{"choice_id":"tiny","choice_name_en":"tiny","choice_name_ja":"極小"}]',
+            choices_csv=None,
+            comment=None,
+        )
+
+        assert result is True
+        assert service.api.last_put is not None
+        updated_attribute = next(attribute for attribute in service.api.last_put["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
+        assert [choice["choice_id"] for choice in updated_attribute["choices"][-2:]] == ["xlarge", "tiny"]
+        assert updated_attribute["default"] == ""
+        assert service.api.last_put["comment"].startswith("以下の選択肢を属性に追加しました。")
+
+    def test_add_choices_to_attribute__attribute_name_and_default(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        result = main.add_choices_to_attribute(
+            attribute_id=None,
+            attribute_name_en="type",
+            choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
+            choices_csv=None,
+            comment="custom",
+        )
+
+        assert result is True
+        assert service.api.last_put is not None
+        updated_attribute = next(attribute for attribute in service.api.last_put["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
+        assert updated_attribute["default"] == "xlarge"
+        assert service.api.last_put["comment"] == "custom"
+
+    def test_add_choices_to_attribute__duplicated_existing_choice_id(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        with pytest.raises(ValueError):
+            main.add_choices_to_attribute(
+                attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
+                attribute_name_en=None,
+                choices_json='[{"choice_id":"08ec927c-18e6-4bba-837a-b16de7061580","choice_name_en":"xlarge"}]',
+                choices_csv=None,
+            )
+
+    def test_add_choices_to_attribute__duplicated_existing_choice_name_en(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        with pytest.raises(ValueError):
+            main.add_choices_to_attribute(
+                attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
+                attribute_name_en=None,
+                choices_json='[{"choice_id":"xlarge","choice_name_en":"large"}]',
+                choices_csv=None,
+            )
+
+    def test_add_choices_to_attribute__attribute_not_choice(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        with pytest.raises(ValueError):
+            main.add_choices_to_attribute(
+                attribute_id="54fa5e97-6f88-49a4-aeb0-a91a15d11528",
+                attribute_name_en=None,
+                choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge"}]',
+                choices_csv=None,
+            )
+
+    def test_add_choices_to_attribute__default_already_exists(self, annotation_specs: dict) -> None:
+        duplicated_specs = copy.deepcopy(annotation_specs)
+        target_attribute = next(attribute for attribute in duplicated_specs["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
+        target_attribute["default"] = "08ec927c-18e6-4bba-837a-b16de7061580"
+        service = DummyService(duplicated_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        with pytest.raises(ValueError):
+            main.add_choices_to_attribute(
+                attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
+                attribute_name_en=None,
+                choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
+                choices_csv=None,
+            )

--- a/tests/annotation_specs/test_add_choices_to_attribute.py
+++ b/tests/annotation_specs/test_add_choices_to_attribute.py
@@ -69,7 +69,7 @@ class TestAddChoicesToAttributeMain:
         assert updated_attribute["default"] == ""
         assert service.api.last_put["comment"].startswith("以下の選択肢を属性に追加しました。")
 
-    def test_add_choices_to_attribute__attribute_name_and_default(self, annotation_specs: dict) -> None:
+    def test_add_choices_to_attribute__attribute_name_and_ignore_default(self, annotation_specs: dict) -> None:
         service = DummyService(annotation_specs)
         main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
 
@@ -84,8 +84,26 @@ class TestAddChoicesToAttributeMain:
         assert result is True
         assert service.api.last_put is not None
         updated_attribute = next(attribute for attribute in service.api.last_put["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
-        assert updated_attribute["default"] == "xlarge"
+        assert updated_attribute["default"] == ""
         assert service.api.last_put["comment"] == "custom"
+
+    def test_add_choices_to_attribute__ignore_default_in_csv(self, annotation_specs: dict, tmp_path: Path) -> None:
+        csv_path = tmp_path / "choices.csv"
+        csv_path.write_text("choice_id,choice_name_en,is_default\nxlarge,xlarge,true\n", encoding="utf-8")
+        service = DummyService(annotation_specs)
+        main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
+
+        result = main.add_choices_to_attribute(
+            attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
+            attribute_name_en=None,
+            choices_json=None,
+            choices_csv=csv_path,
+        )
+
+        assert result is True
+        assert service.api.last_put is not None
+        updated_attribute = next(attribute for attribute in service.api.last_put["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
+        assert updated_attribute["default"] == ""
 
     def test_add_choices_to_attribute__duplicated_existing_choice_id(self, annotation_specs: dict) -> None:
         service = DummyService(annotation_specs)
@@ -123,17 +141,21 @@ class TestAddChoicesToAttributeMain:
                 choices_csv=None,
             )
 
-    def test_add_choices_to_attribute__default_already_exists(self, annotation_specs: dict) -> None:
+    def test_add_choices_to_attribute__ignore_default_when_default_already_exists(self, annotation_specs: dict) -> None:
         duplicated_specs = copy.deepcopy(annotation_specs)
         target_attribute = next(attribute for attribute in duplicated_specs["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
         target_attribute["default"] = "08ec927c-18e6-4bba-837a-b16de7061580"
         service = DummyService(duplicated_specs)
         main = AddChoicesToAttributeMain(service, project_id="prj1", all_yes=True)  # type: ignore
 
-        with pytest.raises(ValueError):
-            main.add_choices_to_attribute(
-                attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
-                attribute_name_en=None,
-                choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
-                choices_csv=None,
-            )
+        result = main.add_choices_to_attribute(
+            attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
+            attribute_name_en=None,
+            choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
+            choices_csv=None,
+        )
+
+        assert result is True
+        assert service.api.last_put is not None
+        updated_attribute = next(attribute for attribute in service.api.last_put["additionals"] if attribute["additional_data_definition_id"] == "71620647-98cf-48ad-b43b-4af425a24f32")
+        assert updated_attribute["default"] == "08ec927c-18e6-4bba-837a-b16de7061580"

--- a/tests/annotation_specs/test_add_choices_to_attribute.py
+++ b/tests/annotation_specs/test_add_choices_to_attribute.py
@@ -57,8 +57,8 @@ class TestAddChoicesToAttributeMain:
         result = main.add_choices_to_attribute(
             attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
             attribute_name_en=None,
-            choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","choice_name_ja":"特大"},{"choice_id":"tiny","choice_name_en":"tiny","choice_name_ja":"極小"}]',
-            choices_csv=None,
+            choice_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","choice_name_ja":"特大"},{"choice_id":"tiny","choice_name_en":"tiny","choice_name_ja":"極小"}]',
+            choice_csv=None,
             comment=None,
         )
 
@@ -76,8 +76,8 @@ class TestAddChoicesToAttributeMain:
         result = main.add_choices_to_attribute(
             attribute_id=None,
             attribute_name_en="type",
-            choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
-            choices_csv=None,
+            choice_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
+            choice_csv=None,
             comment="custom",
         )
 
@@ -96,8 +96,8 @@ class TestAddChoicesToAttributeMain:
         result = main.add_choices_to_attribute(
             attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
             attribute_name_en=None,
-            choices_json=None,
-            choices_csv=csv_path,
+            choice_json=None,
+            choice_csv=csv_path,
         )
 
         assert result is True
@@ -113,8 +113,8 @@ class TestAddChoicesToAttributeMain:
             main.add_choices_to_attribute(
                 attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
                 attribute_name_en=None,
-                choices_json='[{"choice_id":"08ec927c-18e6-4bba-837a-b16de7061580","choice_name_en":"xlarge"}]',
-                choices_csv=None,
+                choice_json='[{"choice_id":"08ec927c-18e6-4bba-837a-b16de7061580","choice_name_en":"xlarge"}]',
+                choice_csv=None,
             )
 
     def test_add_choices_to_attribute__duplicated_existing_choice_name_en(self, annotation_specs: dict) -> None:
@@ -125,8 +125,8 @@ class TestAddChoicesToAttributeMain:
             main.add_choices_to_attribute(
                 attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
                 attribute_name_en=None,
-                choices_json='[{"choice_id":"xlarge","choice_name_en":"large"}]',
-                choices_csv=None,
+                choice_json='[{"choice_id":"xlarge","choice_name_en":"large"}]',
+                choice_csv=None,
             )
 
     def test_add_choices_to_attribute__attribute_not_choice(self, annotation_specs: dict) -> None:
@@ -137,8 +137,8 @@ class TestAddChoicesToAttributeMain:
             main.add_choices_to_attribute(
                 attribute_id="54fa5e97-6f88-49a4-aeb0-a91a15d11528",
                 attribute_name_en=None,
-                choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge"}]',
-                choices_csv=None,
+                choice_json='[{"choice_id":"xlarge","choice_name_en":"xlarge"}]',
+                choice_csv=None,
             )
 
     def test_add_choices_to_attribute__ignore_default_when_default_already_exists(self, annotation_specs: dict) -> None:
@@ -151,8 +151,8 @@ class TestAddChoicesToAttributeMain:
         result = main.add_choices_to_attribute(
             attribute_id="71620647-98cf-48ad-b43b-4af425a24f32",
             attribute_name_en=None,
-            choices_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
-            choices_csv=None,
+            choice_json='[{"choice_id":"xlarge","choice_name_en":"xlarge","is_default":true}]',
+            choice_csv=None,
         )
 
         assert result is True


### PR DESCRIPTION
## Summary
- reject duplicated choice_name_en values in add_choice_attribute input
- keep documenting that choice_id and choice_name_en must be unique
- add a regression test for duplicated choice_name_en

## Testing
- make format
- make lint
- uv run pytest tests/annotation_specs/test_add_choice_attribute.py