### PR TITLE
docs: 全体の生産性と品質CSVのサンプルを表示する

### DIFF
--- a/docs/command_reference/statistics/visualize/out_dir/全体の生産性と品質.csv
+++ b/docs/command_reference/statistics/visualize/out_dir/全体の生産性と品質.csv
@@ -1,5 +1,7 @@
 ﻿first_working_date,,2026-05-22
 last_working_date,,2026-06-08
+lastweek_start_date,,2026-06-02
+lastweek_end_date,,2026-06-08
 working_days,,15
 real_monitored_worktime_hour,sum,990.1517122222223
 real_monitored_worktime_hour,annotation,899.4402963888889
@@ -29,6 +31,12 @@ monitored_worktime_hour/annotation_count,annotation,0.02283441520902363
 monitored_worktime_hour/annotation_count,inspection,0.012266303309158913
 actual_worktime_hour/annotation_count,annotation,0.0
 actual_worktime_hour/annotation_count,inspection,0.0
+task_count__lastweek,annotation,180
+task_count__lastweek,inspection,21
+input_data_count__lastweek,annotation,674
+input_data_count__lastweek,inspection,77
+annotation_count__lastweek,annotation,11393
+annotation_count__lastweek,inspection,1362
 monitored_worktime_hour/task_count,annotation,1.9984073033076428
 monitored_worktime_hour/task_count,inspection,0.9638940277777778
 actual_worktime_hour/task_count,annotation,0.0

--- a/docs/command_reference/statistics/visualize_output_rst/全体の生産性と品質_csv.rst
+++ b/docs/command_reference/statistics/visualize_output_rst/全体の生産性と品質_csv.rst
@@ -9,12 +9,21 @@
 `全体の生産性と品質.csvのサンプル <https://github.com/kurusugawa-computer/annofab-cli/blob/main/docs/command_reference/statistics/visualize/out_dir/全体の生産性と品質.csv>`_
 
 
+.. csv-table:: 全体の生産性と品質.csv
+    :file: ../visualize/out_dir/全体の生産性と品質.csv
+
+
 列の内容
 ===================================================================================================
 
 :doc:`メンバごとの生産性と品質_csv` に記載されている列に加えて、以下の列が出力されます。
 
 * ``working_user_count`` : 作業したユーザー数
+* ``lastweek_start_date`` : 直近7日間の開始日。教師付開始日が存在するタスクのうち、最大の教師付開始日から6日前の日付です。
+* ``lastweek_end_date`` : 直近7日間の終了日。教師付開始日が存在するタスクのうち、最大の教師付開始日です。
+* ``task_count__lastweek`` : 直近7日間に教師付開始したタスクの、タスク数
+* ``input_data_count__lastweek`` : 直近7日間に教師付開始したタスクの、入力データ数
+* ``annotation_count__lastweek`` : 直近7日間に教師付開始したタスクの、アノテーション数
 * ``monitored_worktime_hour/task_count`` : タスクあたり計測作業時間
 * ``actual_worktime_hour/task_count`` : タスクあたり実績作業時間
 * ``monitored_worktime_hour/task_count__lastweek`` : 直近7日間に教師付開始したタスクの、タスクあたり計測作業時間

--- a/docs/command_reference/statistics/visualize_output_rst/全体の生産性と品質_csv.rst
+++ b/docs/command_reference/statistics/visualize_output_rst/全体の生産性と品質_csv.rst
@@ -6,10 +6,7 @@
 :doc:`メンバごとの生産性と品質_csv` の内容を集計した値になります。
 
 
-`全体の生産性と品質.csvのサンプル <https://github.com/kurusugawa-computer/annofab-cli/blob/main/docs/command_reference/statistics/visualize/out_dir/全体の生産性と品質.csv>`_
-
-
-.. csv-table:: 全体の生産性と品質.csv
+.. csv-table:: 全体の生産性と品質.csv のサンプル
     :file: ../visualize/out_dir/全体の生産性と品質.csv
 
 


### PR DESCRIPTION
## 概要
- 全体の生産性と品質.csv のドキュメントに csv-table でサンプルCSVを表示
- サンプルCSVに直近7日間の期間と生産量の行を追加

## 確認
- make format
- make lint