### PR TITLE
`annotation_specs add_label`: セグメンテーションを追加したときのfield_valuesの挙動を変更

### DIFF
--- a/annofabcli/annotation_specs/add_label.py
+++ b/annofabcli/annotation_specs/add_label.py
@@ -102,6 +102,27 @@ AUTO_COLOR_PALETTE_HEX: list[str] = [
 """自動色選択で優先する高彩度のカラーパレット。"""
 
 
+SEGMENTATION_ANNOTATION_TYPES = {
+    DefaultAnnotationType.SEGMENTATION.value,
+    DefaultAnnotationType.SEGMENTATION_V2.value,
+}
+"""柔軟な編集用の既定 field_values を適用するアノテーション種類。"""
+
+
+DEFAULT_SEGMENTATION_FIELD_VALUES: dict[str, Any] = {
+    "annotation_editor_feature": {
+        "_type": "AnnotationEditorFeature",
+        "append": True,
+        "erase": True,
+        "fill_near": True,
+        "freehand": True,
+        "polygon_fill": True,
+        "rectangle_fill": True,
+    }
+}
+"""セグメンテーション系ラベルに対して既定で付与する field_values。"""
+
+
 def create_comment_from_label(label_name_en: str) -> str:
     """
     ラベル追加時のデフォルトコメントを生成する。
@@ -114,6 +135,33 @@ def create_comment_from_label(label_name_en: str) -> str:
         アノテーション仕様変更コメント
     """
     return f"以下のラベルを追加しました。\nラベル名(英語): {label_name_en}"
+
+
+def create_label_field_values(*, annotation_type: str, field_values: dict[str, Any] | None) -> dict[str, Any]:
+    """
+    ラベル追加時に設定する field_values を生成する。
+
+    Args:
+        annotation_type: ラベルのアノテーション種類
+        field_values: 入力された field_values
+
+    Returns:
+        新規ラベルに設定する field_values
+    """
+    actual_field_values = copy.deepcopy(field_values) if field_values is not None else {}
+    if annotation_type not in SEGMENTATION_ANNOTATION_TYPES:
+        return actual_field_values
+
+    merged_field_values = copy.deepcopy(DEFAULT_SEGMENTATION_FIELD_VALUES)
+    for key, value in actual_field_values.items():
+        if key == "annotation_editor_feature" and isinstance(value, dict):
+            merged_annotation_editor_feature = copy.deepcopy(DEFAULT_SEGMENTATION_FIELD_VALUES["annotation_editor_feature"])
+            merged_annotation_editor_feature.update(value)
+            merged_field_values[key] = merged_annotation_editor_feature
+            continue
+
+        merged_field_values[key] = value
+    return merged_field_values
 
 
 def validate_new_label(labels: Collection[dict[str, Any]], *, label_id: str, label_name_en: str) -> None:
@@ -221,7 +269,7 @@ def create_new_label(
         "color": color,
         # 以下はキーが存在しないとAPIエラーになるため、空の値を入れておく
         "keybind": [],
-        "field_values": copy.deepcopy(field_values) if field_values is not None else {},
+        "field_values": create_label_field_values(annotation_type=annotation_type, field_values=field_values),
         "additional_data_definitions": [],
     }
 

--- a/annofabcli/annotation_specs/add_label.py
+++ b/annofabcli/annotation_specs/add_label.py
@@ -153,14 +153,7 @@ def create_label_field_values(*, annotation_type: str, field_values: dict[str, A
         return actual_field_values
 
     merged_field_values = copy.deepcopy(DEFAULT_SEGMENTATION_FIELD_VALUES)
-    for key, value in actual_field_values.items():
-        if key == "annotation_editor_feature" and isinstance(value, dict):
-            merged_annotation_editor_feature = copy.deepcopy(DEFAULT_SEGMENTATION_FIELD_VALUES["annotation_editor_feature"])
-            merged_annotation_editor_feature.update(value)
-            merged_field_values[key] = merged_annotation_editor_feature
-            continue
-
-        merged_field_values[key] = value
+    merged_field_values.update(actual_field_values)
     return merged_field_values
 
 

--- a/tests/annotation_specs/test_add_label.py
+++ b/tests/annotation_specs/test_add_label.py
@@ -9,7 +9,12 @@ from pathlib import Path
 import pytest
 
 from annofabcli.annotation_specs import add_label
-from annofabcli.annotation_specs.add_label import AUTO_COLOR_PALETTE_HEX, AddLabelMain, create_auto_color
+from annofabcli.annotation_specs.add_label import (
+    AUTO_COLOR_PALETTE_HEX,
+    DEFAULT_SEGMENTATION_FIELD_VALUES,
+    AddLabelMain,
+    create_auto_color,
+)
 from annofabcli.annotation_specs.color import RgbColor, hex_to_rgb
 
 data_dir = Path("./tests/data/annotation_specs")
@@ -179,6 +184,86 @@ class TestAddLabelMain:
             "display_name": {
                 "_type": "DisplayName",
                 "text": "歩行者",
+            }
+        }
+
+    def test_add_label__segmentation_has_default_field_values(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddLabelMain(service, project_id="prj1", all_yes=True)  # type: ignore[arg-type]
+
+        main.add_label(
+            label_name_en="road",
+            annotation_type="segmentation",
+            label_id="road_label_id",
+            label_name_ja=None,
+            color_code="#00CCFF",
+            field_values=None,
+            comment=None,
+        )
+
+        assert service.api.last_put is not None
+        added_label = service.api.last_put["labels"][-1]
+        assert added_label["field_values"] == DEFAULT_SEGMENTATION_FIELD_VALUES
+
+    def test_add_label__segmentation_v2_merges_default_field_values(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddLabelMain(service, project_id="prj1", all_yes=True)  # type: ignore[arg-type]
+
+        main.add_label(
+            label_name_en="road",
+            annotation_type="segmentation_v2",
+            label_id="road_label_id",
+            label_name_ja=None,
+            color_code="#00CCFF",
+            field_values={
+                "display_name": {
+                    "_type": "DisplayName",
+                    "text": "路面",
+                }
+            },
+            comment=None,
+        )
+
+        assert service.api.last_put is not None
+        added_label = service.api.last_put["labels"][-1]
+        assert added_label["field_values"] == {
+            **DEFAULT_SEGMENTATION_FIELD_VALUES,
+            "display_name": {
+                "_type": "DisplayName",
+                "text": "路面",
+            },
+        }
+
+    def test_add_label__segmentation_merges_partial_annotation_editor_feature(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddLabelMain(service, project_id="prj1", all_yes=True)  # type: ignore[arg-type]
+
+        main.add_label(
+            label_name_en="road",
+            annotation_type="segmentation",
+            label_id="road_label_id",
+            label_name_ja=None,
+            color_code="#00CCFF",
+            field_values={
+                "annotation_editor_feature": {
+                    "_type": "AnnotationEditorFeature",
+                    "append": False,
+                }
+            },
+            comment=None,
+        )
+
+        assert service.api.last_put is not None
+        added_label = service.api.last_put["labels"][-1]
+        assert added_label["field_values"] == {
+            "annotation_editor_feature": {
+                "_type": "AnnotationEditorFeature",
+                "append": False,
+                "erase": True,
+                "fill_near": True,
+                "freehand": True,
+                "polygon_fill": True,
+                "rectangle_fill": True,
             }
         }
 

--- a/tests/annotation_specs/test_add_label.py
+++ b/tests/annotation_specs/test_add_label.py
@@ -234,7 +234,7 @@ class TestAddLabelMain:
             },
         }
 
-    def test_add_label__segmentation_merges_partial_annotation_editor_feature(self, annotation_specs: dict) -> None:
+    def test_add_label__segmentation_overwrites_annotation_editor_feature(self, annotation_specs: dict) -> None:
         service = DummyService(annotation_specs)
         main = AddLabelMain(service, project_id="prj1", all_yes=True)  # type: ignore[arg-type]
 
@@ -259,11 +259,6 @@ class TestAddLabelMain:
             "annotation_editor_feature": {
                 "_type": "AnnotationEditorFeature",
                 "append": False,
-                "erase": True,
-                "fill_near": True,
-                "freehand": True,
-                "polygon_fill": True,
-                "rectangle_fill": True,
             }
         }
 

--- a/tests/annotation_specs/test_add_labels.py
+++ b/tests/annotation_specs/test_add_labels.py
@@ -9,6 +9,7 @@ import pandas
 import pytest
 
 from annofabcli.annotation_specs import add_labels
+from annofabcli.annotation_specs.add_label import DEFAULT_SEGMENTATION_FIELD_VALUES
 from annofabcli.annotation_specs.add_labels import (
     AddLabelsMain,
     LabelInput,
@@ -160,6 +161,21 @@ class TestAddLabelsMain:
 
         assert result is False
         assert service.api.last_put is None
+
+    def test_add_labels__segmentation_has_default_field_values(self, annotation_specs: dict) -> None:
+        service = DummyService(annotation_specs)
+        main = AddLabelsMain(service, project_id="prj1", all_yes=True)  # type: ignore[arg-type]
+
+        main.add_labels(
+            label_inputs=[LabelInput(label_name_en="road"), LabelInput(label_name_en="sidewalk")],
+            annotation_type="segmentation_v2",
+            comment=None,
+        )
+
+        assert service.api.last_put is not None
+        added_labels = service.api.last_put["labels"][-2:]
+        assert added_labels[0]["field_values"] == DEFAULT_SEGMENTATION_FIELD_VALUES
+        assert added_labels[1]["field_values"] == DEFAULT_SEGMENTATION_FIELD_VALUES
 
 
 class TestReadLabels:


### PR DESCRIPTION
## 概要
- segmentation / segmentation_v2 のラベル追加時に annotation_editor_feature を field_values の既定値として設定
- add_label と add_labels の両方に同じ既定値補完を適用
- セグメンテーション系の既定値付与とマージ挙動のテストを追加

## 動作確認
- make format
- make lint
- uv run pytest tests/annotation_specs/test_add_label.py tests/annotation_specs/test_add_labels.py