### PR TITLE
Add supplementary create command

### DIFF
--- a/.agents/skills/python-coding-style/SKILL.md
+++ b/.agents/skills/python-coding-style/SKILL.md
@@ -12,3 +12,5 @@ description: Pythonコードを作成・修正するときに使用。
 * 戻り値をtupleで返そうとする場合は、`NamedTuple`, `dataclass`, pydantic modelの使用を検討して、本当にtupleが適切かどうかを判断する。
 * モジュールレベルの定数、クラス属性、インスタンス属性などには直後に docstring として記述する。VSCodeのtooltipに表示させるため。
 
+# pandas
+* `pandas.DataFrame.to_dict()`は`pd.NA`を`None`に変換します。またnumpyの数値型はpythonの数値型に変換します。したがって、`pandas.DataFrame.to_dict()`の結果に対して、`int()`や`pd.isna()`などの不要な処理は実施しないでください。

--- a/.agents/skills/python-coding-style/SKILL.md
+++ b/.agents/skills/python-coding-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-coding-style
-description: Pythonコードを作成・修正するときに使用。
+description: Pythonコードを作成・修正するときに使用。テストコードには適用されない。
 ---
 
 # 全般

--- a/annofabcli/supplementary/create_supplementary_data.py
+++ b/annofabcli/supplementary/create_supplementary_data.py
@@ -31,10 +31,6 @@ from annofabcli.common.utils import get_file_scheme_path
 
 logger = logging.getLogger(__name__)
 
-DEPRECATED_MESSAGE = (
-    "[DEPRECATED] :: `supplementary put` コマンドは非推奨です。代わりに `supplementary create` コマンドを使用してください。 `supplementary put` コマンドは2027/01/01以降に廃止予定です。"
-)
-
 
 def convert_supplementary_data_name_to_supplementary_data_id(supplementary_data_name: str) -> str:
     """
@@ -59,9 +55,9 @@ class CliSupplementaryData(DataClassJsonMixin):
 
 
 @dataclass
-class SupplementaryDataForPut:
+class SupplementaryDataForCreate:
     """
-    putする補助情報
+    作成する補助情報
     """
 
     input_data_id: str
@@ -73,9 +69,55 @@ class SupplementaryDataForPut:
     last_updated_datetime: str | None
 
 
-class SubPutSupplementaryData:
+def read_supplementary_data_csv(csv_file: Path) -> pandas.DataFrame:
+    """補助情報の情報が記載されているCSVを読み込み、pandas.DataFrameを返します。
+
+    DataFrameには以下の列が存在します。
+    * input_data_id
+    * supplementary_data_name
+    * supplementary_data_path
+    * supplementary_data_id
+    * supplementary_data_type
+    * supplementary_data_number
+
+    Args:
+        csv_file: CSVファイルのパス
+
+    Returns:
+        CSVの情報が格納されたpandas.DataFrame
+
+    Raises:
+        ValueError: 必須列が不足している場合
     """
-    1個の補助情報を登録するためのクラス。multiprocessing.Pool対応。
+    df = pandas.read_csv(
+        str(csv_file),
+        dtype={
+            "input_data_id": "string",
+            "supplementary_data_id": "string",
+            "supplementary_data_name": "string",
+            "supplementary_data_path": "string",
+            "supplementary_data_type": "string",
+            "supplementary_data_number": "Int64",
+        },
+    )
+
+    required_columns = {"input_data_id", "supplementary_data_name", "supplementary_data_path"}
+    if not required_columns.issubset(df.columns):
+        raise ValueError("CSV形式が不正です。ヘッダ行に 'input_data_id' と 'supplementary_data_name' と 'supplementary_data_path' を指定してください。")
+
+    if "supplementary_data_id" not in df.columns:
+        df["supplementary_data_id"] = None
+    if "supplementary_data_type" not in df.columns:
+        df["supplementary_data_type"] = None
+    if "supplementary_data_number" not in df.columns:
+        df["supplementary_data_number"] = None
+
+    return df
+
+
+class SubCreateSupplementaryData:
+    """
+    1個の補助情報を作成するためのクラス。multiprocessing.Pool対応。
 
     Args:
         service:
@@ -87,7 +129,7 @@ class SubPutSupplementaryData:
         self.all_yes = all_yes
         self.supplementary_data_cache: dict[tuple[str, str], list[SupplementaryData]] = {}
 
