### PR TITLE
`annotation_zip filter`:新規作成

### DIFF
--- a/annofabcli/annotation_zip/filter.py
+++ b/annofabcli/annotation_zip/filter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import os
@@ -60,7 +62,7 @@ def create_outer_filepath_dict(namelist: list[str]) -> dict[str, list[str]]:
         namelist: zipファイル内のファイル一覧
 
     Returns:
-
+        外部アノテーションが格納されているディレクトリとファイルパス一覧のdict。
     """
     d = defaultdict(list)
     for name in namelist:
@@ -72,7 +74,21 @@ def create_outer_filepath_dict(namelist: list[str]) -> dict[str, list[str]]:
     return d
 
 
-class FilterAnnotation:
+class FilterAnnotationZip:
+    COMMON_MESSAGE = "annofabcli annotation_zip filter:"
+
+    @staticmethod
+    def get_annotation_json_path(annotation_dir: Path, parser_json_file_path: str) -> tuple[Path, Path]:
+        json_file_path = Path(parser_json_file_path)
+        try:
+            relative_json_file_path = json_file_path.relative_to(annotation_dir)
+            source_json_file_path = json_file_path
+        except ValueError:
+            relative_json_file_path = json_file_path
+            source_json_file_path = annotation_dir / relative_json_file_path
+
+        return source_json_file_path, relative_json_file_path
+
     @staticmethod
     def filter_annotation_zip(annotation_zip: Path, filter_query: FilterQuery, output_dir: Path) -> None:
         with zipfile.ZipFile(str(annotation_zip)) as zip_file:
@@ -104,13 +120,15 @@ class FilterAnnotation:
                 continue
 
             # JSONファイルをコピー
-            dest_task_id_dir = output_dir / parser.task_id
-            dest_task_id_dir.mkdir(exist_ok=True, parents=True)
-            shutil.copy(str(annotation_dir / parser.json_file_path), str(dest_task_id_dir))
+            source_json_file_path, relative_json_file_path = FilterAnnotationZip.get_annotation_json_path(annotation_dir, parser.json_file_path)
+            output_json_file_path = output_dir / relative_json_file_path
+            output_json_file_path.parent.mkdir(exist_ok=True, parents=True)
+            shutil.copy(source_json_file_path, output_json_file_path)
             # 塗りつぶしアノテーションファイルをコピー
-            outer_annotation_dir = annotation_dir / os.path.splitext(parser.json_file_path)[0]  # noqa: PTH122
+            outer_annotation_path = Path(os.path.splitext(str(relative_json_file_path))[0])  # noqa: PTH122
+            outer_annotation_dir = annotation_dir / outer_annotation_path
             if outer_annotation_dir.exists():
-                shutil.copytree(str(outer_annotation_dir), str(output_dir))
+                shutil.copytree(outer_annotation_dir, output_dir / outer_annotation_path, dirs_exist_ok=True)
 
             count += 1
             if count % 10000 == 0:
@@ -140,9 +158,6 @@ class FilterAnnotation:
         )
 
     def main(self, args: argparse.Namespace) -> None:
-        logger.info(f"args: {args}")
-        COMMON_MESSAGE = "annofabcli filesystem filter_annotation:"  # noqa: N806
-
         annotation_path: Path = args.annotation
         output_dir: Path = args.output_dir
         output_dir.mkdir(exist_ok=True, parents=True)
@@ -153,12 +168,12 @@ class FilterAnnotation:
         elif annotation_path.is_dir():
             self.filter_annotation_dir(annotation_path, filter_query=filter_query, output_dir=output_dir)
         else:
-            print(f"{COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
+            print(f"{self.COMMON_MESSAGE} argument --annotation: ZIPファイルまたはディレクトリを指定してください。", file=sys.stderr)  # noqa: T201
             sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
 
 
 def main(args: argparse.Namespace) -> None:
-    FilterAnnotation().main(args)
+    FilterAnnotationZip().main(args)
 
 
 def parse_args(parser: argparse.ArgumentParser) -> None:
@@ -220,7 +235,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
 
 def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
-    subcommand_name = "filter_annotation"
+    subcommand_name = "filter"
 
     subcommand_help = "アノテーションzipから特定のファイルを絞り込んで、zip展開します。"
 

--- a/annofabcli/annotation_zip/subcommand_annotation_zip.py
+++ b/annofabcli/annotation_zip/subcommand_annotation_zip.py
@@ -3,6 +3,7 @@
 import argparse
 
 import annofabcli
+from annofabcli.annotation_zip.filter import add_parser as add_parser_filter
 from annofabcli.annotation_zip.list_annotation_3d_bounding_box import add_parser as add_parser_list_annotation_3d_bounding_box
 from annofabcli.annotation_zip.list_annotation_bounding_box_2d import add_parser as add_parser_list_annotation_bounding_box_2d
 from annofabcli.annotation_zip.list_polygon_annotation import add_parser as add_parser_list_polygon_annotation
@@ -21,6 +22,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     subparsers = parser.add_subparsers(dest="subcommand_name")
 
     # サブコマンドの定義
+    add_parser_filter(subparsers)
     add_parser_list_annotation_3d_bounding_box(subparsers)
     add_parser_list_annotation_bounding_box_2d(subparsers)
     add_parser_list_polygon_annotation(subparsers)

--- a/annofabcli/filesystem/subcommand_filesystem.py
+++ b/annofabcli/filesystem/subcommand_filesystem.py
@@ -2,7 +2,6 @@ import argparse
 
 import annofabcli.common.cli
 import annofabcli.filesystem.draw_annotation
-import annofabcli.filesystem.filter_annotation
 import annofabcli.filesystem.mask_user_info
 import annofabcli.filesystem.merge_annotation
 
@@ -12,7 +11,6 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     # サブコマンドの定義
     annofabcli.filesystem.draw_annotation.add_parser(subparsers)
-    annofabcli.filesystem.filter_annotation.add_parser(subparsers)
     annofabcli.filesystem.mask_user_info.add_parser(subparsers)
     annofabcli.filesystem.merge_annotation.add_parser(subparsers)
 

--- a/docs/command_reference/annotation_zip/filter.rst
+++ b/docs/command_reference/annotation_zip/filter.rst
@@ -1,5 +1,5 @@
 =================================
-filesystem filter_annotation
+annotation_zip filter
 =================================
 
 Description
@@ -22,7 +22,7 @@ Examples
 
 .. code-block::
 
-    $ annofabcli filesystem filter_annotation  --annotation annotation.zip \
+    $ annofabcli annotation_zip filter --annotation annotation.zip \
     --task_query '{"status":"complete"}' \
     --output_dir out/
 
@@ -31,9 +31,9 @@ Examples
 
 .. code-block::
 
-    $ annofabcli filesystem filter_annotation  --annotation annotation.zip \
+    $ annofabcli annotation_zip filter --annotation annotation.zip \
     --task_query '{"status":"complete"}' \
-    --exclude_task_id task1 task2
+    --exclude_task_id task1 task2 \
     --output_dir out/
 
 task_id以外にも ``--input_data_id`` , ``--input_data_name`` で絞り込むことができます。
@@ -42,8 +42,7 @@ Usage Details
 =================================
 
 .. argparse::
-   :ref: annofabcli.filesystem.filter_annotation.add_parser
-   :prog: annofabcli filesystem filter_annotation
+   :ref: annofabcli.annotation_zip.filter.add_parser
+   :prog: annofabcli annotation_zip filter
    :nosubcommands:
    :nodefaultconst:
-

--- a/docs/command_reference/annotation_zip/index.rst
+++ b/docs/command_reference/annotation_zip/index.rst
@@ -15,6 +15,7 @@ Available Commands
    :maxdepth: 1
    :titlesonly:
 
+   filter
    list_3d_bounding_box_annotation
    list_bounding_box_annotation
    list_polygon_annotation

--- a/docs/command_reference/filesystem/draw_annotation.rst
+++ b/docs/command_reference/filesystem/draw_annotation.rst
@@ -225,7 +225,7 @@ CSVのフォーマットは以下の通りです。
 
 .. code-block::
 
-    $ annofabcli filesystem filter_annotation  --annotation annotation.zip \
+    $ annofabcli annotation_zip filter --annotation annotation.zip \
     --task_query '{"status":"complete"}' \
     --output_dir out/
 

--- a/docs/command_reference/filesystem/index.rst
+++ b/docs/command_reference/filesystem/index.rst
@@ -17,7 +17,6 @@ Available Commands
    :titlesonly:
 
    draw_annotation
-   filter_annotation
    mask_user_info
    merge_annotation
 

--- a/tests/annotation_zip/test_filter.py
+++ b/tests/annotation_zip/test_filter.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from annofabcli.__main__ import main
+
+data_dir = Path("./tests/data/filesystem")
+out_dir = Path("./tests/out/annotation_zip")
+
+
+class TestCommandLine:
+    def test_filter(self):
+        zip_path = data_dir / "simple-annotation.zip"
+        output_dir = out_dir / "filter-output"
+
+        main(
+            [
+                "annotation_zip",
+                "filter",
+                "--annotation",
+                str(zip_path),
+                "--output_dir",
+                str(output_dir),
+                "--task_query",
+                '{"status":"complete"}',
+            ]
+        )
+
+        assert (output_dir / "sample_1/c6e1c2ec-6c7c-41c6-9639-4244c2ed2839.json").exists()
+
+    def test_filter_dir_with_outer_file(self):
+        annotation_dir = data_dir / "merge/annotation-A"
+        output_dir = out_dir / "filter-dir-output"
+
+        main(
+            [
+                "annotation_zip",
+                "filter",
+                "--annotation",
+                str(annotation_dir),
+                "--output_dir",
+                str(output_dir),
+                "--input_data_id",
+                "input2",
+            ]
+        )
+
+        assert (output_dir / "task2/input2/1e2931d2-de34-4956-ab75-81f710dc0108").exists()

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -26,23 +26,6 @@ class TestCommandLine:
             ]
         )
 
-    def test_filter_annotation(self):
-        zip_path = data_dir / "simple-annotation.zip"
-        output_dir = out_dir / "filter-annotation-output"
-
-        main(
-            [
-                "filesystem",
-                "filter_annotation",
-                "--annotation",
-                str(zip_path),
-                "--output_dir",
-                str(output_dir),
-                "--task_query",
-                '{"status":"complete"}',
-            ]
-        )
-
     def test_mask_user_info(self):
         csv_path = data_dir / "user1.csv"
         out_path = out_dir / "out-user1.csv"


### PR DESCRIPTION
"filesystem filter_annotation"から"annotation_zip"配下に移動しました。
## Summary
- add annofabcli annotation_zip filter as a new command
- reuse the existing filesystem filter_annotation behavior and command arguments without interface changes
- add command reference docs and CLI test

## Tests
- make format
- make lint
- uv run pytest tests/annotation_zip/test_filter.py tests/test_filesystem.py::TestCommandLine::test_filter_annotation