### PR TITLE
AnnofabApiFacadeのアノテーション仕様に関する関数を削除

### DIFF
--- a/annofabcli/annotation_specs/attribute_restriction.py
+++ b/annofabcli/annotation_specs/attribute_restriction.py
@@ -3,9 +3,8 @@ from collections.abc import Collection
 from enum import Enum
 from typing import Any
 
+from annofabapi.util.annotation_specs import get_attribute_name_en, get_choice_name_en, get_label_name_en
 from more_itertools import first_true
-
-from annofabcli.common.facade import AnnofabApiFacade
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +58,7 @@ class AttributeRestrictionMessage:
         for label_id in label_ids:
             label = self.label_dict.get(label_id)
             if label is not None:
-                label_name = AnnofabApiFacade.get_label_name_en(label)
+                label_name = get_label_name_en(label)
             else:
                 logger.warning(f"ラベルIDが'{label_id}'であるラベルは存在しません。")
                 if self.raise_if_not_found:
@@ -94,18 +93,14 @@ class AttributeRestrictionMessage:
             choice = first_true(choices, pred=lambda e: e["choice_id"] == value)
             if value == "" or choice is not None:
                 # `value == ""`を判定条件に加える理由：「排他選択属性が空である/空でない」という制約の場合、`value`は空文字列になるため。
-                choice_name = AnnofabApiFacade.get_choice_name_en(choice) if choice is not None else ""
+                choice_name = get_choice_name_en(choice) if choice is not None else ""
                 tmp = f"'{choice_name}'"
                 if self.output_format == OutputFormat.DETAILED_TEXT:
                     tmp = f"{tmp} (id='{value}')"
                 return tmp
 
             else:
-                message = (
-                    f"選択肢IDが'{value}'である選択肢は存在しません。 :: "
-                    f"属性名='{AnnofabApiFacade.get_additional_data_definition_name_en(attribute)}', "
-                    f"属性ID='{attribute['additional_data_definition_id']}'"
-                )
+                message = f"選択肢IDが'{value}'である選択肢は存在しません。 :: 属性名='{get_attribute_name_en(attribute)}', 属性ID='{attribute['additional_data_definition_id']}'"
                 logger.warning(message)
                 if self.raise_if_not_found:
                     raise ValueError(message)
@@ -134,7 +129,7 @@ class AttributeRestrictionMessage:
 
         attribute = self.attribute_dict.get(attribute_id)
         if attribute is not None:
-            subject = f"'{AnnofabApiFacade.get_additional_data_definition_name_en(attribute)}'"
+            subject = f"'{get_attribute_name_en(attribute)}'"
             if self.output_format == OutputFormat.DETAILED_TEXT:
                 subject = f"{subject} (id='{attribute_id}', type='{attribute['type']}')"
         else:
@@ -178,7 +173,7 @@ class AttributeRestrictionMessage:
         return tmp
 
     def get_attribute_from_name(self, attribute_name: str) -> dict[str, Any] | None:
-        tmp = [attribute for attribute in self.attribute_dict.values() if AnnofabApiFacade.get_additional_data_definition_name_en(attribute) == attribute_name]
+        tmp = [attribute for attribute in self.attribute_dict.values() if get_attribute_name_en(attribute) == attribute_name]
         if len(tmp) == 1:
             return tmp[0]
         elif len(tmp) == 0:
@@ -189,7 +184,7 @@ class AttributeRestrictionMessage:
             return None
 
     def get_label_from_name(self, label_name: str) -> dict[str, Any] | None:
-        tmp = [label for label in self.label_dict.values() if AnnofabApiFacade.get_label_name_en(label) == label_name]
+        tmp = [label for label in self.label_dict.values() if get_label_name_en(label) == label_name]
         if len(tmp) == 1:
             return tmp[0]
         elif len(tmp) == 0:

--- a/annofabcli/annotation_specs/get_annotation_specs_with_attribute_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_attribute_id_replaced.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from typing import Any
 
 import more_itertools
