### PR TITLE
annotation_specs diffで定型指摘の差分を出力する (#1623)

### DIFF
--- a/annofabcli/annotation_specs/import_annotation_specs.py
+++ b/annofabcli/annotation_specs/import_annotation_specs.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import functools
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import annofabapi
+from annofabapi.dataclass.annotation import AdditionalDataV1
+
+import annofabcli.common.cli
+from annofabcli.annotation.annotation_query import AnnotationQueryForAPI
+from annofabcli.annotation_specs.diff_compare import create_annotation_specs_diff
+from annofabcli.annotation_specs.diff_models import AnnotationSpecsDiff
+from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login
+from annofabcli.common.facade import AnnofabApiFacade
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProtectedImportChanges:
+    """既存アノテーションで使われているため、importを中止する変更一覧。"""
+
+    removed_label_ids: list[str] = field(default_factory=list)
+    """削除対象のうち、アノテーションで使われているラベルID一覧。"""
+
+    changed_annotation_type_label_ids: list[str] = field(default_factory=list)
+    """種類変更対象のうち、アノテーションで使われているラベルID一覧。"""
+
+    removed_attribute_ids: list[str] = field(default_factory=list)
+    """削除対象のうち、アノテーションで使われている属性ID一覧。"""
+
+    changed_type_attribute_ids: list[str] = field(default_factory=list)
+    """種類変更対象のうち、アノテーションで使われている属性ID一覧。"""
+
+    removed_label_attribute_relations: list[tuple[str, str]] = field(default_factory=list)
+    """ラベルから削除される属性のうち、アノテーションで使われている一覧。要素は(label_id, attribute_id)。"""
+
+    removed_choices: list[tuple[str, str]] = field(default_factory=list)
+    """削除対象のうち、アノテーションで使われている選択肢一覧。要素は(attribute_id, choice_id)。"""
+
+    def has_changes(self) -> bool:
+        """importを中止すべき変更があるかどうかを返す。"""
+        return any(
+            [
+                self.removed_label_ids,
+                self.changed_annotation_type_label_ids,
+                self.removed_attribute_ids,
+                self.changed_type_attribute_ids,
+                self.removed_label_attribute_relations,
+                self.removed_choices,
+            ]
+        )
+
+
+def create_comment_for_import_annotation_specs() -> str:
+    """import時のデフォルトコメントを生成する。"""
+    return "annofabcli annotation_specs import コマンドでアノテーション仕様をインポートしました。"
+
+
+def read_annotation_specs_json(annotation_specs_json: Path) -> dict[str, Any]:
+    """アノテーション仕様JSONを読み込む。
+
+    Args:
+        annotation_specs_json: アノテーション仕様JSONのパス
+
+    Returns:
+        読み込んだアノテーション仕様
+    """
+    with annotation_specs_json.open(encoding="utf-8") as f:
+        loaded = json.load(f)
+    if not isinstance(loaded, dict):
+        raise TypeError("`--annotation_specs_json` にはJSONオブジェクト形式のアノテーション仕様を指定してください。")
+    return loaded
+
+
+def create_label_annotation_query(label_id: str) -> dict[str, Any]:
+    """ラベルを利用しているアノテーションを検索するqueryを生成する。"""
+    return {"label_id": label_id}
+
+
+def create_attribute_annotation_query(attribute_id: str) -> dict[str, Any]:
+    """属性を利用しているアノテーションを検索するqueryを生成する。"""
+    additional_data = AdditionalDataV1.from_dict({"additional_data_definition_id": attribute_id}, infer_missing=True)
+    query = AnnotationQueryForAPI(attributes=[additional_data]).to_dict()
+    return {key: value for key, value in query.items() if value is not None}
+
+
+def create_choice_annotation_query(attribute_id: str, choice_id: str) -> dict[str, Any]:
+    """選択肢を利用しているアノテーションを検索するqueryを生成する。"""
+    additional_data = AdditionalDataV1.from_dict({"additional_data_definition_id": attribute_id, "choice": choice_id}, infer_missing=True)
+    query = AnnotationQueryForAPI(attributes=[additional_data]).to_dict()
+    return {key: value for key, value in query.items() if value is not None}
+
+
+def build_request_body_for_import_annotation_specs(
+    current_annotation_specs: dict[str, Any],
+    imported_annotation_specs: dict[str, Any],
+    *,
+    comment: str | None,
+) -> dict[str, Any]:
+    """アノテーション仕様import用の request body を生成する。
+
+    Args:
+        current_annotation_specs: 現在のアノテーション仕様
+        imported_annotation_specs: インポートするアノテーション仕様
+        comment: 変更コメント
+
+    Returns:
+        Annofab API に渡す request body
+    """
+    request_body = copy.deepcopy(imported_annotation_specs)
+    request_body.pop("project_id", None)
+    request_body["comment"] = comment if comment is not None else create_comment_for_import_annotation_specs()
+    request_body["last_updated_datetime"] = current_annotation_specs["updated_datetime"]
+    return request_body
+
+
+def create_protected_import_changes(
+    diff: AnnotationSpecsDiff,
+    *,
+    is_label_used: Callable[[str], bool],
+    is_attribute_used: Callable[[str], bool],
+    is_choice_used: Callable[[str, str], bool],
+) -> ProtectedImportChanges:
+    """差分のうち、既存アノテーションで使われている変更を抽出する。
+
+    Args:
+        diff: 現在仕様とimport仕様の差分
+        is_label_used: label_idを受け取り、利用中ならTrueを返す関数
+        is_attribute_used: attribute_idを受け取り、利用中ならTrueを返す関数
+        is_choice_used: attribute_idとchoice_idを受け取り、利用中ならTrueを返す関数
+
+    Returns:
+        importを中止すべき変更一覧
+    """
+    protected = ProtectedImportChanges()
+
+    if diff.labels is not None:
+        protected.removed_label_ids.extend(label_id for label_id in diff.labels.removed_label_ids if is_label_used(label_id))
+        for changed_label in diff.labels.changed_labels:
+            if changed_label.annotation_type_changed and is_label_used(changed_label.label_id):
+                protected.changed_annotation_type_label_ids.append(changed_label.label_id)
+            protected.removed_label_attribute_relations.extend((changed_label.label_id, attribute_id) for attribute_id in changed_label.removed_attribute_ids if is_attribute_used(attribute_id))
+
+    if diff.attributes is not None:
+        protected.removed_attribute_ids.extend(attribute_id for attribute_id in diff.attributes.removed_attribute_ids if is_attribute_used(attribute_id))
+        for changed_attribute in diff.attributes.changed_attributes:
+            if changed_attribute.type_changed and is_attribute_used(changed_attribute.attribute_id):
+                protected.changed_type_attribute_ids.append(changed_attribute.attribute_id)
+            protected.removed_choices.extend(
+                (changed_attribute.attribute_id, choice_id) for choice_id in changed_attribute.removed_choice_ids if is_choice_used(changed_attribute.attribute_id, choice_id)
+            )
+
+    return protected
+
+
+def validate_import_annotation_specs(protected_changes: ProtectedImportChanges) -> None:
+    """importを中止すべき変更があれば例外を送出する。
+
+    Args:
+        protected_changes: importを中止すべき変更一覧
+
+    Raises:
+        ValueError: 既存アノテーションで使われているラベル/属性/選択肢の削除や種類変更がある場合
+    """
+    if not protected_changes.has_changes():
+        return
+
+    messages = []
+    if protected_changes.removed_label_ids:
+        messages.append(f"削除対象のラベルがアノテーションで使われています。 :: label_ids={protected_changes.removed_label_ids}")
+    if protected_changes.changed_annotation_type_label_ids:
+        messages.append(f"種類変更対象のラベルがアノテーションで使われています。 :: label_ids={protected_changes.changed_annotation_type_label_ids}")
+    if protected_changes.removed_attribute_ids:
+        messages.append(f"削除対象の属性がアノテーションで使われています。 :: attribute_ids={protected_changes.removed_attribute_ids}")
+    if protected_changes.changed_type_attribute_ids:
+        messages.append(f"種類変更対象の属性がアノテーションで使われています。 :: attribute_ids={protected_changes.changed_type_attribute_ids}")
+    if protected_changes.removed_label_attribute_relations:
+        messages.append(f"ラベルから削除される属性がアノテーションで使われています。 :: label_attribute_pairs={protected_changes.removed_label_attribute_relations}")
+    if protected_changes.removed_choices:
+        messages.append(f"削除対象の選択肢がアノテーションで使われています。 :: attribute_choice_pairs={protected_changes.removed_choices}")
+
+    raise ValueError("既存アノテーションに影響するため、アノテーション仕様のインポートを中止しました。\n" + "\n".join(messages))
+
+
+class ImportAnnotationSpecsMain(CommandLineWithConfirm):
+    """アノテーション仕様をimportする本体処理。"""
+
+    def __init__(
+        self,
+        service: annofabapi.Resource,
+        *,
+        project_id: str,
+        all_yes: bool,
+    ) -> None:
+        self.service = service
+        self.project_id = project_id
+        CommandLineWithConfirm.__init__(self, all_yes)
+
+    def has_annotation(self, query: dict[str, Any]) -> bool:
+        """指定したqueryに一致するアノテーションが存在するかどうかを返す。"""
+        content, _ = self.service.api.get_annotation_list(
+            self.project_id,
+            query_params={"query": query, "limit": 1, "v": "2"},
+        )
+        return content["total_count"] > 0
+
+    def validate_import(self, *, current_annotation_specs: dict[str, Any], imported_annotation_specs: dict[str, Any]) -> None:
+        """importしてよい差分かどうかを検証する。"""
+        diff = create_annotation_specs_diff(current_annotation_specs, imported_annotation_specs, targets={"labels", "attributes"})
+
+        @functools.cache
+        def is_label_used(label_id: str) -> bool:
+            return self.has_annotation(create_label_annotation_query(label_id))
+
+        @functools.cache
+        def is_attribute_used(attribute_id: str) -> bool:
+            return self.has_annotation(create_attribute_annotation_query(attribute_id))
+
+        @functools.cache
+        def is_choice_used(attribute_id: str, choice_id: str) -> bool:
+            return self.has_annotation(create_choice_annotation_query(attribute_id, choice_id))
+
+        protected_changes = create_protected_import_changes(
+            diff,
+            is_label_used=is_label_used,
+            is_attribute_used=is_attribute_used,
+            is_choice_used=is_choice_used,
+        )
+        validate_import_annotation_specs(protected_changes)
+
+    def import_annotation_specs(self, *, imported_annotation_specs: dict[str, Any], comment: str | None = None) -> bool:
+        """アノテーション仕様をimportする。
+
+        Args:
+            imported_annotation_specs: インポートするアノテーション仕様
+            comment: 変更コメント
+
+        Returns:
+            更新を実行した場合はTrue、確認で中断した場合はFalse
+        """
+        current_annotation_specs, _ = self.service.api.get_annotation_specs(self.project_id, query_params={"v": "3"})
+        self.validate_import(current_annotation_specs=current_annotation_specs, imported_annotation_specs=imported_annotation_specs)
+
+        confirm_message = f"プロジェクト'{self.project_id}'のアノテーション仕様をインポートします。よろしいですか？"
+        if not self.confirm_processing(confirm_message):
+            return False
+
+        request_body = build_request_body_for_import_annotation_specs(current_annotation_specs, imported_annotation_specs, comment=comment)
+        self.service.api.put_annotation_specs(self.project_id, query_params={"v": "3"}, request_body=request_body)
+        logger.info(f"プロジェクト'{self.project_id}'のアノテーション仕様をインポートしました。")
+        return True
+
+
+class ImportAnnotationSpecs(CommandLine):
+    COMMON_MESSAGE = "annofabcli annotation_specs import: error:"
+
+    def main(self) -> None:
+        args = self.args
+        imported_annotation_specs = read_annotation_specs_json(args.annotation_specs_json)
+        obj = ImportAnnotationSpecsMain(self.service, project_id=args.project_id, all_yes=args.yes)
+        obj.import_annotation_specs(imported_annotation_specs=imported_annotation_specs, comment=args.comment)
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    argument_parser = ArgumentParser(parser)
+    argument_parser.add_project_id()
+    parser.add_argument(
+        "--annotation_specs_json",
+        type=Path,
+        required=True,
+        help="インポートするアノテーション仕様JSONを指定します。 ``annotation_specs export`` コマンドで出力したJSONを指定してください。",
+    )
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
+    parser.set_defaults(subcommand_func=main)
+
+
+def main(args: argparse.Namespace) -> None:
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    ImportAnnotationSpecs(service, facade, args).main()
+
+
+def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
+    subcommand_name = "import"
+    subcommand_help = "アノテーション仕様の情報をインポートします。"
+    description = "アノテーション仕様の情報をJSON形式でインポートします。既存アノテーションで使われているラベルや属性、選択肢に影響する削除や種類変更は中止します。"
+
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
+    parse_args(parser)
+    return parser

--- a/annofabcli/annotation_specs/subcommand_annotation_specs.py
+++ b/annofabcli/annotation_specs/subcommand_annotation_specs.py
@@ -15,6 +15,7 @@ import annofabcli.annotation_specs.export_annotation_specs
 import annofabcli.annotation_specs.get_annotation_specs_with_attribute_id_replaced
 import annofabcli.annotation_specs.get_annotation_specs_with_choice_id_replaced
 import annofabcli.annotation_specs.get_annotation_specs_with_label_id_replaced
+import annofabcli.annotation_specs.import_annotation_specs
 import annofabcli.annotation_specs.list_annotation_specs_attribute
 import annofabcli.annotation_specs.list_annotation_specs_choice
 import annofabcli.annotation_specs.list_annotation_specs_history
@@ -48,6 +49,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.annotation_specs.get_annotation_specs_with_attribute_id_replaced.add_parser(subparsers)
     annofabcli.annotation_specs.get_annotation_specs_with_choice_id_replaced.add_parser(subparsers)
     annofabcli.annotation_specs.get_annotation_specs_with_label_id_replaced.add_parser(subparsers)
+    annofabcli.annotation_specs.import_annotation_specs.add_parser(subparsers)
     annofabcli.annotation_specs.list_annotation_specs_attribute.add_parser(subparsers)
     annofabcli.annotation_specs.list_annotation_specs_choice.add_parser(subparsers)
     annofabcli.annotation_specs.list_annotation_specs_history.add_parser(subparsers)

--- a/docs/command_reference/annotation_specs/import.rst
+++ b/docs/command_reference/annotation_specs/import.rst
@@ -1,0 +1,49 @@
+====================================================================================
+annotation_specs import
+====================================================================================
+
+Description
+=================================
+アノテーション仕様の情報をJSON形式でインポートします。
+``annotation_specs export`` コマンドで出力したJSONを利用できます。
+
+既存アノテーションに影響する変更を防ぐため、以下の変更対象がアノテーションで使われている場合はインポートを中止します。
+
+* ラベルの削除
+* ラベルの種類の変更
+* 属性の削除
+* 属性の種類の変更
+* ラベルに属する属性の削除
+* 選択肢の削除
+
+
+Examples
+=================================
+
+基本的な使い方
+--------------------------
+
+
+.. code-block::
+
+    $ annofabcli annotation_specs import --project_id prj1 --annotation_specs_json annotation_specs.json
+
+
+``annotation_specs export`` と組み合わせる場合
+------------------------------------------------------------
+
+
+.. code-block::
+
+    $ annofabcli annotation_specs export --project_id src_prj --out annotation_specs.json --format pretty_json
+    $ annofabcli annotation_specs import --project_id dest_prj --annotation_specs_json annotation_specs.json
+
+
+Usage Details
+=================================
+
+.. argparse::
+   :ref: annofabcli.annotation_specs.import_annotation_specs.add_parser
+   :prog: annofabcli annotation_specs import
+   :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/annotation_specs/index.rst
+++ b/docs/command_reference/annotation_specs/index.rst
@@ -30,6 +30,7 @@ Available Commands
    get_with_attribute_id_replaced_label_name
    get_with_choice_id_replaced_label_name
    get_with_label_id_replaced_label_name
+   import
    list_attribute
    list_choice
    list_history

--- a/tests/annotation_specs/test_import_annotation_specs.py
+++ b/tests/annotation_specs/test_import_annotation_specs.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from annofabcli.annotation_specs.diff_compare import create_annotation_specs_diff
+from annofabcli.annotation_specs.import_annotation_specs import (
+    ProtectedImportChanges,
+    build_request_body_for_import_annotation_specs,
+    create_attribute_annotation_query,
+    create_choice_annotation_query,
+    create_label_annotation_query,
+    create_protected_import_changes,
+    validate_import_annotation_specs,
+)
+
+
+def _create_message(ja: str, en: str) -> dict[str, Any]:
+    return {
+        "messages": [
+            {"lang": "ja-JP", "message": ja},
+            {"lang": "en-US", "message": en},
+        ],
+        "default_lang": "ja-JP",
+    }
+
+
+def _create_choice(choice_id: str, *, ja: str, en: str) -> dict[str, Any]:
+    return {
+        "choice_id": choice_id,
+        "name": _create_message(ja, en),
+        "keybind": [],
+    }
+
+
+def _create_attribute(attribute_id: str, *, attribute_type: str, choices: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "additional_data_definition_id": attribute_id,
+        "read_only": False,
+        "name": _create_message(attribute_id, attribute_id),
+        "keybind": [],
+        "type": attribute_type,
+        "default": choices[0]["choice_id"] if choices else False,
+        "choices": choices if choices is not None else [],
+        "metadata": {},
+        "option": {},
+    }
+
+
+def _create_label(label_id: str, *, annotation_type: str = "bounding_box", attribute_ids: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "label_id": label_id,
+        "label_name": _create_message(label_id, label_id),
+        "keybind": [],
+        "annotation_type": annotation_type,
+        "additional_data_definitions": attribute_ids if attribute_ids is not None else [],
+        "color": {"red": 255, "green": 0, "blue": 0},
+        "field_values": {},
+        "metadata": {},
+    }
+
+
+def _create_annotation_specs() -> dict[str, Any]:
+    return {
+        "format_version": 3,
+        "project_id": "src_prj",
+        "labels": [
+            _create_label("label_car", attribute_ids=["attr_occluded", "attr_truncated"]),
+            _create_label("label_bus", attribute_ids=["attr_occluded"]),
+        ],
+        "additionals": [
+            _create_attribute(
+                "attr_occluded",
+                attribute_type="select",
+                choices=[
+                    _create_choice("choice_yes", ja="はい", en="yes"),
+                    _create_choice("choice_no", ja="いいえ", en="no"),
+                ],
+            ),
+            _create_attribute("attr_truncated", attribute_type="flag"),
+        ],
+        "restrictions": [],
+        "inspection_phrases": [],
+        "metadata": {},
+        "updated_datetime": "2026-04-24T00:00:00+09:00",
+    }
+
+
+def _assert_import_allowed(
+    current_specs: dict[str, Any],
+    imported_specs: dict[str, Any],
+    *,
+    used_label_ids: set[str] | None = None,
+    used_attribute_ids: set[str] | None = None,
+    used_choices: set[tuple[str, str]] | None = None,
+) -> None:
+    protected_changes = _create_protected_changes(
+        current_specs,
+        imported_specs,
+        used_label_ids=used_label_ids,
+        used_attribute_ids=used_attribute_ids,
+        used_choices=used_choices,
+    )
+    validate_import_annotation_specs(protected_changes)
+
+
+def _assert_import_blocked(
+    current_specs: dict[str, Any],
+    imported_specs: dict[str, Any],
+    *,
+    used_label_ids: set[str] | None = None,
+    used_attribute_ids: set[str] | None = None,
+    used_choices: set[tuple[str, str]] | None = None,
+) -> None:
+    protected_changes = _create_protected_changes(
+        current_specs,
+        imported_specs,
+        used_label_ids=used_label_ids,
+        used_attribute_ids=used_attribute_ids,
+        used_choices=used_choices,
+    )
+    with pytest.raises(ValueError):
+        validate_import_annotation_specs(protected_changes)
+
+
+def _create_protected_changes(
+    current_specs: dict[str, Any],
+    imported_specs: dict[str, Any],
+    *,
+    used_label_ids: set[str] | None = None,
+    used_attribute_ids: set[str] | None = None,
+    used_choices: set[tuple[str, str]] | None = None,
+) -> ProtectedImportChanges:
+    used_label_ids = used_label_ids if used_label_ids is not None else set()
+    used_attribute_ids = used_attribute_ids if used_attribute_ids is not None else set()
+    used_choices = used_choices if used_choices is not None else set()
+    diff = create_annotation_specs_diff(current_specs, imported_specs, targets={"labels", "attributes"})
+    return create_protected_import_changes(
+        diff,
+        is_label_used=_to_used_checker(used_label_ids),
+        is_attribute_used=_to_used_checker(used_attribute_ids),
+        is_choice_used=lambda attribute_id, choice_id: (attribute_id, choice_id) in used_choices,
+    )
+
+
+def _to_used_checker(used_values: set[str]) -> Callable[[str], bool]:
+    return lambda value: value in used_values
+
+
+class TestBuildRequestBodyForImportAnnotationSpecs:
+    def test_request_bodyを生成できる(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["project_id"] = "other_prj"
+        imported_specs["updated_datetime"] = "2026-05-01T00:00:00+09:00"
+        imported_specs["labels"][0]["color"] = {"red": 0, "green": 255, "blue": 0}
+
+        actual = build_request_body_for_import_annotation_specs(current_specs, imported_specs, comment="importしました")
+
+        assert actual["labels"][0]["color"] == {"red": 0, "green": 255, "blue": 0}
+        assert actual["comment"] == "importしました"
+        assert actual["last_updated_datetime"] == current_specs["updated_datetime"]
+        assert "project_id" not in actual
+
+    def test_comment未指定ならデフォルトコメントを設定する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+
+        actual = build_request_body_for_import_annotation_specs(current_specs, imported_specs, comment=None)
+
+        assert "annotation_specs import" in actual["comment"]
+
+
+class TestValidateImportAnnotationSpecs:
+    def test_中止対象差分がなければ許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"][0]["color"] = {"red": 0, "green": 255, "blue": 0}
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+    def test_使われているラベルを削除する場合は中止する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"] = [label for label in imported_specs["labels"] if label["label_id"] != "label_car"]
+
+        _assert_import_blocked(current_specs, imported_specs, used_label_ids={"label_car"})
+
+    def test_使われていないラベルを削除する場合は許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"] = [label for label in imported_specs["labels"] if label["label_id"] != "label_car"]
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+    def test_使われているラベルの種類を変更する場合は中止する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"][0]["annotation_type"] = "polygon"
+
+        _assert_import_blocked(current_specs, imported_specs, used_label_ids={"label_car"})
+
+    def test_使われていないラベルの種類を変更する場合は許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"][0]["annotation_type"] = "polygon"
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+    def test_使われている属性を削除する場合は中止する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["additionals"] = [attribute for attribute in imported_specs["additionals"] if attribute["additional_data_definition_id"] != "attr_truncated"]
+
+        _assert_import_blocked(current_specs, imported_specs, used_attribute_ids={"attr_truncated"})
+
+    def test_使われていない属性を削除する場合は許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["additionals"] = [attribute for attribute in imported_specs["additionals"] if attribute["additional_data_definition_id"] != "attr_truncated"]
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+    def test_使われている属性の種類を変更する場合は中止する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["additionals"][1]["type"] = "integer"
+
+        _assert_import_blocked(current_specs, imported_specs, used_attribute_ids={"attr_truncated"})
+
+    def test_使われていない属性の種類を変更する場合は許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["additionals"][1]["type"] = "integer"
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+    def test_使われている属性をラベルから削除する場合は中止する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"][0]["additional_data_definitions"] = ["attr_occluded"]
+
+        _assert_import_blocked(current_specs, imported_specs, used_attribute_ids={"attr_truncated"})
+
+    def test_使われていない属性をラベルから削除する場合は許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["labels"][0]["additional_data_definitions"] = ["attr_occluded"]
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+    def test_使われている選択肢を削除する場合は中止する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["additionals"][0]["choices"] = [choice for choice in imported_specs["additionals"][0]["choices"] if choice["choice_id"] != "choice_yes"]
+
+        _assert_import_blocked(current_specs, imported_specs, used_choices={("attr_occluded", "choice_yes")})
+
+    def test_使われていない選択肢を削除する場合は許可する(self) -> None:
+        current_specs = _create_annotation_specs()
+        imported_specs = copy.deepcopy(current_specs)
+        imported_specs["additionals"][0]["choices"] = [choice for choice in imported_specs["additionals"][0]["choices"] if choice["choice_id"] != "choice_yes"]
+
+        _assert_import_allowed(current_specs, imported_specs)
+
+
+class TestCreateAnnotationQuery:
+    def test_ラベル検索queryを生成できる(self) -> None:
+        assert create_label_annotation_query("label_car") == {"label_id": "label_car"}
+
+    def test_属性検索queryを生成できる(self) -> None:
+        assert create_attribute_annotation_query("attr_occluded") == {
+            "attributes": [
+                {
+                    "additional_data_definition_id": "attr_occluded",
+                    "flag": None,
+                    "integer": None,
+                    "comment": None,
+                    "choice": None,
+                }
+            ]
+        }
+
+    def test_選択肢検索queryを生成できる(self) -> None:
+        assert create_choice_annotation_query("attr_occluded", "choice_yes") == {
+            "attributes": [
+                {
+                    "additional_data_definition_id": "attr_occluded",
+                    "flag": None,
+                    "integer": None,
+                    "comment": None,
+                    "choice": "choice_yes",
+                }
+            ]
+        }


### PR DESCRIPTION
* annotation_specs diffで定型指摘の差分を出力する

* annotation_specs diffでmetadataの差分を出力する

* metadataキー必須の前提で差分処理する

* Fix attribute restriction detail text output

* Omit metadata values from added and removed detail text

* Fix annotation specs detail text keys

* Simplify label order detail text

* docs: update annotation specs diff reference

* feat: add support for option diff in annotation specs comparison

* fix: replace CommandLine import with argparse in diff_annotation_specs.py

* docs: remove redundant details from JSON output section in diff.rst

* Stabilize inspection phrase diff order