-    def put_supplementary_data(self, project_id: str, supplementary_data: SupplementaryDataForPut) -> None:
+    def create_supplementary_data(self, project_id: str, supplementary_data: SupplementaryDataForCreate) -> None:
         file_path = get_file_scheme_path(supplementary_data.supplementary_data_path)
         if file_path is not None:
             request_body = {
@@ -100,7 +142,7 @@ class SubPutSupplementaryData:
                 request_body.update({"supplementary_data_type": supplementary_data.supplementary_data_type})
 
             logger.debug(
-                f"'{file_path}'を補助情報として登録します。 :: "
+                f"'{file_path}'を補助情報として作成します。 :: "
                 f"input_data_id='{supplementary_data.input_data_id}', "
                 f"supplementary_data_id='{supplementary_data.supplementary_data_id}', "
                 f"supplementary_data_name='{supplementary_data.supplementary_data_name}'"
@@ -139,12 +181,10 @@ class SubPutSupplementaryData:
         "ALL"が入力されたら、`all_yes`属性をTrueにする
 
         Args:
-            task_id: 処理するtask_id
             confirm_message: 確認メッセージ
 
         Returns:
-            True: Yes, False: No
-
+            YesならTrue、NoならFalse
         """
         if self.all_yes:
             return True
@@ -156,15 +196,15 @@ class SubPutSupplementaryData:
 
         return yes
 
-    def confirm_put_supplementary_data(self, csv_supplementary_data: CliSupplementaryData, supplementary_data_id: str, *, already_exists: bool = False) -> bool:
+    def confirm_create_supplementary_data(self, csv_supplementary_data: CliSupplementaryData, supplementary_data_id: str, *, already_exists: bool = False) -> bool:
         if already_exists:
-            message_for_confirm = f"supplementary_data_name='{csv_supplementary_data.supplementary_data_name}', supplementary_data_id='{supplementary_data_id}'の補助情報を更新しますか？"
+            message_for_confirm = f"supplementary_data_name='{csv_supplementary_data.supplementary_data_name}', supplementary_data_id='{supplementary_data_id}'の補助情報を上書きして作成しますか？"
         else:
-            message_for_confirm = f"supplementary_data_name='{csv_supplementary_data.supplementary_data_name}', supplementary_data_id='{supplementary_data_id}'の補助情報を登録しますか？"
+            message_for_confirm = f"supplementary_data_name='{csv_supplementary_data.supplementary_data_name}', supplementary_data_id='{supplementary_data_id}'の補助情報を作成しますか？"
 
         return self.confirm_processing(message_for_confirm)
 
-    def put_supplementary_data_main(self, project_id: str, csv_data: CliSupplementaryData, *, overwrite: bool = False) -> bool:
+    def create_supplementary_data_main(self, project_id: str, csv_data: CliSupplementaryData, *, overwrite: bool = False) -> bool:
         last_updated_datetime = None
         input_data_id = csv_data.input_data_id
         supplementary_data_id = (
@@ -174,7 +214,7 @@ class SubPutSupplementaryData:
         supplementary_data_list = self.service.wrapper.get_supplementary_data_list_or_none(project_id, input_data_id)
         if supplementary_data_list is None:
             # 入力データが存在しない場合は、`supplementary_data_list`はNoneになる
-            logger.warning(f"input_data_id='{input_data_id}'である入力データは存在しないため、補助情報の登録をスキップします。")
+            logger.warning(f"input_data_id='{input_data_id}'である入力データは存在しないため、補助情報の作成をスキップします。")
             return False
 
         old_supplementary_data = first_true(supplementary_data_list, pred=lambda e: e["supplementary_data_id"] == supplementary_data_id)
@@ -197,22 +237,20 @@ class SubPutSupplementaryData:
                 last_updated_datetime = old_supplementary_data["updated_datetime"]
             else:
                 logger.debug(
-                    f"supplementary_data_id='{supplementary_data_id}'である補助情報がすでに存在するので、補助情報の登録をスキップします。 :: "
+                    f"supplementary_data_id='{supplementary_data_id}'である補助情報がすでに存在するので、補助情報の作成をスキップします。 :: "
                     f"input_data_id='{input_data_id}', supplementary_data_name='{csv_data.supplementary_data_name}'"
                 )
                 return False
 
         file_path = get_file_scheme_path(csv_data.supplementary_data_path)
-        if file_path is not None:  # noqa: SIM102
-            if not Path(file_path).exists():
-                logger.warning(f"'{csv_data.supplementary_data_path}' は存在しません。補助情報の登録をスキップします。")
-                return False
-
-        if not self.confirm_put_supplementary_data(csv_data, supplementary_data_id, already_exists=last_updated_datetime is not None):
+        if file_path is not None and not Path(file_path).exists():
+            logger.warning(f"'{csv_data.supplementary_data_path}' は存在しません。補助情報の作成をスキップします。")
             return False
 
-        # 補助情報を登録
-        supplementary_data_for_put = SupplementaryDataForPut(
+        if not self.confirm_create_supplementary_data(csv_data, supplementary_data_id, already_exists=last_updated_datetime is not None):
+            return False
+
+        supplementary_data_for_create = SupplementaryDataForCreate(
             input_data_id=csv_data.input_data_id,
             supplementary_data_id=supplementary_data_id,
             supplementary_data_name=csv_data.supplementary_data_name,
@@ -222,32 +260,34 @@ class SubPutSupplementaryData:
             last_updated_datetime=last_updated_datetime,
         )
         try:
-            self.put_supplementary_data(project_id, supplementary_data_for_put)
+            self.create_supplementary_data(project_id, supplementary_data_for_create)
             logger.debug(
-                f"補助情報を登録しました。 :: "
-                f"input_data_id='{supplementary_data_for_put.input_data_id}', "
-                f"supplementary_data_id='{supplementary_data_for_put.supplementary_data_id}', "
-                f"supplementary_data_name='{supplementary_data_for_put.supplementary_data_name}'"
+                f"補助情報を作成しました。 :: "
+                f"input_data_id='{supplementary_data_for_create.input_data_id}', "
+                f"supplementary_data_id='{supplementary_data_for_create.supplementary_data_id}', "
+                f"supplementary_data_name='{supplementary_data_for_create.supplementary_data_name}'"
             )
             return True  # noqa: TRY300
 
         except requests.exceptions.HTTPError:
             logger.warning(
-                f"補助情報の登録に失敗しました。 ::"
-                f"input_data_id='{supplementary_data_for_put.input_data_id}',"
-                f"supplementary_data_id='{supplementary_data_for_put.supplementary_data_id}', "
-                f"supplementary_data_name='{supplementary_data_for_put.supplementary_data_name}'",
+                f"補助情報の作成に失敗しました。 ::"
+                f"input_data_id='{supplementary_data_for_create.input_data_id}',"
+                f"supplementary_data_id='{supplementary_data_for_create.supplementary_data_id}', "
+                f"supplementary_data_name='{supplementary_data_for_create.supplementary_data_name}'",
                 exc_info=True,
             )
             return False
 
 
-class PutSupplementaryData(CommandLine):
+class CreateSupplementaryData(CommandLine):
     """
-    補助情報をCSVで登録する。
+    補助情報を作成する。
     """
 
-    def put_supplementary_data_list(
+    COMMON_MESSAGE = "annofabcli supplementary create: error:"
+
+    def create_supplementary_data_list(
         self,
         project_id: str,
         supplementary_data_list: list[CliSupplementaryData],
@@ -255,36 +295,27 @@ class PutSupplementaryData(CommandLine):
         overwrite: bool = False,
         parallelism: int | None = None,
     ) -> None:
-        """
-        補助情報を一括で登録する。
-
-        Args:
-            project_id: 補助情報の登録先プロジェクトのプロジェクトID
-            supplementary_data_list: 補助情報List
-            overwrite: Trueならば、supplementary_data_id（省略時はsupplementary_data_number）がすでに存在していたら上書きします。Falseならばスキップします。
-            parallelism: 並列度
-
-        """
+        """補助情報を一括で作成する。"""
 
         project_title = self.facade.get_project_title(project_id)
-        logger.info(f"{project_title} に、{len(supplementary_data_list)} 件の補助情報を登録します。")
+        logger.info(f"{project_title} に、{len(supplementary_data_list)} 件の補助情報を作成します。")
 
-        count_put_supplementary_data = 0
+        count_create_supplementary_data = 0
 
-        obj = SubPutSupplementaryData(service=self.service, all_yes=self.all_yes)
+        obj = SubCreateSupplementaryData(service=self.service, all_yes=self.all_yes)
         if parallelism is not None:
-            partial_func = partial(obj.put_supplementary_data_main, project_id, overwrite=overwrite)
+            partial_func = partial(obj.create_supplementary_data_main, project_id, overwrite=overwrite)
             with Pool(parallelism) as pool:
                 result_bool_list = pool.map(partial_func, supplementary_data_list)
-                count_put_supplementary_data = len([e for e in result_bool_list if e])
+                count_create_supplementary_data = len([e for e in result_bool_list if e])
 
         else:
             for csv_supplementary_data in supplementary_data_list:
-                result = obj.put_supplementary_data_main(project_id, csv_data=csv_supplementary_data, overwrite=overwrite)
+                result = obj.create_supplementary_data_main(project_id, csv_data=csv_supplementary_data, overwrite=overwrite)
                 if result:
-                    count_put_supplementary_data += 1
+                    count_create_supplementary_data += 1
 
-        logger.info(f"{project_title} に、{count_put_supplementary_data} / {len(supplementary_data_list)} 件の補助情報を登録しました。")
+        logger.info(f"{project_title} に、{count_create_supplementary_data} / {len(supplementary_data_list)} 件の補助情報を作成しました。")
 
     @staticmethod
     def get_supplementary_data_list_from_dict(supplementary_data_dict_list: list[dict[str, Any]]) -> list[CliSupplementaryData]:
@@ -292,27 +323,14 @@ class PutSupplementaryData(CommandLine):
 
     @staticmethod
     def get_supplementary_data_list_from_csv(csv_path: Path) -> list[CliSupplementaryData]:
-        df = pandas.read_csv(
-            str(csv_path),
-            dtype={
-                "input_data_id": "string",
-                "supplementary_data_id": "string",
-                "supplementary_data_name": "string",
-                "supplementary_data_path": "string",
-                "supplementary_data_type": "string",
-                "supplementary_data_number": "Int64",
-            },
-        )
+        df = read_supplementary_data_csv(csv_path)
         supplementary_data_list = [CliSupplementaryData.from_dict(e) for e in df.to_dict("records")]
         return supplementary_data_list
 
-    COMMON_MESSAGE = "annofabcli supplementary_data put: error:"
-
     def validate(self, args: argparse.Namespace) -> bool:
-        if args.csv is not None:  # noqa: SIM102
-            if not Path(args.csv).exists():
-                print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
-                return False
+        if args.csv is not None and not Path(args.csv).exists():
+            print(f"{self.COMMON_MESSAGE} argument --csv: ファイルパスが存在しません。 '{args.csv}'", file=sys.stderr)  # noqa: T201
+            return False
 
         if args.parallelism is not None and not args.yes:
             print(  # noqa: T201
@@ -332,7 +350,11 @@ class PutSupplementaryData(CommandLine):
         super().validate_project(project_id, [ProjectMemberRole.OWNER])
 
         if args.csv is not None:
-            supplementary_data_list = self.get_supplementary_data_list_from_csv(Path(args.csv))
+            try:
+                supplementary_data_list = self.get_supplementary_data_list_from_csv(Path(args.csv))
+            except ValueError as e:
+                print(f"{self.COMMON_MESSAGE} argument --csv: {e}", file=sys.stderr)  # noqa: T201
+                sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
         elif args.json is not None:
             supplementary_data_list = self.get_supplementary_data_list_from_dict(get_json_from_args(args.json))
         else:
@@ -342,7 +364,7 @@ class PutSupplementaryData(CommandLine):
             )
             return
 
-        self.put_supplementary_data_list(
+        self.create_supplementary_data_list(
             project_id,
             supplementary_data_list=supplementary_data_list,
             overwrite=args.overwrite,
@@ -351,10 +373,9 @@ class PutSupplementaryData(CommandLine):
 
 
 def main(args: argparse.Namespace) -> None:
-    print(DEPRECATED_MESSAGE, file=sys.stderr)  # noqa: T201
     service = build_annofabapi_resource_and_login(args)
     facade = AnnofabApiFacade(service)
-    PutSupplementaryData(service, facade, args).main()
+    CreateSupplementaryData(service, facade, args).main()
 
 
 def parse_args(parser: argparse.ArgumentParser) -> None:
@@ -365,23 +386,19 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     file_group = parser.add_mutually_exclusive_group(required=True)
     file_group.add_argument(
         "--csv",
-        type=str,
+        type=Path,
         help=(
             "補助情報が記載されたCSVファイルのパスを指定してください。CSVのフォーマットは、以下の通りです。\n"
             "\n"
             " * ヘッダ行あり, カンマ区切り\n"
-            " * input_data_id (required)\n"
-            " * supplementary_data_name (required)\n"
-            " * supplementary_data_path (required)\n"
-            " * supplementary_data_id\n"
-            " * supplementary_data_type\n"
-            " * supplementary_data_number\n"
+            " * 必須列: input_data_id, supplementary_data_name, supplementary_data_path\n"
+            " * 任意列: supplementary_data_id, supplementary_data_type, supplementary_data_number\n"
             "\n"
-            "各項目の詳細は https://annofab-cli.readthedocs.io/ja/latest/command_reference/supplementary/put.html を参照してください。"
+            "各項目の詳細は https://annofab-cli.readthedocs.io/ja/latest/command_reference/supplementary/create.html を参照してください。"
         ),
     )
 
-    JSON_SAMPLE = [  # noqa: N806
+    json_sample = [
         {
             "input_data_id": "input1",
             "supplementary_data_name": "foo",
@@ -392,9 +409,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--json",
         type=str,
         help=(
-            "登録対象の補助情報データをJSON形式で指定してください。\n"
+            "作成対象の補助情報データをJSON形式で指定してください。\n"
             "\n"
-            f"(ex) ``{json.dumps(JSON_SAMPLE)}`` \n"
+            f"(ex) ``{json.dumps(json_sample)}`` \n"
             "\n"
             "JSONの各キーは ``--csv`` に渡すCSVの各列に対応しています。"
             " ``file://`` を先頭に付けるとjsonファイルを指定できます。"
@@ -418,9 +435,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
 
 def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
-    subcommand_name = "put"
-    subcommand_help = "補助情報を登録します。"
-    description = "補助情報を登録します。"
+    subcommand_name = "create"
+    subcommand_help = "補助情報を作成します。"
+    description = "補助情報を作成します。"
     epilog = "オーナーロールを持つユーザで実行してください。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description, epilog=epilog)

--- a/annofabcli/supplementary/subcommand_supplementary.py
+++ b/annofabcli/supplementary/subcommand_supplementary.py
@@ -1,18 +1,22 @@
 import argparse
 
 import annofabcli.common.cli
+import annofabcli.supplementary.create_supplementary_data
 import annofabcli.supplementary.delete_supplementary_data
 import annofabcli.supplementary.list_supplementary_data
 import annofabcli.supplementary.put_supplementary_data
+import annofabcli.supplementary.update_supplementary_data
 
 
 def parse_args(parser: argparse.ArgumentParser) -> None:
     subparsers = parser.add_subparsers(dest="subcommand_name")
 
     # サブコマンドの定義
+    annofabcli.supplementary.create_supplementary_data.add_parser(subparsers)
     annofabcli.supplementary.delete_supplementary_data.add_parser(subparsers)
     annofabcli.supplementary.list_supplementary_data.add_parser(subparsers)
     annofabcli.supplementary.put_supplementary_data.add_parser(subparsers)
+    annofabcli.supplementary.update_supplementary_data.add_parser(subparsers)
 
 
 def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:

--- a/annofabcli/supplementary/update_supplementary_data.py
+++ b/annofabcli/supplementary/update_supplementary_data.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import enum
+import logging
+import multiprocessing
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import annofabapi
+import pandas
+from dataclasses_json import DataClassJsonMixin
+from more_itertools import first_true
+
+import annofabcli.common.cli
+from annofabcli.common.cli import (
+    COMMAND_LINE_ERROR_STATUS_CODE,
+    PARALLELISM_CHOICES,
+    ArgumentParser,
+    CommandLine,
+    CommandLineWithConfirm,
+    build_annofabapi_resource_and_login,
+    get_json_from_args,
+)
+from annofabcli.common.facade import AnnofabApiFacade
+from annofabcli.common.utils import get_file_scheme_path
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateResult(Enum):
+    """更新結果の種類"""
+
+    SUCCESS = enum.auto()
+    """更新に成功した"""
+    SKIPPED = enum.auto()
+    """更新を実行しなかった"""
+    FAILED = enum.auto()
+    """更新を試みたが例外で失敗"""
+
+
+@dataclass
+class UpdatedSupplementaryData(DataClassJsonMixin):
+    """
+    更新される補助情報
+    """
+
+    input_data_id: str
+    """更新対象の補助情報が紐づく入力データID"""
+    supplementary_data_id: str
+    """更新対象の補助情報ID"""
+    supplementary_data_name: str | None = None
+    """変更後の補助情報名（指定した場合のみ更新）"""
+    supplementary_data_path: str | None = None
+    """変更後の補助情報パス（指定した場合のみ更新）"""
+    supplementary_data_type: str | None = None
+    """変更後の補助情報種別（指定した場合のみ更新）"""
+    supplementary_data_number: int | None = None
+    """変更後の補助情報表示順（指定した場合のみ更新）"""
+
+
+def create_updated_supplementary_data_list_from_dict(supplementary_data_dict_list: list[dict[str, Any]]) -> list[UpdatedSupplementaryData]:
+    return [UpdatedSupplementaryData.from_dict(e) for e in supplementary_data_dict_list]
+
+
+def create_updated_supplementary_data_list_from_csv(csv_file: Path) -> list[UpdatedSupplementaryData]:
+    """補助情報の更新内容が記載されているCSVを読み込み、UpdatedSupplementaryDataのlistを返します。
+
+    CSVには以下の列が存在します。
+    * input_data_id (必須)
+    * supplementary_data_id (必須)
+    * supplementary_data_name (任意)
+    * supplementary_data_path (任意)
+    * supplementary_data_type (任意)
+    * supplementary_data_number (任意)
+
+    Args:
+        csv_file: CSVファイルのパス
+
+    Returns:
+        更新対象の補助情報のlist
+
+    Raises:
+        ValueError: 必須列が不足している場合
+    """
+    df = pandas.read_csv(
+        csv_file,
+        dtype={
+            "input_data_id": "string",
+            "supplementary_data_id": "string",
+            "supplementary_data_name": "string",
+            "supplementary_data_path": "string",
+            "supplementary_data_type": "string",
+            "supplementary_data_number": "Int64",
+        },
+    )
+
+    required_columns = {"input_data_id", "supplementary_data_id"}
+    if not required_columns.issubset(df.columns):
+        raise ValueError("CSV形式が不正です。ヘッダ行に 'input_data_id' と 'supplementary_data_id' を指定してください。")
+
+    for column in ["supplementary_data_name", "supplementary_data_path", "supplementary_data_type", "supplementary_data_number"]:
+        if column not in df.columns:
+            df[column] = None
+
+    return create_updated_supplementary_data_list_from_dict(df.to_dict("records"))
+
+
+class UpdateSupplementaryDataMain(CommandLineWithConfirm):
+    def __init__(self, service: annofabapi.Resource, *, all_yes: bool = False) -> None:
+        self.service = service
+        CommandLineWithConfirm.__init__(self, all_yes)
+
+    @staticmethod
+    def _create_change_messages(
+        old_supplementary_data: dict[str, Any],
+        *,
+        new_supplementary_data_name: str | None,
+        new_supplementary_data_path: str | None,
+        new_supplementary_data_type: str | None,
+        new_supplementary_data_number: int | None,
+        file_path: str | None,
+    ) -> list[str]:
+        changes = []
+        if new_supplementary_data_name is not None:
+            changes.append(f"supplementary_data_name='{old_supplementary_data['supplementary_data_name']}'を'{new_supplementary_data_name}'に変更")
+        if file_path is not None:
+            changes.append(f"supplementary_data_pathをローカルファイル'{file_path}'のアップロード結果に変更")
+        elif new_supplementary_data_path is not None:
+            changes.append(f"supplementary_data_path='{old_supplementary_data['supplementary_data_path']}'を'{new_supplementary_data_path}'に変更")
+        if new_supplementary_data_type is not None:
+            changes.append(f"supplementary_data_type='{old_supplementary_data['supplementary_data_type']}'を'{new_supplementary_data_type}'に変更")
+        if new_supplementary_data_number is not None:
+            changes.append(f"supplementary_data_number='{old_supplementary_data['supplementary_data_number']}'を'{new_supplementary_data_number}'に変更")
+        return changes
+
+    @staticmethod
+    def _create_request_body(
+        old_supplementary_data: dict[str, Any],
+        *,
+        new_supplementary_data_name: str | None,
+        new_supplementary_data_path: str | None,
+        new_supplementary_data_type: str | None,
+        new_supplementary_data_number: int | None,
+        file_path: str | None,
+    ) -> dict[str, Any]:
+        request_body = copy.deepcopy(old_supplementary_data)
+        request_body["last_updated_datetime"] = old_supplementary_data["updated_datetime"]
+
+        if new_supplementary_data_name is not None:
+            request_body["supplementary_data_name"] = new_supplementary_data_name
+        if new_supplementary_data_path is not None and file_path is None:
+            request_body["supplementary_data_path"] = new_supplementary_data_path
+        if new_supplementary_data_type is not None:
+            request_body["supplementary_data_type"] = new_supplementary_data_type
+        if new_supplementary_data_number is not None:
+            request_body["supplementary_data_number"] = new_supplementary_data_number
+
+        return request_body
+
+    def update_supplementary_data(
+        self,
+        project_id: str,
+        input_data_id: str,
+        supplementary_data_id: str,
+        *,
+        new_supplementary_data_name: str | None = None,
+        new_supplementary_data_path: str | None = None,
+        new_supplementary_data_type: str | None = None,
+        new_supplementary_data_number: int | None = None,
+        supplementary_data_index: int | None = None,
+    ) -> UpdateResult:
+        """1個の補助情報を更新します。"""
+
+        log_prefix = f"input_data_id='{input_data_id}', supplementary_data_id='{supplementary_data_id}' :: "
+        if supplementary_data_index is not None:
+            log_prefix = f"{supplementary_data_index + 1}件目 :: {log_prefix}"
+
+        supplementary_data_list = self.service.wrapper.get_supplementary_data_list_or_none(project_id, input_data_id)
+        if supplementary_data_list is None:
+            logger.warning(f"{log_prefix}入力データは存在しません。")
+            return UpdateResult.SKIPPED
+
+        old_supplementary_data = first_true(supplementary_data_list, pred=lambda e: e["supplementary_data_id"] == supplementary_data_id)
+        if old_supplementary_data is None:
+            logger.warning(f"{log_prefix}補助情報は存在しません。")
+            return UpdateResult.SKIPPED
+
+        file_path = get_file_scheme_path(new_supplementary_data_path) if new_supplementary_data_path is not None else None
+        if file_path is not None and not Path(file_path).exists():
+            logger.warning(f"{log_prefix}supplementary_data_path='{new_supplementary_data_path}'にファイルは存在しません。補助情報の更新をスキップします。")
+            return UpdateResult.SKIPPED
+
+        changes = self._create_change_messages(
+            old_supplementary_data,
+            new_supplementary_data_name=new_supplementary_data_name,
+            new_supplementary_data_path=new_supplementary_data_path,
+            new_supplementary_data_type=new_supplementary_data_type,
+            new_supplementary_data_number=new_supplementary_data_number,
+            file_path=file_path,
+        )
+
+        if len(changes) == 0:
+            logger.warning(f"{log_prefix}更新する内容が指定されていません。")
+            return UpdateResult.SKIPPED
+
+        change_message = "、".join(changes)
+        if not self.confirm_processing(f"{log_prefix}{change_message}しますか？"):
+            return UpdateResult.SKIPPED
+
+        request_body = self._create_request_body(
+            old_supplementary_data,
+            new_supplementary_data_name=new_supplementary_data_name,
+            new_supplementary_data_path=new_supplementary_data_path,
+            new_supplementary_data_type=new_supplementary_data_type,
+            new_supplementary_data_number=new_supplementary_data_number,
+            file_path=file_path,
+        )
+
+        if file_path is not None:
+            self.service.wrapper.put_supplementary_data_from_file(
+                project_id,
+                input_data_id=input_data_id,
+                supplementary_data_id=supplementary_data_id,
+                file_path=file_path,
+                request_body=request_body,
+            )
+        else:
+            self.service.api.put_supplementary_data(project_id, input_data_id, supplementary_data_id, request_body=request_body)
+
+        logger.debug(f"{log_prefix} :: 補助情報を更新しました。 :: {changes}")
+        return UpdateResult.SUCCESS
+
+    def update_supplementary_data_list_sequentially(
+        self,
+        project_id: str,
+        updated_supplementary_data_list: list[UpdatedSupplementaryData],
+    ) -> None:
+        """複数の補助情報を逐次的に更新します。"""
+        success_count = 0
+        skipped_count = 0
+        failed_count = 0
+
+        logger.info(f"{len(updated_supplementary_data_list)} 件の補助情報を更新します。")
+
+        for supplementary_data_index, updated_supplementary_data in enumerate(updated_supplementary_data_list):
+            current_num = supplementary_data_index + 1
+
+            if current_num % 1000 == 0:
+                logger.info(f"{current_num} / {len(updated_supplementary_data_list)} 件目の補助情報を処理中...")
+
+            try:
+                result = self.update_supplementary_data(
+                    project_id,
+                    updated_supplementary_data.input_data_id,
+                    updated_supplementary_data.supplementary_data_id,
+                    new_supplementary_data_name=updated_supplementary_data.supplementary_data_name,
+                    new_supplementary_data_path=updated_supplementary_data.supplementary_data_path,
+                    new_supplementary_data_type=updated_supplementary_data.supplementary_data_type,
+                    new_supplementary_data_number=updated_supplementary_data.supplementary_data_number,
+                    supplementary_data_index=supplementary_data_index,
+                )
+                if result == UpdateResult.SUCCESS:
+                    success_count += 1
+                elif result == UpdateResult.SKIPPED:
+                    skipped_count += 1
+            except Exception:
+                logger.warning(
+                    f"{current_num}件目 :: input_data_id='{updated_supplementary_data.input_data_id}', "
+                    f"supplementary_data_id='{updated_supplementary_data.supplementary_data_id}'の補助情報を更新するのに失敗しました。",
+                    exc_info=True,
+                )
+                failed_count += 1
+                continue
+
+        logger.info(f"{success_count} / {len(updated_supplementary_data_list)} 件の補助情報を更新しました。（成功: {success_count}件, スキップ: {skipped_count}件, 失敗: {failed_count}件）")
+
+    def _update_supplementary_data_wrapper(self, args: tuple[int, UpdatedSupplementaryData], project_id: str) -> UpdateResult:
+        index, updated_supplementary_data = args
+        try:
+            return self.update_supplementary_data(
+                project_id,
+                input_data_id=updated_supplementary_data.input_data_id,
+                supplementary_data_id=updated_supplementary_data.supplementary_data_id,
+                new_supplementary_data_name=updated_supplementary_data.supplementary_data_name,
+                new_supplementary_data_path=updated_supplementary_data.supplementary_data_path,
+                new_supplementary_data_type=updated_supplementary_data.supplementary_data_type,
+                new_supplementary_data_number=updated_supplementary_data.supplementary_data_number,
+                supplementary_data_index=index,
+            )
+        except Exception:
+            logger.warning(
+                f"{index + 1}件目 :: input_data_id='{updated_supplementary_data.input_data_id}', "
+                f"supplementary_data_id='{updated_supplementary_data.supplementary_data_id}'の補助情報を更新するのに失敗しました。",
+                exc_info=True,
+            )
+            return UpdateResult.FAILED
+
+    def update_supplementary_data_list_in_parallel(
+        self,
+        project_id: str,
+        updated_supplementary_data_list: list[UpdatedSupplementaryData],
+        parallelism: int,
+    ) -> None:
+        """複数の補助情報を並列的に更新します。"""
+
+        logger.info(f"{len(updated_supplementary_data_list)} 件の補助情報を更新します。{parallelism}個のプロセスを使用して並列実行します。")
+
+        partial_func = partial(self._update_supplementary_data_wrapper, project_id=project_id)
+        with multiprocessing.Pool(parallelism) as pool:
+            result_list = pool.map(partial_func, enumerate(updated_supplementary_data_list))
+            success_count = len([e for e in result_list if e == UpdateResult.SUCCESS])
+            skipped_count = len([e for e in result_list if e == UpdateResult.SKIPPED])
+            failed_count = len([e for e in result_list if e == UpdateResult.FAILED])
+
+        logger.info(f"{success_count} / {len(updated_supplementary_data_list)} 件の補助情報を更新しました。（成功: {success_count}件, スキップ: {skipped_count}件, 失敗: {failed_count}件）")
+
+
+CLI_COMMON_MESSAGE = "annofabcli supplementary update: error:"
+
+
+class UpdateSupplementaryData(CommandLine):
+    @staticmethod
+    def validate(args: argparse.Namespace) -> bool:
+        if args.parallelism is not None and not args.yes:
+            print(  # noqa: T201
+                f"{CLI_COMMON_MESSAGE} argument --parallelism: '--parallelism'を指定するときは、必ず ``--yes`` を指定してください。",
+                file=sys.stderr,
+            )
+            return False
+
+        return True
+
+    def main(self) -> None:
+        args = self.args
+        if not self.validate(args):
+            sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+
+        main_obj = UpdateSupplementaryDataMain(self.service, all_yes=self.all_yes)
+
+        if args.csv is not None:
+            try:
+                updated_supplementary_data_list = create_updated_supplementary_data_list_from_csv(args.csv)
+            except ValueError as e:
+                print(f"{CLI_COMMON_MESSAGE} argument --csv: {e}", file=sys.stderr)  # noqa: T201
+                sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+
+        elif args.json is not None:
+            supplementary_data_dict_list = get_json_from_args(args.json)
+            if not isinstance(supplementary_data_dict_list, list):
+                print(f"{CLI_COMMON_MESSAGE} JSON形式が不正です。オブジェクトの配列を指定してください。", file=sys.stderr)  # noqa: T201
+                sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+            updated_supplementary_data_list = create_updated_supplementary_data_list_from_dict(supplementary_data_dict_list)
+        else:
+            raise RuntimeError("argparse により相互排他が保証されているため、ここには到達しません")
+
+        project_id: str = args.project_id
+        if args.parallelism is not None:
+            main_obj.update_supplementary_data_list_in_parallel(project_id, updated_supplementary_data_list=updated_supplementary_data_list, parallelism=args.parallelism)
+        else:
+            main_obj.update_supplementary_data_list_sequentially(project_id, updated_supplementary_data_list=updated_supplementary_data_list)
+
+
+def main(args: argparse.Namespace) -> None:
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    UpdateSupplementaryData(service, facade, args).main()
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    argument_parser = ArgumentParser(parser)
+    argument_parser.add_project_id()
+
+    file_group = parser.add_mutually_exclusive_group(required=True)
+    file_group.add_argument(
+        "--csv",
+        type=Path,
+        help=(
+            "更新対象の補助情報と更新後の値が記載されたCSVファイルのパスを指定します。\n"
+            "CSVのフォーマットは以下の通りです。"
+            "\n"
+            " * ヘッダ行あり, カンマ区切り\n"
+            " * input_data_id (required)\n"
+            " * supplementary_data_id (required)\n"
+            " * supplementary_data_name (optional)\n"
+            " * supplementary_data_path (optional): ``file://`` を先頭に付けると、ローカルファイルを補助情報に使用します。\n"
+            " * supplementary_data_type (optional)\n"
+            " * supplementary_data_number (optional)\n"
+            "更新しないプロパティは、セルの値を空欄にしてください。\n"
+        ),
+    )
+
+    json_sample = (
+        '[{"input_data_id":"input1","supplementary_data_id":"id1","supplementary_data_name":"new_name1"},'
+        '{"input_data_id":"input2","supplementary_data_id":"id2","supplementary_data_path":"file://new_image.jpg"}]'
+    )
+    file_group.add_argument(
+        "--json",
+        type=str,
+        help=(
+            "更新対象の補助情報と更新後の値をJSON形式で指定します。\n"
+            "JSONの各キーは ``--csv`` に渡すCSVの各列に対応しています。\n"
+            "``file://`` を先頭に付けるとjsonファイルを指定できます。\n"
+            f"(ex) ``{json_sample}`` \n"
+            "更新しないプロパティは、キーを記載しないか値をnullにしてください。\n"
+        ),
+    )
+
+    parser.add_argument(
+        "--parallelism",
+        type=int,
+        choices=PARALLELISM_CHOICES,
+        help="使用するプロセス数（並列度）。指定しない場合は、逐次的に処理します。指定する場合は ``--yes`` も一緒に指定する必要があります。",
+    )
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
+    subcommand_name = "update"
+    subcommand_help = "補助情報の名前、パス、種類、表示順を更新します。"
+    epilog = "オーナロールを持つユーザで実行してください。"
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, epilog=epilog)
+    parse_args(parser)
+    return parser

--- a/docs/command_reference/supplementary/create.rst
+++ b/docs/command_reference/supplementary/create.rst
@@ -26,8 +26,8 @@ CSVのフォーマットは以下の通りです。
    :header: 列名,必須,備考
 
     input_data_id,Yes,
-    supplementary_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
     supplementary_data_name,Yes,
+    supplementary_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
     supplementary_data_id,No,省略した場合はsupplementary_data_nameに近い値（IDに使えない文字を加工した値）になります。
     supplementary_data_type,No,補助情報の種類。 ``image`` 、 ``text`` または ``custom`` のいずれかを指定ください。省略した場合は、ファイル名から推測します。
     supplementary_data_number,No,補助情報の表示順。省略した場合は、既存の補助情報の最大値+1になります。
@@ -38,12 +38,12 @@ CSVのフォーマットは以下の通りです。
     :caption: supplementary_data.csv
 
     input_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_id,supplementary_data_type,supplementary_data_number
-    input1,data1-1,s3://example.com/data1,id1,
+    input1,data1-1,s3://example.com/data1,id1,,
     input1,data1-2,s3://example.com/data2,id2,image,1
     input1,data1-3,s3://example.com/data3,id3,text,2
-    input2,data2-1,https://example.com/data4,,
-    input2,data2-2,file://sample.jpg,,
-    input2,data2-3,file:///tmp/sample.jpg,,
+    input2,data2-1,https://example.com/data4,,,
+    input2,data2-2,file://sample.jpg,,,
+    input2,data2-3,file:///tmp/sample.jpg,,,
 
 
 .. warning::

--- a/docs/command_reference/supplementary/create.rst
+++ b/docs/command_reference/supplementary/create.rst
@@ -48,7 +48,7 @@ CSVのフォーマットは以下の通りです。
 
 .. warning::
 
-    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``input_data_path`` に ``https`` または ``s3`` スキームを利用できません。
+    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``supplementary_data_path`` に ``https`` または ``s3`` スキームを利用できません。
     プライベートストレージを利用するには、Annofabサポート窓口への問い合わせが必要です。
     詳細は https://annofab.readme.io/docs/external-storage を参照してください。
 

--- a/docs/command_reference/supplementary/create.rst
+++ b/docs/command_reference/supplementary/create.rst
@@ -1,16 +1,10 @@
 =================================
-supplementary put
+supplementary create
 =================================
 
 Description
 =================================
 補助情報を作成します。
-
-.. warning::
-
-   このコマンドは非推奨です。代わりに :doc:`create` コマンドを使用してください。
-
-   ``supplementary put`` コマンドは2027/01/01以降に廃止予定です。
 
 
 
@@ -18,9 +12,9 @@ Examples
 =================================
 
 
-CSVから補助情報を登録する
+CSVから補助情報を作成する
 --------------------------------------
-補助情報が記載されたCSVファイルを元に、補助情報を登録します。
+補助情報が記載されたCSVファイルを元に、補助情報を作成します。
 
 
 CSVのフォーマットは以下の通りです。
@@ -64,19 +58,19 @@ CSVのフォーマットは以下の通りです。
 
 .. code-block::
 
-    $ annofabcli supplementary put --project_id prj1 --csv supplementary_data.csv
+    $ annofabcli supplementary create --project_id prj1 --csv supplementary_data.csv
 
 
 supplementary_data_idが一致する補助情報が既に存在する場合は、デフォルトではスキップします。補助情報を上書きする場合は、 ``--overwrite`` を指定してください。
 
 .. code-block::
-    
-    $ annofabcli supplementary put --project_id prj1 --csv supplementary_data.csv --overwrite
+
+    $ annofabcli supplementary create --project_id prj1 --csv supplementary_data.csv --overwrite
 
 
-JSONから補助情報を登録する
+JSONから補助情報を作成する
 --------------------------------------
-補助情報が記載されたJSONファイルを元に、補助情報を登録します。
+補助情報が記載されたJSONファイルを元に、補助情報を作成します。
 
 
 以下は、JSONのサンプルです。
@@ -88,7 +82,7 @@ JSONから補助情報を登録する
     :caption: supplementary_data.json
 
     [
-        
+
         {
             "input_data_id": "input1",
             "supplementary_data_number": 1,
@@ -114,9 +108,9 @@ JSONのキーは、``--csv`` に指定するCSVファイルの列に対応しま
 
 .. code-block::
 
-    $ annofabcli supplementary put --project_id prj1 --json file://supplementary_data.json
+    $ annofabcli supplementary create --project_id prj1 --json file://supplementary_data.json
 
-    
+
 
 並列処理
 ----------------------------------------------
@@ -125,15 +119,15 @@ JSONのキーは、``--csv`` に指定するCSVファイルの列に対応しま
 
 .. code-block::
 
-    $ annofabcli supplementary put --project_id prj1 --csv supplementary_data.csv
+    $ annofabcli supplementary create --project_id prj1 --csv supplementary_data.csv
     --parallelism 4 --yes
 
 Usage Details
 =================================
 
 .. argparse::
-   :ref: annofabcli.supplementary.put_supplementary_data.add_parser
-   :prog: annofabcli supplementary put
+   :ref: annofabcli.supplementary.create_supplementary_data.add_parser
+   :prog: annofabcli supplementary create
    :nosubcommands:
    :nodefaultconst:
 

--- a/docs/command_reference/supplementary/index.rst
+++ b/docs/command_reference/supplementary/index.rst
@@ -15,9 +15,11 @@ Available Commands
    :maxdepth: 1
    :titlesonly:
 
+   create
    delete
    list
    put
+   update
 
 Usage Details
 =================================

--- a/docs/command_reference/supplementary/put.rst
+++ b/docs/command_reference/supplementary/put.rst
@@ -54,7 +54,7 @@ CSVのフォーマットは以下の通りです。
 
 .. warning::
 
-    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``input_data_path`` に ``https`` または ``s3`` スキームを利用できません。
+    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``supplementary_data_path`` に ``https`` または ``s3`` スキームを利用できません。
     プライベートストレージを利用するには、Annofabサポート窓口への問い合わせが必要です。
     詳細は https://annofab.readme.io/docs/external-storage を参照してください。
 

--- a/docs/command_reference/supplementary/put.rst
+++ b/docs/command_reference/supplementary/put.rst
@@ -32,8 +32,8 @@ CSVのフォーマットは以下の通りです。
    :header: 列名,必須,備考
 
     input_data_id,Yes,
-    supplementary_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
     supplementary_data_name,Yes,
+    supplementary_data_path,Yes,先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
     supplementary_data_id,No,省略した場合はsupplementary_data_nameに近い値（IDに使えない文字を加工した値）になります。
     supplementary_data_type,No,補助情報の種類。 ``image`` 、 ``text`` または ``custom`` のいずれかを指定ください。省略した場合は、ファイル名から推測します。
     supplementary_data_number,No,補助情報の表示順。省略した場合は、既存の補助情報の最大値+1になります。
@@ -44,12 +44,12 @@ CSVのフォーマットは以下の通りです。
     :caption: supplementary_data.csv
 
     input_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_id,supplementary_data_type,supplementary_data_number
-    input1,data1-1,s3://example.com/data1,id1,
+    input1,data1-1,s3://example.com/data1,id1,,
     input1,data1-2,s3://example.com/data2,id2,image,1
     input1,data1-3,s3://example.com/data3,id3,text,2
-    input2,data2-1,https://example.com/data4,,
-    input2,data2-2,file://sample.jpg,,
-    input2,data2-3,file:///tmp/sample.jpg,,
+    input2,data2-1,https://example.com/data4,,,
+    input2,data2-2,file://sample.jpg,,,
+    input2,data2-3,file:///tmp/sample.jpg,,,
 
 
 .. warning::

--- a/docs/command_reference/supplementary/update.rst
+++ b/docs/command_reference/supplementary/update.rst
@@ -1,0 +1,112 @@
+=================================
+supplementary update
+=================================
+
+Description
+=================================
+補助情報の名前、パス、種類、表示順を更新します。
+
+
+Examples
+=================================
+
+
+CSVファイルを指定する場合
+--------------------------------------
+``--csv`` に、更新対象の補助情報と更新後の値が記載されたCSVファイルのパスを指定してください。
+
+CSVのフォーマットは以下の通りです。
+
+* カンマ区切り
+* ヘッダ行あり
+
+.. csv-table::
+   :header: 列名,必須,備考
+
+    input_data_id,Yes,更新対象の補助情報が紐づく入力データID
+    supplementary_data_id,Yes,更新対象の補助情報ID
+    supplementary_data_name,No,変更後の補助情報名。更新しない場合は空欄
+    supplementary_data_path,No,変更後の補助情報パス。更新しない場合は空欄。先頭が ``file://`` の場合、ローカルのファイルを補助情報に使用します。
+    supplementary_data_type,No,変更後の補助情報の種類。更新しない場合は空欄
+    supplementary_data_number,No,変更後の補助情報の表示順。更新しない場合は空欄
+
+
+以下はCSVファイルのサンプルです。
+
+.. code-block::
+    :caption: supplementary_data.csv
+
+    input_data_id,supplementary_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_type,supplementary_data_number
+    input1,supplementary1,new_name1,,,
+    input1,supplementary2,,s3://bucket/new_image.jpg,,
+    input2,supplementary3,new_name3,https://example.com/new_image.jpg,image,2
+    input2,supplementary4,,file://new_image.jpg,,
+
+
+.. warning::
+
+    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``input_data_path`` に ``https`` または ``s3`` スキームを利用できません。
+    プライベートストレージを利用するには、Annofabサポート窓口への問い合わせが必要です。
+    詳細は https://annofab.readme.io/docs/external-storage を参照してください。
+
+``supplementary_data_path`` の先頭が ``file://`` の場合、指定したローカルファイルをアップロードし、補助情報のパスをアップロード後のパスに更新します。
+
+
+.. code-block::
+
+    $ annofabcli supplementary update --project_id prj1 --csv supplementary_data.csv
+
+
+JSON文字列を指定する場合
+--------------------------------------
+``--json`` に、更新対象の補助情報と更新後の値をJSON文字列で指定してください。
+
+以下は、JSONのサンプルです。
+
+.. code-block::
+    :caption: supplementary_data.json
+
+    [
+        {
+            "input_data_id": "input1",
+            "supplementary_data_id": "supplementary1",
+            "supplementary_data_name": "new_name1"
+        },
+        {
+            "input_data_id": "input1",
+            "supplementary_data_id": "supplementary2",
+            "supplementary_data_path": "s3://bucket/new_image.jpg"
+        },
+        {
+            "input_data_id": "input2",
+            "supplementary_data_id": "supplementary3",
+            "supplementary_data_name": "new_name3",
+            "supplementary_data_path": "https://example.com/new_image.jpg",
+            "supplementary_data_type": "image",
+            "supplementary_data_number": 2
+        },
+        {
+            "input_data_id": "input2",
+            "supplementary_data_id": "supplementary4",
+            "supplementary_data_path": "file://new_image.jpg"
+        }
+    ]
+
+JSONのキーは、 ``--csv`` に指定するCSVファイルの列に対応します。
+更新しないプロパティは、キーを記載しないか値をnullにしてください。
+
+``--json`` にJSON形式の文字列、またはJSONファイルのパスを指定できます。
+
+.. code-block::
+
+    $ annofabcli supplementary update --project_id prj1 --json file://supplementary_data.json
+
+
+Usage Details
+=================================
+
+.. argparse::
+   :ref: annofabcli.supplementary.update_supplementary_data.add_parser
+   :prog: annofabcli supplementary update
+   :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/supplementary/update.rst
+++ b/docs/command_reference/supplementary/update.rst
@@ -45,7 +45,7 @@ CSVのフォーマットは以下の通りです。
 
 .. warning::
 
-    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``input_data_path`` に ``https`` または ``s3`` スキームを利用できません。
+    プライベートストレージが利用可能な組織配下のプロジェクトでしか、 ``supplementary_data_path`` に ``https`` または ``s3`` スキームを利用できません。
     プライベートストレージを利用するには、Annofabサポート窓口への問い合わせが必要です。
     詳細は https://annofab.readme.io/docs/external-storage を参照してください。
 

--- a/tests/supplementary/test_create_supplementary_data.py
+++ b/tests/supplementary/test_create_supplementary_data.py
@@ -1,0 +1,53 @@
+import pytest
+
+from annofabcli.supplementary.create_supplementary_data import CreateSupplementaryData, read_supplementary_data_csv
+
+
+def test__common_message():
+    assert CreateSupplementaryData.COMMON_MESSAGE == "annofabcli supplementary create: error:"
+
+
+def test__read_supplementary_data_csv__header_exists(tmp_path):
+    csv_path = tmp_path / "supplementary_data.csv"
+    csv_path.write_text(
+        "input_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_id,supplementary_data_type,supplementary_data_number\ninput1,data1,file://data1.jpg,id1,image,1\n"
+    )
+
+    df = read_supplementary_data_csv(csv_path)
+
+    assert df.to_dict("records") == [
+        {
+            "input_data_id": "input1",
+            "supplementary_data_name": "data1",
+            "supplementary_data_path": "file://data1.jpg",
+            "supplementary_data_id": "id1",
+            "supplementary_data_type": "image",
+            "supplementary_data_number": 1,
+        }
+    ]
+
+
+def test__read_supplementary_data_csv__header_not_exists(tmp_path):
+    csv_path = tmp_path / "supplementary_data.csv"
+    csv_path.write_text("input1,data1,file://data1.jpg,id1,image,1\n")
+
+    with pytest.raises(ValueError):
+        read_supplementary_data_csv(csv_path)
+
+
+def test__get_supplementary_data_list_from_csv__supplementary_data_number_is_optional(tmp_path):
+    csv_path = tmp_path / "supplementary_data.csv"
+    csv_path.write_text("input_data_id,supplementary_data_name,supplementary_data_path\ninput1,data1,file://data1.jpg\n")
+
+    supplementary_data_list = CreateSupplementaryData.get_supplementary_data_list_from_csv(csv_path)
+
+    assert supplementary_data_list[0].supplementary_data_number is None
+
+
+def test__get_supplementary_data_list_from_csv__empty_supplementary_data_number(tmp_path):
+    csv_path = tmp_path / "supplementary_data.csv"
+    csv_path.write_text("input_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_number\ninput1,data1,file://data1.jpg,\n")
+
+    supplementary_data_list = CreateSupplementaryData.get_supplementary_data_list_from_csv(csv_path)
+
+    assert supplementary_data_list[0].supplementary_data_number is None

--- a/tests/supplementary/test_update_supplementary_data.py
+++ b/tests/supplementary/test_update_supplementary_data.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+import annofabapi
+import pytest
+
+from annofabcli.supplementary.update_supplementary_data import (
+    UpdateResult,
+    UpdateSupplementaryDataMain,
+    create_updated_supplementary_data_list_from_csv,
+)
+
+
+def create_old_supplementary_data() -> dict[str, str | int]:
+    return {
+        "input_data_id": "input1",
+        "supplementary_data_id": "supplementary1",
+        "supplementary_data_name": "old_name",
+        "supplementary_data_path": "s3://bucket/old_image.jpg",
+        "supplementary_data_type": "image",
+        "supplementary_data_number": 1,
+        "updated_datetime": "2026-01-01T00:00:00.000+09:00",
+    }
+
+
+def create_service() -> tuple[annofabapi.Resource, Mock, Mock]:
+    api = Mock()
+    wrapper = Mock()
+    wrapper.get_supplementary_data_list_or_none.return_value = [create_old_supplementary_data()]
+    service = cast(annofabapi.Resource, SimpleNamespace(api=api, wrapper=wrapper))
+    return service, api, wrapper
+
+
+def test_update_supplementary_data_with_url_path() -> None:
+    service, api, wrapper = create_service()
+    main_obj = UpdateSupplementaryDataMain(service, all_yes=True)
+
+    result = main_obj.update_supplementary_data(
+        "project1",
+        "input1",
+        "supplementary1",
+        new_supplementary_data_path="s3://bucket/new_image.jpg",
+        new_supplementary_data_number=2,
+    )
+
+    assert result == UpdateResult.SUCCESS
+    api.put_supplementary_data.assert_called_once_with(
+        "project1",
+        "input1",
+        "supplementary1",
+        request_body={
+            "input_data_id": "input1",
+            "supplementary_data_id": "supplementary1",
+            "supplementary_data_name": "old_name",
+            "supplementary_data_path": "s3://bucket/new_image.jpg",
+            "supplementary_data_type": "image",
+            "supplementary_data_number": 2,
+            "updated_datetime": "2026-01-01T00:00:00.000+09:00",
+            "last_updated_datetime": "2026-01-01T00:00:00.000+09:00",
+        },
+    )
+    wrapper.put_supplementary_data_from_file.assert_not_called()
+
+
+def test_update_supplementary_data_with_file_scheme_path(tmp_path: Path) -> None:
+    supplementary_data_file = tmp_path / "new_image.jpg"
+    supplementary_data_file.write_bytes(b"image")
+    service, api, wrapper = create_service()
+    main_obj = UpdateSupplementaryDataMain(service, all_yes=True)
+
+    result = main_obj.update_supplementary_data(
+        "project1",
+        "input1",
+        "supplementary1",
+        new_supplementary_data_name="new_name",
+        new_supplementary_data_path=f"file://{supplementary_data_file}",
+    )
+
+    assert result == UpdateResult.SUCCESS
+    wrapper.put_supplementary_data_from_file.assert_called_once_with(
+        "project1",
+        input_data_id="input1",
+        supplementary_data_id="supplementary1",
+        file_path=str(supplementary_data_file),
+        request_body={
+            "input_data_id": "input1",
+            "supplementary_data_id": "supplementary1",
+            "supplementary_data_name": "new_name",
+            "supplementary_data_path": "s3://bucket/old_image.jpg",
+            "supplementary_data_type": "image",
+            "supplementary_data_number": 1,
+            "updated_datetime": "2026-01-01T00:00:00.000+09:00",
+            "last_updated_datetime": "2026-01-01T00:00:00.000+09:00",
+        },
+    )
+    api.put_supplementary_data.assert_not_called()
+
+
+def test_update_supplementary_data_with_missing_file_scheme_path(tmp_path: Path) -> None:
+    service, api, wrapper = create_service()
+    main_obj = UpdateSupplementaryDataMain(service, all_yes=True)
+
+    result = main_obj.update_supplementary_data("project1", "input1", "supplementary1", new_supplementary_data_path=f"file://{tmp_path / 'missing.jpg'}")
+
+    assert result == UpdateResult.SKIPPED
+    wrapper.put_supplementary_data_from_file.assert_not_called()
+    api.put_supplementary_data.assert_not_called()
+
+
+def test_update_supplementary_data_without_changes() -> None:
+    service, api, wrapper = create_service()
+    main_obj = UpdateSupplementaryDataMain(service, all_yes=True)
+
+    result = main_obj.update_supplementary_data("project1", "input1", "supplementary1")
+
+    assert result == UpdateResult.SKIPPED
+    wrapper.put_supplementary_data_from_file.assert_not_called()
+    api.put_supplementary_data.assert_not_called()
+
+
+def test_create_updated_supplementary_data_list_from_csv(tmp_path: Path) -> None:
+    csv_path = tmp_path / "supplementary_data.csv"
+    csv_path.write_text(
+        "input_data_id,supplementary_data_id,supplementary_data_name,supplementary_data_path,supplementary_data_type,supplementary_data_number\ninput1,supplementary1,new_name,,text,2\n"
+    )
+
+    supplementary_data_list = create_updated_supplementary_data_list_from_csv(csv_path)
+
+    assert len(supplementary_data_list) == 1
+    assert supplementary_data_list[0].input_data_id == "input1"
+    assert supplementary_data_list[0].supplementary_data_id == "supplementary1"
+    assert supplementary_data_list[0].supplementary_data_name == "new_name"
+    assert supplementary_data_list[0].supplementary_data_path is None
+    assert supplementary_data_list[0].supplementary_data_type == "text"
+    assert supplementary_data_list[0].supplementary_data_number == 2
+
+
+def test_create_updated_supplementary_data_list_from_csv_without_required_columns(tmp_path: Path) -> None:
+    csv_path = tmp_path / "supplementary_data.csv"
+    csv_path.write_text("input_data_id,supplementary_data_name\ninput1,new_name\n")
+
+    with pytest.raises(ValueError):
+        create_updated_supplementary_data_list_from_csv(csv_path)


### PR DESCRIPTION
## Summary
- add `annofabcli supplementary create` as the create-style entrypoint for supplementary data
- register the command in supplementary subcommands and docs
- mark `supplementary put` as deprecated in CLI output and docs

close #1357

## Tests
- `make format`
- `make lint`
- `uv run pytest tests/supplementary`
- `uv run annofabcli supplementary create --help`