+from annofabapi.util.annotation_specs import get_attribute_name_en
 
 import annofabcli.common.cli
 from annofabcli.common.cli import (
@@ -93,7 +94,7 @@ class ReplacingAttributeId(CommandLineWithConfirm):
         replaced_count = 0
         for attribute in attribute_list:
             attribute_id = attribute["additional_data_definition_id"]
-            attribute_name_en = AnnofabApiFacade.get_additional_data_definition_name_en(attribute)
+            attribute_name_en = get_attribute_name_en(attribute)
 
             if target_attribute_names is not None:  # noqa: SIM102
                 if attribute_name_en not in target_attribute_names:

--- a/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_choice_id_replaced.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from typing import Any
 
 import more_itertools
+from annofabapi.util.annotation_specs import get_attribute_name_en, get_choice_name_en
 
 import annofabcli.common.cli
 from annofabcli.common.cli import (
@@ -49,7 +50,7 @@ class ReplacingChoiceId(CommandLineWithConfirm):
         replaced_count = 0
         attribute_count = 0
         for attribute in attribute_list:
-            attribute_name_en = AnnofabApiFacade.get_additional_data_definition_name_en(attribute)
+            attribute_name_en = get_attribute_name_en(attribute)
 
             if target_attribute_names is not None:  # noqa: SIM102
                 if attribute_name_en not in target_attribute_names:
@@ -66,7 +67,7 @@ class ReplacingChoiceId(CommandLineWithConfirm):
 
             replaced_choice_id_count = 0
             for choice in choice_list:
-                choice_name_en = AnnofabApiFacade.get_choice_name_en(choice)
+                choice_name_en = get_choice_name_en(choice)
                 choice_id = choice["choice_id"]
 
                 if not self.validate_choice_id(choice_name_en):

--- a/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
+++ b/annofabcli/annotation_specs/get_annotation_specs_with_label_id_replaced.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from typing import Any
 
 import more_itertools
+from annofabapi.util.annotation_specs import get_label_name_en
 
 import annofabcli.common.cli
 from annofabcli.common.cli import (
@@ -78,7 +79,7 @@ class ReplacingLabelId(CommandLineWithConfirm):
         replaced_count = 0
         for label in label_list:
             label_id = label["label_id"]
-            label_name_en = AnnofabApiFacade.get_label_name_en(label)
+            label_name_en = get_label_name_en(label)
 
             if target_label_names is not None:  # noqa: SIM102
                 if label_name_en not in target_label_names:

--- a/annofabcli/annotation_specs/list_label_color.py
+++ b/annofabcli/annotation_specs/list_label_color.py
@@ -6,6 +6,8 @@ import argparse
 import logging
 from typing import Any
 
+from annofabapi.util.annotation_specs import get_label_name_en
+
 import annofabcli.common.cli
 from annofabcli.common.cli import (
     ArgumentParser,
@@ -36,7 +38,7 @@ class PrintLabelColor(CommandLine):
         annotation_specs, _ = self.service.api.get_annotation_specs(project_id, query_params={"v": "3"})
         labels = annotation_specs["labels"]
 
-        label_color_dict = {self.facade.get_label_name_en(label): self.get_rgb(label) for label in labels}
+        label_color_dict = {get_label_name_en(label): self.get_rgb(label) for label in labels}
 
         self.print_according_to_format(label_color_dict)
 

--- a/annofabcli/annotation_specs/put_label_color.py
+++ b/annofabcli/annotation_specs/put_label_color.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import annofabapi
+from annofabapi.util.annotation_specs import get_label_name_en
 
 import annofabcli.common.cli
 from annofabcli.common.cli import (
@@ -50,7 +51,7 @@ class PuttingLabelColorMain(CommandLineWithConfirm):
         changed_labels: list[Label] = []
         labels = request_body["labels"]
         for label_name_en, color in label_color_dict.items():
-            target_labels = [e for e in labels if AnnofabApiFacade.get_label_name_en(e) == label_name_en]
+            target_labels = [e for e in labels if get_label_name_en(e) == label_name_en]
             if len(target_labels) == 0:
                 logger.warning(f"label_name_en='{label_name_en}'であるラベルは存在しません。")
                 continue
@@ -64,7 +65,7 @@ class PuttingLabelColorMain(CommandLineWithConfirm):
                     changed_labels.append(
                         Label(
                             label_id=target_label["label_id"],
-                            label_name_en=AnnofabApiFacade.get_label_name_en(target_label),
+                            label_name_en=get_label_name_en(target_label),
                         )
                     )
 

--- a/annofabcli/common/facade.py
+++ b/annofabcli/common/facade.py
@@ -17,6 +17,7 @@ from annofabapi.models import (
     TaskPhase,
     TaskStatus,
 )
+from annofabapi.util.annotation_specs import get_label_name_en
 from dataclasses_json import DataClassJsonMixin
 
 from annofabcli.common.exceptions import OrganizationAuthorizationError, ProjectAuthorizationError
@@ -233,7 +234,7 @@ def convert_annotation_specs_labels_v2_to_v1(labels_v2: list[dict[str, Any]], ad
             else:
                 raise ValueError(
                     f"additional_data_definition_id='{additional_data_definition_id}' に対応する属性情報が存在しません。"
-                    f"label_id='{label_v2['label_id']}', label_name_en='{AnnofabApiFacade.get_label_name_en(label_v2)}'"
+                    f"label_id='{label_v2['label_id']}', label_name_en='{get_label_name_en(label_v2)}'"
                 )
         label_v2["additional_data_definitions"] = new_additional_data_definitions
         return label_v2
@@ -251,24 +252,6 @@ class AnnofabApiFacade:
 
     def __init__(self, service: annofabapi.Resource) -> None:
         self.service = service
-
-    @staticmethod
-    def get_label_name_en(label: dict[str, Any]) -> str:
-        """label情報から英語名を取得する"""
-        label_name_messages = label["label_name"]["messages"]
-        return [e["message"] for e in label_name_messages if e["lang"] == "en-US"][0]  # noqa: RUF015
-
-    @staticmethod
-    def get_additional_data_definition_name_en(additional_data_definition: dict[str, Any]) -> str:
-        """additional_data_definitionから英語名を取得する"""
-        messages = additional_data_definition["name"]["messages"]
-        return [e["message"] for e in messages if e["lang"] == "en-US"][0]  # noqa: RUF015
-
-    @staticmethod
-    def get_choice_name_en(choice: dict[str, Any]) -> str:
-        """choiceから英語名を取得する"""
-        messages = choice["name"]["messages"]
-        return [e["message"] for e in messages if e["lang"] == "en-US"][0]  # noqa: RUF015
 
     def get_project_title(self, project_id: str) -> str:
         """

--- a/annofabcli/project/diff_projects.py
+++ b/annofabcli/project/diff_projects.py
@@ -14,6 +14,7 @@ import annofabapi
 import dictdiffer
 import more_itertools
 from annofabapi.models import ProjectMemberRole
+from annofabapi.util.annotation_specs import get_label_name_en
 
 import annofabcli.common.cli
 from annofabcli.common.cli import CommandLine, build_annofabapi_resource_and_login
@@ -169,8 +170,8 @@ class DiffProjects(CommandLine):
 
         diff_message = ""
 
-        label_names1 = [AnnofabApiFacade.get_label_name_en(e) for e in labels1]
-        label_names2 = [AnnofabApiFacade.get_label_name_en(e) for e in labels2]
+        label_names1 = [get_label_name_en(e) for e in labels1]
+        label_names2 = [get_label_name_en(e) for e in labels2]
 
         # 重複チェック
         is_duplicated, duplicated_message = self.validate_duplicated(label_names1, label_names2)
@@ -191,7 +192,7 @@ class DiffProjects(CommandLine):
         for label_name in label_names:
 
             def get_label_func(label_name: str, label: dict[str, Any]) -> bool:
-                return AnnofabApiFacade.get_label_name_en(label) == label_name
+                return get_label_name_en(label) == label_name
 
             label1 = more_itertools.first_true(labels1, pred=functools.partial(get_label_func, label_name))
             label2 = more_itertools.first_true(labels2, pred=functools.partial(get_label_func, label_name))


### PR DESCRIPTION
 `AnnofabApiFacade` の以下の関数を削除して、代わりにに`annofabapi.util.annotation_specs`内の関数を使うように置き換えました。
* `get_choice_name_en`
* `get_additional_data_definition_name_en`
* `get_choice_name_en`
* 
