### PR TITLE
プロンプトの表示を"y/N/ALL"でなく、CLI慣習に合わせた"y/n/all"にしました。

### DIFF
--- a/annofabcli/common/cli.py
+++ b/annofabcli/common/cli.py
@@ -381,14 +381,14 @@ def prompt_yesnoall(msg: str) -> tuple[bool, bool]:
 
     """
     while True:
-        choice = input(f"{msg} [y/N/ALL] : ")
+        choice = input(f"{msg} [y/n/all] : ").lower()
         if choice == "y":  # noqa: SIM116
             return True, False
 
-        elif choice == "N":
+        elif choice == "n":
             return False, False
 
-        elif choice == "ALL":
+        elif choice == "all":
             return True, True
 
 

--- a/tests/common/test_cli.py
+++ b/tests/common/test_cli.py
@@ -1,8 +1,9 @@
 import argparse
+import builtins
 
 import pytest
 
-from annofabcli.common.cli import get_json_from_args, get_list_from_args, non_negative_int
+from annofabcli.common.cli import get_json_from_args, get_list_from_args, non_negative_int, prompt_yesnoall
 
 
 def test_get_json_from_args():
@@ -31,3 +32,22 @@ def test_non_negative_int() -> None:
 
     with pytest.raises(argparse.ArgumentTypeError):
         non_negative_int("-1")
+
+
+def test_prompt_yesnoall_uses_lowercase_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompt_list = []
+
+    def input_mock(prompt: str) -> str:
+        prompt_list.append(prompt)
+        return "all"
+
+    monkeypatch.setattr(builtins, "input", input_mock)
+
+    assert prompt_yesnoall("処理しますか？") == (True, True)
+    assert prompt_list == ["処理しますか？ [y/n/all] : "]
+
+
+def test_prompt_yesnoall_accepts_uppercase_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(builtins, "input", lambda _prompt: "ALL")
+
+    assert prompt_yesnoall("処理しますか？") == (True, True)


### PR DESCRIPTION
close #1481 