### PR TITLE
Rename task put_by_count command

### DIFF
--- a/annofabcli/task/create_tasks_by_input_data_count.py
+++ b/annofabcli/task/create_tasks_by_input_data_count.py
@@ -21,7 +21,7 @@ class InputDataOrder(Enum):
     RANDOM = "random"
 
 
-class PuttingTaskByCountMain:
+class CreatingTasksByInputDataCountMain:
     def __init__(
         self,
         service: annofabapi.Resource,
@@ -56,7 +56,7 @@ class PuttingTaskByCountMain:
         }
         content, _ = self.service.api.initiate_tasks_generation(self.project_id, request_body=request_body)
         job = content["job"]
-        logger.info(f"Annofab上でタスク作成処理が開始されました。 :: task_id_prefix='{task_id_prefix}', input_data_count='input_data_count'")
+        logger.info(f"Annofab上でタスク作成処理が開始されました。 :: task_id_prefix='{task_id_prefix}', input_data_count='{input_data_count}'")
         if should_wait:
             self.wait_for_completion(job["job_id"])
         else:
@@ -90,13 +90,13 @@ class PuttingTaskByCountMain:
             logger.warning(f"job_id='{job_id}' :: {max_wait_minute}分間待ちましたが、タスク登録のジョブが終了しませんでした。")
 
 
-class PutTaskByCount(CommandLine):
+class CreateTasksByInputDataCount(CommandLine):
     def main(self) -> None:
         args = self.args
         project_id = args.project_id
         super().validate_project(project_id, [ProjectMemberRole.OWNER])
 
-        main_obj = PuttingTaskByCountMain(
+        main_obj = CreatingTasksByInputDataCountMain(
             self.service,
             project_id=args.project_id,
         )
@@ -113,7 +113,7 @@ class PutTaskByCount(CommandLine):
 def main(args: argparse.Namespace) -> None:
     service = build_annofabapi_resource_and_login(args)
     facade = AnnofabApiFacade(service)
-    PutTaskByCount(service, facade, args).main()
+    CreateTasksByInputDataCount(service, facade, args).main()
 
 
 def parse_args(parser: argparse.ArgumentParser) -> None:
@@ -141,7 +141,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
 
 def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
-    subcommand_name = "put_by_count"
+    subcommand_name = "create_by_input_data_count"
     subcommand_help = "タスクに割り当てる入力データの個数を指定して、タスクを作成します。"
     epilog = "オーナロールを持つユーザで実行してください。"
 

--- a/annofabcli/task/subcommand_task.py
+++ b/annofabcli/task/subcommand_task.py
@@ -8,6 +8,7 @@ import annofabcli.task.change_status_to_on_hold
 import annofabcli.task.complete_tasks
 import annofabcli.task.copy_tasks
 import annofabcli.task.create_tasks
+import annofabcli.task.create_tasks_by_input_data_count
 import annofabcli.task.delete_metadata_key_of_task
 import annofabcli.task.delete_tasks
 import annofabcli.task.download_task_json
@@ -16,7 +17,6 @@ import annofabcli.task.list_all_tasks_added_task_history
 import annofabcli.task.list_tasks
 import annofabcli.task.list_tasks_added_task_history
 import annofabcli.task.put_tasks
-import annofabcli.task.put_tasks_by_count
 import annofabcli.task.reject_tasks
 import annofabcli.task.update_metadata_of_task
 
@@ -32,6 +32,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.task.complete_tasks.add_parser(subparsers)
     annofabcli.task.copy_tasks.add_parser(subparsers)
     annofabcli.task.create_tasks.add_parser(subparsers)
+    annofabcli.task.create_tasks_by_input_data_count.add_parser(subparsers)
     annofabcli.task.delete_tasks.add_parser(subparsers)
     annofabcli.task.delete_metadata_key_of_task.add_parser(subparsers)
     annofabcli.task.download_task_json.add_parser(subparsers)
@@ -40,7 +41,6 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.task.list_all_tasks.add_parser(subparsers)
     annofabcli.task.list_all_tasks_added_task_history.add_parser(subparsers)
     annofabcli.task.put_tasks.add_parser(subparsers)
-    annofabcli.task.put_tasks_by_count.add_parser(subparsers)
     annofabcli.task.reject_tasks.add_parser(subparsers)
     annofabcli.task.update_metadata_of_task.add_parser(subparsers)
 

--- a/docs/command_reference/task/create_by_input_data_count.rst
+++ b/docs/command_reference/task/create_by_input_data_count.rst
@@ -1,5 +1,5 @@
 =================================
-task put_by_count
+task create_by_input_data_count
 =================================
 
 Description
@@ -19,7 +19,7 @@ Examples
 
 .. code-block::
 
-    $ annofabcli task put --project_id prj1 \
+    $ annofabcli task create_by_input_data_count --project_id prj1 \
     --task_id_prefix sample --input_data_count 10
 
 
@@ -31,7 +31,7 @@ Examples
 
 .. code-block::
 
-    $ annofabcli task put --project_id prj1 \
+    $ annofabcli task create_by_input_data_count --project_id prj1 \
     --task_id_prefix sample --input_data_count 10 --wait
 
 
@@ -39,7 +39,7 @@ Usage Details
 =================================
 
 .. argparse::
-   :ref: annofabcli.task.put_tasks_by_count.add_parser
-   :prog: annofabcli task put_by_count
+   :ref: annofabcli.task.create_tasks_by_input_data_count.add_parser
+   :prog: annofabcli task create_by_input_data_count
    :nosubcommands:
    :nodefaultconst:

--- a/docs/command_reference/task/index.rst
+++ b/docs/command_reference/task/index.rst
@@ -22,6 +22,7 @@ Available Commands
    complete
    copy
    create
+   create_by_input_data_count
    delete
    delete_metadata_key
    download
@@ -30,7 +31,6 @@ Available Commands
    list_all
    list_all_added_task_history
    put
-   put_by_count
    reject
    update_metadata
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -114,12 +114,12 @@ class TestCommandLine:
         )
 
     @pytest.mark.submitting_job
-    def test_put_task_by_count(self):
+    def test_create_task_by_input_data_count(self):
         task_id_prefix = f"test-{int(datetime.datetime.now().timestamp())!s}"
         main(
             [
                 self.command_name,
-                "put_by_count",
+                "create_by_input_data_count",
                 "--project_id",
                 project_id,
                 "--task_id_prefix",


### PR DESCRIPTION
## Summary
- Rename annofabcli task put_by_count to annofabcli task create_by_input_data_count
- Rename the implementation module and command reference page
- Update the related task command test
- Fix the task generation start log to show the actual input_data_count

## Tests
- make format
- make lint
- uv run pytest tests/test_task.py::TestCommandLine::test_create_task_by_input_data_count

Note: the first pytest run inside the sandbox failed because annofab.com could not be resolved. The same test passed after rerunning with network access.