### PR TITLE
`annotation_specs delete_choices`: 選択肢を削除可能にする

### DIFF
--- a/annofabcli/annotation_specs/delete_attributes.py
+++ b/annofabcli/annotation_specs/delete_attributes.py
@@ -104,7 +104,7 @@ def restriction_references_attribute(restriction: Mapping[str, Any], attribute_i
     return references_attribute(restriction)
 
 
-def create_comment_for_delete_attribute(resolved_deletion: ResolvedAttributeDeletion) -> str:
+def create_comment_for_delete_attributes(resolved_deletion: ResolvedAttributeDeletion) -> str:
     """
     属性削除時のデフォルトコメントを生成する。
 
@@ -122,7 +122,7 @@ def create_comment_for_delete_attribute(resolved_deletion: ResolvedAttributeDele
     return "\n".join(lines)
 
 
-def create_confirm_message_for_delete_attribute(
+def create_confirm_message_for_delete_attributes(
     resolved_deletion: ResolvedAttributeDeletion,
     *,
     affecting_annotations: Sequence[AffectingAnnotation],
@@ -343,7 +343,7 @@ def resolve_attribute_deletion(
     )
 
 
-def build_request_body_for_delete_attribute(
+def build_request_body_for_delete_attributes(
     annotation_specs: dict[str, Any],
     *,
     resolved_deletion: ResolvedAttributeDeletion,
@@ -373,13 +373,13 @@ def build_request_body_for_delete_attribute(
     request_body["additionals"] = [attribute for attribute in request_body["additionals"] if attribute["additional_data_definition_id"] not in orphan_attribute_ids]
     request_body["restrictions"] = [restriction for restriction in request_body["restrictions"] if restriction not in resolved_deletion.restrictions_to_remove]
     if comment is None:
-        comment = create_comment_for_delete_attribute(resolved_deletion)
+        comment = create_comment_for_delete_attributes(resolved_deletion)
     request_body["comment"] = comment
     request_body["last_updated_datetime"] = annotation_specs["updated_datetime"]
     return request_body
 
 
-class DeleteAttributeMain(CommandLineWithConfirm):
+class DeleteAttributesMain(CommandLineWithConfirm):
     """
     ラベルから属性を削除する本体処理。
     """
@@ -465,7 +465,7 @@ class DeleteAttributeMain(CommandLineWithConfirm):
         )
         return False
 
-    def delete_attribute(
+    def delete_attributes(
         self,
         *,
         attribute_ids: Collection[str] | None,
@@ -502,22 +502,22 @@ class DeleteAttributeMain(CommandLineWithConfirm):
         if not self.validate_deletion(affecting_annotations):
             return False
 
-        confirm_message = create_confirm_message_for_delete_attribute(resolved_deletion, affecting_annotations=affecting_annotations)
+        confirm_message = create_confirm_message_for_delete_attributes(resolved_deletion, affecting_annotations=affecting_annotations)
         if not self.confirm_processing(confirm_message):
             return False
 
-        request_body = build_request_body_for_delete_attribute(old_annotation_specs, resolved_deletion=resolved_deletion, comment=comment)
+        request_body = build_request_body_for_delete_attributes(old_annotation_specs, resolved_deletion=resolved_deletion, comment=comment)
         self.service.api.put_annotation_specs(self.project_id, query_params={"v": "3"}, request_body=request_body)
         logger.info(f"{len(resolved_deletion.label_attribute_pairs)} 件のラベル属性関係を削除しました。")
         return True
 
 
-class DeleteAttribute(CommandLine):
+class DeleteAttributes(CommandLine):
     """
     ラベルから属性を削除するコマンド。
     """
 
-    COMMON_MESSAGE = "annofabcli annotation_specs delete_attribute: error:"
+    COMMON_MESSAGE = "annofabcli annotation_specs delete_attributes: error:"
 
     def main(self) -> None:
         args = self.args
@@ -527,13 +527,13 @@ class DeleteAttribute(CommandLine):
         label_ids = get_list_from_args(args.label_id) if args.label_id is not None else None
         label_name_ens = get_list_from_args(args.label_name_en) if args.label_name_en is not None else None
 
-        obj = DeleteAttributeMain(
+        obj = DeleteAttributesMain(
             self.service,
             project_id=args.project_id,
             all_yes=args.yes,
             allow_affecting_annotations=args.allow_affecting_annotations,
         )
-        obj.delete_attribute(
+        obj.delete_attributes(
             attribute_ids=attribute_ids,
             attribute_name_ens=attribute_name_ens,
             label_ids=label_ids,
@@ -545,7 +545,7 @@ class DeleteAttribute(CommandLine):
 
 def parse_args(parser: argparse.ArgumentParser) -> None:
     """
-    ``delete_attribute`` サブコマンドの引数を定義する。
+    ``delete_attributes`` サブコマンドの引数を定義する。
 
     Args:
         parser: 引数を追加するArgumentParser
@@ -598,19 +598,19 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
 def main(args: argparse.Namespace) -> None:
     """
-    ``delete_attribute`` コマンドのエントリポイント。
+    ``delete_attributes`` コマンドのエントリポイント。
 
     Args:
         args: コマンドライン引数
     """
     service = build_annofabapi_resource_and_login(args)
     facade = AnnofabApiFacade(service)
-    DeleteAttribute(service, facade, args).main()
+    DeleteAttributes(service, facade, args).main()
 
 
 def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
     """
-    ``annotation_specs delete_attribute`` 用のparserを生成する。
+    ``annotation_specs delete_attributes`` 用のparserを生成する。
 
     Args:
         subparsers: 親parserのsubparsers
@@ -618,7 +618,7 @@ def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse
     Returns:
         生成したArgumentParser
     """
-    subcommand_name = "delete_attribute"
+    subcommand_name = "delete_attributes"
     subcommand_help = "アノテーション仕様のラベルから属性を削除します。"
     description = "アノテーション仕様のラベルから属性を削除します。"
 

--- a/annofabcli/annotation_specs/delete_choices.py
+++ b/annofabcli/annotation_specs/delete_choices.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import logging
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import annofabapi
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_attribute_name_en, get_choice_name_en
+
+import annofabcli.common.cli
+from annofabcli.annotation_specs.attribute_restriction import AttributeRestrictionMessage
+from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login, get_list_from_args
+from annofabcli.common.facade import AnnofabApiFacade
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedChoiceDeletion:
+    """
+    選択肢削除対象を既存アノテーション仕様に対して解決した結果。
+    """
+
+    target_attribute: Mapping[str, Any]
+    """選択肢を削除する対象属性。"""
+
+    choices_to_remove: list[Mapping[str, Any]]
+    """削除対象選択肢一覧。"""
+
+    restrictions_to_remove: list[dict[str, Any]]
+    """削除対象選択肢を参照するため削除する属性制約一覧。"""
+
+    restriction_text_list: list[str]
+    """削除する属性制約のテキスト一覧。"""
+
+
+@dataclass(frozen=True)
+class AffectingAnnotation:
+    """
+    既存アノテーションに影響する削除対象。
+    """
+
+    attribute_name_en: str
+    """影響を受ける属性英語名。"""
+
+    choice_name_en: str
+    """影響を受ける選択肢英語名。"""
+
+    annotation_count: int
+    """対象選択肢のアノテーション数。"""
+
+
+def get_choice_text(target_attribute: Mapping[str, Any], choice: Mapping[str, Any]) -> str:
+    """
+    属性と選択肢を表示用テキストに変換する。
+
+    Args:
+        target_attribute: 選択肢が属する属性
+        choice: 選択肢
+
+    Returns:
+        表示用テキスト
+    """
+    return f"attribute_name_en='{get_attribute_name_en(target_attribute)}', choice_name_en='{get_choice_name_en(choice)}'"
+
+
+def restriction_references_choice(restriction: Mapping[str, Any], *, attribute_id: str, choice_ids: Collection[str]) -> bool:
+    """
+    属性制約が指定選択肢を参照しているかどうかを返す。
+
+    Args:
+        restriction: 属性制約
+        attribute_id: 選択肢が属する属性ID
+        choice_ids: 選択肢ID一覧
+
+    Returns:
+        属性制約が指定選択肢を参照していればTrue
+    """
+
+    def condition_references_choice(current_attribute_id: str, condition: Mapping[str, Any]) -> bool:
+        condition_type = condition["_type"]
+        if condition_type == "Imply":
+            premise = condition["premise"]
+            return condition_references_choice(premise["additional_data_definition_id"], premise["condition"]) or condition_references_choice(current_attribute_id, condition["condition"])
+
+        return current_attribute_id == attribute_id and condition_type in ["Equals", "NotEquals"] and condition.get("value") in choice_ids
+
+    return condition_references_choice(restriction["additional_data_definition_id"], restriction["condition"])
+
+
+def get_target_choices(
+    target_attribute: Mapping[str, Any],
+    *,
+    choice_ids: Sequence[str] | None,
+    choice_name_ens: Sequence[str] | None,
+) -> list[Mapping[str, Any]]:
+    """
+    CLI引数で指定された選択肢ID・選択肢名から削除対象選択肢一覧を取得する。
+
+    Args:
+        target_attribute: 選択肢を削除する対象属性
+        choice_ids: 指定された選択肢ID一覧。未指定時はNone
+        choice_name_ens: 指定された選択肢英語名一覧。未指定時はNone
+
+    Returns:
+        重複を除いた削除対象選択肢一覧
+
+    Raises:
+        ValueError: 引数の指定方法が不正な場合、選択肢が見つからない場合、または選択肢名が曖昧な場合
+    """
+    if (choice_ids is None) == (choice_name_ens is None):
+        raise ValueError("対象選択肢は `choice_id` または `choice_name_en` のどちらか一方だけ指定してください。")
+
+    resolved_choice_ids = [] if choice_ids is None else list(choice_ids)
+    resolved_choice_name_ens = [] if choice_name_ens is None else list(choice_name_ens)
+    if len(resolved_choice_ids) == 0 and len(resolved_choice_name_ens) == 0:
+        raise ValueError("対象選択肢を1件以上指定してください。")
+
+    choices = target_attribute["choices"]
+    result: list[Mapping[str, Any]] = []
+    result_choice_ids: set[str] = set()
+    for choice_id in resolved_choice_ids:
+        matched_choices = [choice for choice in choices if choice["choice_id"] == choice_id]
+        if len(matched_choices) == 0:
+            raise ValueError(f"選択肢情報が見つかりませんでした。 :: choice_id='{choice_id}'")
+        choice = matched_choices[0]
+        if choice_id not in result_choice_ids:
+            result.append(choice)
+            result_choice_ids.add(choice_id)
+
+    for choice_name_en in resolved_choice_name_ens:
+        matched_choices = [choice for choice in choices if get_choice_name_en(choice) == choice_name_en]
+        if len(matched_choices) == 0:
+            raise ValueError(f"選択肢情報が見つかりませんでした。 :: choice_name_en='{choice_name_en}'")
+        if len(matched_choices) > 1:
+            raise ValueError(f"選択肢情報が複数（{len(matched_choices)}件）見つかりました。 :: choice_name_en='{choice_name_en}'")
+        choice = matched_choices[0]
+        resolved_choice_id = choice["choice_id"]
+        if resolved_choice_id not in result_choice_ids:
+            result.append(choice)
+            result_choice_ids.add(resolved_choice_id)
+
+    return result
+
+
+def create_comment_for_delete_choices(resolved_deletion: ResolvedChoiceDeletion) -> str:
+    """
+    選択肢削除時のデフォルトコメントを生成する。
+
+    Args:
+        resolved_deletion: 解決済み選択肢削除対象
+
+    Returns:
+        アノテーション仕様変更コメント
+    """
+    lines = ["以下の選択肢を属性から削除しました。"]
+    lines.extend(f" * {get_choice_text(resolved_deletion.target_attribute, choice)}" for choice in resolved_deletion.choices_to_remove)
+    if resolved_deletion.restriction_text_list:
+        lines.extend(("", "以下の属性制約も削除しました。"))
+        lines.extend(f" * {restriction_text}" for restriction_text in resolved_deletion.restriction_text_list)
+    return "\n".join(lines)
+
+
+def create_confirm_message_for_delete_choices(
+    resolved_deletion: ResolvedChoiceDeletion,
+    *,
+    affecting_annotations: Sequence[AffectingAnnotation],
+) -> str:
+    """
+    選択肢削除前の確認メッセージを生成する。
+
+    Args:
+        resolved_deletion: 解決済み選択肢削除対象
+        affecting_annotations: 既存アノテーションに影響する削除対象
+
+    Returns:
+        確認メッセージ
+    """
+    lines = [f"以下の選択肢({len(resolved_deletion.choices_to_remove)}件)を属性から削除します。"]
+    lines.extend(f" * {get_choice_text(resolved_deletion.target_attribute, choice)}" for choice in resolved_deletion.choices_to_remove)
+    if resolved_deletion.restriction_text_list:
+        lines.extend(("", "以下の属性制約も削除します。"))
+        lines.extend(f" * {restriction_text}" for restriction_text in resolved_deletion.restriction_text_list)
+    if affecting_annotations:
+        lines.extend(("", "既存アノテーションへの影響:"))
+        lines.extend(f" * attribute_name_en='{affected.attribute_name_en}', choice_name_en='{affected.choice_name_en}': {affected.annotation_count} 件" for affected in affecting_annotations)
+    lines.extend(("", "よろしいですか？"))
+    return "\n".join(lines)
+
+
+def create_message_for_affecting_annotations(affecting_annotations: Sequence[AffectingAnnotation]) -> str:
+    """
+    既存アノテーションに影響する削除対象を表すメッセージを生成する。
+
+    Args:
+        affecting_annotations: 既存アノテーションに影響する削除対象
+
+    Returns:
+        既存アノテーションに影響する削除対象を表すメッセージ
+    """
+    attribute_choice_names = [(affected.attribute_name_en, affected.choice_name_en) for affected in affecting_annotations]
+    annotation_counts = {(affected.attribute_name_en, affected.choice_name_en): affected.annotation_count for affected in affecting_annotations}
+    return f"削除対象の選択肢がアノテーションで使われています。 :: attribute_choice_names_en={attribute_choice_names}, annotation_counts={annotation_counts}"
+
+
+def resolve_choice_deletion(
+    annotation_specs: dict[str, Any],
+    *,
+    attribute_id: str | None,
+    attribute_name_en: str | None,
+    choice_ids: Sequence[str] | None,
+    choice_name_ens: Sequence[str] | None,
+    unsafe_defaults: bool = False,
+) -> ResolvedChoiceDeletion:
+    """
+    選択肢削除対象を既存アノテーション仕様に対して解決する。
+
+    Args:
+        annotation_specs: 既存のアノテーション仕様
+        attribute_id: 対象属性ID
+        attribute_name_en: 対象属性英語名
+        choice_ids: 対象選択肢ID一覧
+        choice_name_ens: 対象選択肢英語名一覧
+        unsafe_defaults: Trueなら、削除対象選択肢がデフォルト値でも削除を許可する
+
+    Returns:
+        解決済み選択肢削除対象
+    """
+    annotation_specs_accessor = AnnotationSpecsAccessor(annotation_specs)
+    target_attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_id, attribute_name=attribute_name_en)
+    if target_attribute["type"] not in ["choice", "select"]:
+        raise ValueError(f"属性ID='{target_attribute['additional_data_definition_id']}' は選択肢系属性ではありません。")
+
+    target_attribute_choices = target_attribute["choices"]
+    assert target_attribute_choices is not None
+    choices_to_remove = get_target_choices(target_attribute, choice_ids=choice_ids, choice_name_ens=choice_name_ens)
+    if len(target_attribute_choices) - len(choices_to_remove) < 2:
+        raise ValueError("削除後の選択肢数が2件未満になるため、選択肢を削除できません。")
+
+    removed_choice_ids = {choice["choice_id"] for choice in choices_to_remove}
+    default_choice_id = target_attribute.get("default")
+    if default_choice_id in removed_choice_ids and not unsafe_defaults:
+        raise ValueError("削除対象の選択肢が属性のデフォルト値に設定されています。削除する場合は `--unsafe_defaults` を指定してください。")
+
+    target_attribute_id = target_attribute["additional_data_definition_id"]
+    restrictions_to_remove = [
+        restriction for restriction in annotation_specs["restrictions"] if restriction_references_choice(restriction, attribute_id=target_attribute_id, choice_ids=removed_choice_ids)
+    ]
+    message_obj = AttributeRestrictionMessage(
+        labels=annotation_specs["labels"],
+        additionals=annotation_specs["additionals"],
+        raise_if_not_found=True,
+    )
+    restriction_text_list = [message_obj.get_restriction_text(restriction["additional_data_definition_id"], restriction["condition"]) for restriction in restrictions_to_remove]
+    return ResolvedChoiceDeletion(
+        target_attribute=target_attribute,
+        choices_to_remove=choices_to_remove,
+        restrictions_to_remove=restrictions_to_remove,
+        restriction_text_list=restriction_text_list,
+    )
+
+
+def build_request_body_for_delete_choices(
+    annotation_specs: dict[str, Any],
+    *,
+    resolved_deletion: ResolvedChoiceDeletion,
+    unsafe_defaults: bool,
+    comment: str | None,
+) -> dict[str, Any]:
+    """
+    選択肢削除用の request body を生成する。
+
+    Args:
+        annotation_specs: 既存のアノテーション仕様
+        resolved_deletion: 解決済み選択肢削除対象
+        unsafe_defaults: Trueなら、削除対象選択肢がデフォルト値でもデフォルト値を解除して削除する
+        comment: 変更コメント
+
+    Returns:
+        Annofab API に渡す request body
+    """
+    request_body = copy.deepcopy(annotation_specs)
+    target_attribute_id = resolved_deletion.target_attribute["additional_data_definition_id"]
+    removed_choice_ids = {choice["choice_id"] for choice in resolved_deletion.choices_to_remove}
+    for attribute in request_body["additionals"]:
+        if attribute["additional_data_definition_id"] != target_attribute_id:
+            continue
+        attribute["choices"] = [choice for choice in attribute["choices"] if choice["choice_id"] not in removed_choice_ids]
+        if unsafe_defaults and attribute.get("default") in removed_choice_ids:
+            attribute["default"] = ""
+        break
+
+    request_body["restrictions"] = [restriction for restriction in request_body["restrictions"] if restriction not in resolved_deletion.restrictions_to_remove]
+    if comment is None:
+        comment = create_comment_for_delete_choices(resolved_deletion)
+    request_body["comment"] = comment
+    request_body["last_updated_datetime"] = annotation_specs["updated_datetime"]
+    return request_body
+
+
+class DeleteChoicesMain(CommandLineWithConfirm):
+    """
+    選択肢を削除する本体処理。
+    """
+
+    def __init__(
+        self,
+        service: annofabapi.Resource,
+        *,
+        project_id: str,
+        all_yes: bool,
+        allow_affecting_annotations: bool = False,
+    ) -> None:
+        self.service = service
+        self.project_id = project_id
+        self.allow_affecting_annotations = allow_affecting_annotations
+        CommandLineWithConfirm.__init__(self, all_yes)
+
+    def count_annotations_by_choice(self, attribute_id: str, choice_id: str) -> int:
+        """
+        指定選択肢のアノテーション数を返す。
+
+        Args:
+            attribute_id: 属性ID
+            choice_id: 選択肢ID
+
+        Returns:
+            指定選択肢のアノテーション数
+        """
+        content, _ = self.service.api.get_annotation_list(
+            self.project_id,
+            query_params={"query": {"attributes": [{"additional_data_definition_id": attribute_id, "choice": choice_id}]}, "limit": 1, "v": "2"},
+        )
+        return int(content["total_count"])
+
+    def collect_affecting_annotations(self, resolved_deletion: ResolvedChoiceDeletion) -> list[AffectingAnnotation]:
+        """
+        削除対象のうち既存アノテーションに影響するものを返す。
+
+        Args:
+            resolved_deletion: 解決済み選択肢削除対象
+
+        Returns:
+            既存アノテーションに影響する削除対象一覧
+        """
+        target_attribute = resolved_deletion.target_attribute
+        attribute_id = target_attribute["additional_data_definition_id"]
+        attribute_name_en = get_attribute_name_en(target_attribute)
+        affecting_annotations: list[AffectingAnnotation] = []
+        for choice in resolved_deletion.choices_to_remove:
+            annotation_count = self.count_annotations_by_choice(attribute_id, choice["choice_id"])
+            if annotation_count == 0:
+                continue
+            affecting_annotations.append(
+                AffectingAnnotation(
+                    attribute_name_en=attribute_name_en,
+                    choice_name_en=get_choice_name_en(choice),
+                    annotation_count=annotation_count,
+                )
+            )
+        return affecting_annotations
+
+    def validate_deletion(self, affecting_annotations: Sequence[AffectingAnnotation]) -> bool:
+        """
+        選択肢を削除してよいか検証する。
+
+        Args:
+            affecting_annotations: 既存アノテーションに影響する削除対象
+
+        Returns:
+            削除してよい場合はTrue、既存アノテーションに影響するため中止する場合はFalse
+        """
+        if len(affecting_annotations) == 0:
+            return True
+
+        message = create_message_for_affecting_annotations(affecting_annotations)
+        if self.allow_affecting_annotations:
+            logger.warning("既存アノテーションに影響する変更がありますが、オプションで許可されているため、選択肢を削除します。\n%s", message)
+            return True
+
+        logger.warning(
+            "既存アノテーションに影響するため、選択肢の削除を中止しました。既存アノテーションに影響が出ることを理解した上で削除する場合は、 `--allow_affecting_annotations` を指定してください。\n%s",
+            message,
+        )
+        return False
+
+    def delete_choices(
+        self,
+        *,
+        attribute_id: str | None,
+        attribute_name_en: str | None,
+        choice_ids: Sequence[str] | None,
+        choice_name_ens: Sequence[str] | None,
+        unsafe_defaults: bool = False,
+        comment: str | None = None,
+    ) -> bool:
+        """
+        指定した選択肢を属性から削除し、アノテーション仕様を更新する。
+
+        Args:
+            attribute_id: 対象属性ID
+            attribute_name_en: 対象属性英語名
+            choice_ids: 対象選択肢ID一覧
+            choice_name_ens: 対象選択肢英語名一覧
+            unsafe_defaults: Trueなら、削除対象選択肢がデフォルト値でもデフォルト値を解除して削除する
+            comment: 変更コメント
+
+        Returns:
+            更新を実行した場合はTrue、確認で中断した場合はFalse
+        """
+        old_annotation_specs, _ = self.service.api.get_annotation_specs(self.project_id, query_params={"v": "3"})
+        resolved_deletion = resolve_choice_deletion(
+            old_annotation_specs,
+            attribute_id=attribute_id,
+            attribute_name_en=attribute_name_en,
+            choice_ids=choice_ids,
+            choice_name_ens=choice_name_ens,
+            unsafe_defaults=unsafe_defaults,
+        )
+        affecting_annotations = self.collect_affecting_annotations(resolved_deletion)
+        if not self.validate_deletion(affecting_annotations):
+            return False
+
+        confirm_message = create_confirm_message_for_delete_choices(resolved_deletion, affecting_annotations=affecting_annotations)
+        if not self.confirm_processing(confirm_message):
+            return False
+
+        request_body = build_request_body_for_delete_choices(old_annotation_specs, resolved_deletion=resolved_deletion, unsafe_defaults=unsafe_defaults, comment=comment)
+        self.service.api.put_annotation_specs(self.project_id, query_params={"v": "3"}, request_body=request_body)
+        logger.info(f"{len(resolved_deletion.choices_to_remove)} 件の選択肢を削除しました。")
+        return True
+
+
+class DeleteChoices(CommandLine):
+    """
+    選択肢を削除するコマンド。
+    """
+
+    COMMON_MESSAGE = "annofabcli annotation_specs delete_choices: error:"
+
+    def main(self) -> None:
+        args = self.args
+
+        choice_ids = get_list_from_args(args.choice_id) if args.choice_id is not None else None
+        choice_name_ens = get_list_from_args(args.choice_name_en) if args.choice_name_en is not None else None
+
+        obj = DeleteChoicesMain(
+            self.service,
+            project_id=args.project_id,
+            all_yes=args.yes,
+            allow_affecting_annotations=args.allow_affecting_annotations,
+        )
+        obj.delete_choices(
+            attribute_id=args.attribute_id,
+            attribute_name_en=args.attribute_name_en,
+            choice_ids=choice_ids,
+            choice_name_ens=choice_name_ens,
+            unsafe_defaults=args.unsafe_defaults,
+            comment=args.comment,
+        )
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    """
+    ``delete_choices`` サブコマンドの引数を定義する。
+
+    Args:
+        parser: 引数を追加するArgumentParser
+    """
+    argument_parser = ArgumentParser(parser)
+    argument_parser.add_project_id()
+
+    attribute_group = parser.add_mutually_exclusive_group(required=True)
+    attribute_group.add_argument("--attribute_name_en", type=str, help="選択肢を削除する対象属性の英語名。")
+    attribute_group.add_argument("--attribute_id", type=str, help="選択肢を削除する対象属性の属性ID。")
+
+    choice_group = parser.add_mutually_exclusive_group(required=True)
+    choice_group.add_argument(
+        "--choice_name_en",
+        type=str,
+        nargs="+",
+        help="削除する選択肢の英語名。複数指定できます。 ``file://`` を先頭に付けると一覧ファイルを指定できます。",
+    )
+    choice_group.add_argument(
+        "--choice_id",
+        type=str,
+        nargs="+",
+        help="削除する選択肢のchoice_id。複数指定できます。 ``file://`` を先頭に付けると一覧ファイルを指定できます。",
+    )
+    parser.add_argument(
+        "--allow_affecting_annotations",
+        action="store_true",
+        help="指定すると、既存アノテーションに影響する変更でも選択肢を削除します。",
+    )
+    parser.add_argument(
+        "--unsafe_defaults",
+        action="store_true",
+        help="指定すると、削除対象選択肢が属性のデフォルト値に設定されている場合でも、デフォルト値を解除して選択肢を削除します。",
+    )
+    parser.add_argument("--comment", type=str, help="アノテーション仕様の変更内容を説明するコメント。未指定の場合、自動でコメントが生成されます。")
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def main(args: argparse.Namespace) -> None:
+    """
+    ``delete_choices`` コマンドのエントリポイント。
+
+    Args:
+        args: コマンドライン引数
+    """
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    DeleteChoices(service, facade, args).main()
+
+
+def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
+    """
+    ``annotation_specs delete_choices`` 用のparserを生成する。
+
+    Args:
+        subparsers: 親parserのsubparsers
+
+    Returns:
+        生成したArgumentParser
+    """
+    subcommand_name = "delete_choices"
+    subcommand_help = "アノテーション仕様の選択肢系属性から選択肢を削除します。"
+    description = "アノテーション仕様の選択肢系属性から選択肢を複数件削除します。"
+
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
+    parse_args(parser)
+    return parser

--- a/annofabcli/annotation_specs/delete_labels.py
+++ b/annofabcli/annotation_specs/delete_labels.py
@@ -12,7 +12,7 @@ from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_attrib
 
 import annofabcli.common.cli
 from annofabcli.annotation_specs.attribute_restriction import AttributeRestrictionMessage
-from annofabcli.annotation_specs.delete_attribute import restriction_references_attribute
+from annofabcli.annotation_specs.delete_attributes import restriction_references_attribute
 from annofabcli.annotation_specs.utils import get_target_labels
 from annofabcli.common.cli import ArgumentParser, CommandLine, CommandLineWithConfirm, build_annofabapi_resource_and_login, get_list_from_args
 from annofabcli.common.facade import AnnofabApiFacade

--- a/annofabcli/annotation_specs/subcommand_annotation_specs.py
+++ b/annofabcli/annotation_specs/subcommand_annotation_specs.py
@@ -9,8 +9,9 @@ import annofabcli.annotation_specs.add_existing_attribute_to_labels
 import annofabcli.annotation_specs.add_label
 import annofabcli.annotation_specs.add_labels
 import annofabcli.annotation_specs.change_attribute_type
-import annofabcli.annotation_specs.delete_attribute
 import annofabcli.annotation_specs.delete_attribute_restriction
+import annofabcli.annotation_specs.delete_attributes
+import annofabcli.annotation_specs.delete_choices
 import annofabcli.annotation_specs.delete_labels
 import annofabcli.annotation_specs.diff_annotation_specs
 import annofabcli.annotation_specs.export_annotation_specs
@@ -44,8 +45,9 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.annotation_specs.add_label.add_parser(subparsers)
     annofabcli.annotation_specs.add_labels.add_parser(subparsers)
     annofabcli.annotation_specs.change_attribute_type.add_parser(subparsers)
-    annofabcli.annotation_specs.delete_attribute.add_parser(subparsers)
     annofabcli.annotation_specs.delete_attribute_restriction.add_parser(subparsers)
+    annofabcli.annotation_specs.delete_attributes.add_parser(subparsers)
+    annofabcli.annotation_specs.delete_choices.add_parser(subparsers)
     annofabcli.annotation_specs.delete_labels.add_parser(subparsers)
     annofabcli.annotation_specs.diff_annotation_specs.add_parser(subparsers)
     annofabcli.annotation_specs.export_annotation_specs.add_parser(subparsers)

--- a/docs/command_reference/annotation_specs/delete_attributes.rst
+++ b/docs/command_reference/annotation_specs/delete_attributes.rst
@@ -1,5 +1,5 @@
 ==========================================
-annotation_specs delete_attribute
+annotation_specs delete_attributes
 ==========================================
 
 Description
@@ -22,7 +22,7 @@ Examples
 
 .. code-block::
 
-    $ annofabcli annotation_specs delete_attribute \
+    $ annofabcli annotation_specs delete_attributes \
      --project_id prj1 \
      --attribute_name_en occluded \
      --label_name_en car bus
@@ -35,7 +35,7 @@ Examples
 
 .. code-block::
 
-    $ annofabcli annotation_specs delete_attribute \
+    $ annofabcli annotation_specs delete_attributes \
      --project_id prj1 \
      --attribute_name_en occluded \
      --all_labels
@@ -46,7 +46,7 @@ Examples
 
 .. code-block::
 
-    $ annofabcli annotation_specs delete_attribute \
+    $ annofabcli annotation_specs delete_attributes \
      --project_id prj1 \
      --attribute_name_en occluded \
      --label_name_en car bus \
@@ -57,7 +57,7 @@ Usage Details
 =================================
 
 .. argparse::
-    :ref: annofabcli.annotation_specs.delete_attribute.add_parser
-    :prog: annofabcli annotation_specs delete_attribute
+    :ref: annofabcli.annotation_specs.delete_attributes.add_parser
+    :prog: annofabcli annotation_specs delete_attributes
     :nosubcommands:
     :nodefaultconst:

--- a/docs/command_reference/annotation_specs/delete_choices.rst
+++ b/docs/command_reference/annotation_specs/delete_choices.rst
@@ -1,0 +1,79 @@
+==========================================
+annotation_specs delete_choices
+==========================================
+
+Description
+=================================
+アノテーション仕様の選択肢系属性（ラジオボタン/ドロップダウン）から選択肢を削除します。
+
+削除対象選択肢に関連する属性制約も削除します。
+
+削除後の選択肢数が2件未満になる場合は削除できません。
+削除対象選択肢が属性のデフォルト値に設定されている場合は、デフォルトでは削除できません。
+デフォルト値を解除した上で選択肢を削除する場合は、 ``--unsafe_defaults`` を指定してください。
+
+削除対象選択肢が既存アノテーションで使われている場合は、デフォルトでは削除できません。
+既存アノテーションに影響することを理解した上で選択肢を削除する場合は、 ``--allow_affecting_annotations`` を指定してください。
+
+
+Examples
+=================================
+
+選択肢名を指定して削除する
+----------------------------------------------
+
+以下のコマンドは、"type" 属性から "large", "medium" 選択肢を削除します。
+
+.. code-block::
+
+    $ annofabcli annotation_specs delete_choices \
+     --project_id prj1 \
+     --attribute_name_en type \
+     --choice_name_en large medium
+
+
+選択肢IDを指定して削除する
+----------------------------------------------
+
+.. code-block::
+
+    $ annofabcli annotation_specs delete_choices \
+     --project_id prj1 \
+     --attribute_id 71620647-98cf-48ad-b43b-4af425a24f32 \
+     --choice_id choice_large choice_medium
+
+
+デフォルト値に設定されている選択肢を削除する
+------------------------------------------------------------
+
+``--unsafe_defaults`` を指定すると、削除対象選択肢が属性のデフォルト値に設定されていても、デフォルト値を解除して選択肢を削除します。
+
+.. code-block::
+
+    $ annofabcli annotation_specs delete_choices \
+     --project_id prj1 \
+     --attribute_name_en type \
+     --choice_name_en large \
+     --unsafe_defaults
+
+
+既存アノテーションに影響する変更を許可する
+------------------------------------------------------------
+
+.. code-block::
+
+    $ annofabcli annotation_specs delete_choices \
+     --project_id prj1 \
+     --attribute_name_en type \
+     --choice_name_en large \
+     --allow_affecting_annotations
+
+
+Usage Details
+=================================
+
+.. argparse::
+    :ref: annofabcli.annotation_specs.delete_choices.add_parser
+    :prog: annofabcli annotation_specs delete_choices
+    :nosubcommands:
+    :nodefaultconst:

--- a/docs/command_reference/annotation_specs/index.rst
+++ b/docs/command_reference/annotation_specs/index.rst
@@ -24,8 +24,9 @@ Available Commands
    add_label
    add_labels
    change_attribute_type
-   delete_attribute
    delete_attribute_restriction
+   delete_attributes
+   delete_choices
    delete_labels
    diff
    export

--- a/tests/annotation_specs/test_delete_attributes.py
+++ b/tests/annotation_specs/test_delete_attributes.py
@@ -8,12 +8,12 @@ from typing import Any
 
 import pytest
 
-from annofabcli.annotation_specs.delete_attribute import (
+from annofabcli.annotation_specs.delete_attributes import (
     AffectingAnnotation,
-    DeleteAttributeMain,
-    build_request_body_for_delete_attribute,
-    create_comment_for_delete_attribute,
-    create_confirm_message_for_delete_attribute,
+    DeleteAttributesMain,
+    build_request_body_for_delete_attributes,
+    create_comment_for_delete_attributes,
+    create_confirm_message_for_delete_attributes,
     resolve_attribute_deletion,
     restriction_references_attribute,
 )
@@ -60,7 +60,7 @@ def add_same_name_attributes_to_same_label(annotation_specs: dict[str, Any]) -> 
     car_label["additional_data_definitions"].extend(["car_foo_attribute_id_1", "car_foo_attribute_id_2"])
 
 
-class TestDeleteAttributeHelpers:
+class TestDeleteAttributesHelpers:
     def test_restriction_references_attribute__ネストされた属性参照を検出する(self) -> None:
         annotation_specs = load_annotation_specs()
         restriction = annotation_specs["restrictions"][-1]
@@ -68,7 +68,7 @@ class TestDeleteAttributeHelpers:
         assert restriction_references_attribute(restriction, {"f12a0b59-dfce-4241-bb87-4b2c0259fc6f"}) is True
         assert restriction_references_attribute(restriction, {"not-found"}) is False
 
-    def test_create_comment_for_delete_attribute(self) -> None:
+    def test_create_comment_for_delete_attributes(self) -> None:
         annotation_specs = load_annotation_specs()
         resolved = resolve_attribute_deletion(
             annotation_specs,
@@ -78,13 +78,13 @@ class TestDeleteAttributeHelpers:
             label_name_ens=["car"],
         )
 
-        actual = create_comment_for_delete_attribute(resolved)
+        actual = create_comment_for_delete_attributes(resolved)
 
         assert "以下のラベルから属性を削除しました。" in actual
         assert "label_name_en='car', attribute_name_en='unclear'" in actual
         assert "'comment' MATCHES '[0-9]' IF 'unclear' EQUALS 'true'" in actual
 
-    def test_create_confirm_message_for_delete_attribute(self) -> None:
+    def test_create_confirm_message_for_delete_attributes(self) -> None:
         annotation_specs = load_annotation_specs()
         resolved = resolve_attribute_deletion(
             annotation_specs,
@@ -94,7 +94,7 @@ class TestDeleteAttributeHelpers:
             label_name_ens=["car"],
         )
 
-        actual = create_confirm_message_for_delete_attribute(resolved, affecting_annotations=[])
+        actual = create_confirm_message_for_delete_attributes(resolved, affecting_annotations=[])
 
         assert "以下のラベルから属性(1件)を削除します。" in actual
         assert "label_name_en='car', attribute_name_en='unclear'" in actual
@@ -215,8 +215,8 @@ class TestResolveAttributeDeletion:
         assert actual.restriction_text_list == ["'comment' MATCHES '[0-9]' IF 'unclear' EQUALS 'true'"]
 
 
-class TestBuildRequestBodyForDeleteAttribute:
-    def test_build_request_body_for_delete_attribute__孤立属性と関連制約も削除する(self) -> None:
+class TestBuildRequestBodyForDeleteAttributes:
+    def test_build_request_body_for_delete_attributes__孤立属性と関連制約も削除する(self) -> None:
         annotation_specs = load_annotation_specs()
         resolved = resolve_attribute_deletion(
             annotation_specs,
@@ -226,7 +226,7 @@ class TestBuildRequestBodyForDeleteAttribute:
             label_name_ens=["car"],
         )
 
-        actual = build_request_body_for_delete_attribute(annotation_specs, resolved_deletion=resolved, comment=None)
+        actual = build_request_body_for_delete_attributes(annotation_specs, resolved_deletion=resolved, comment=None)
 
         car_label = next(label for label in actual["labels"] if label["label_id"] == "car_label_id")
         assert "f12a0b59-dfce-4241-bb87-4b2c0259fc6f" not in car_label["additional_data_definitions"]
@@ -235,7 +235,7 @@ class TestBuildRequestBodyForDeleteAttribute:
         assert actual["last_updated_datetime"] == "2026-04-24T00:00:00+09:00"
         assert "以下のラベルから属性を削除しました。" in actual["comment"]
 
-    def test_build_request_body_for_delete_attribute__custom_comment(self) -> None:
+    def test_build_request_body_for_delete_attributes__custom_comment(self) -> None:
         annotation_specs = load_annotation_specs()
         resolved = resolve_attribute_deletion(
             annotation_specs,
@@ -245,14 +245,14 @@ class TestBuildRequestBodyForDeleteAttribute:
             label_name_ens=["car"],
         )
 
-        actual = build_request_body_for_delete_attribute(annotation_specs, resolved_deletion=resolved, comment="custom")
+        actual = build_request_body_for_delete_attributes(annotation_specs, resolved_deletion=resolved, comment="custom")
 
         assert actual["comment"] == "custom"
 
 
-class TestDeleteAttributeMain:
+class TestDeleteAttributesMain:
     def test_validate_deletion__既存アノテーションに影響するときは許可オプションを案内する(self, caplog: pytest.LogCaptureFixture) -> None:
-        obj = DeleteAttributeMain(
+        obj = DeleteAttributesMain(
             service=None,  # type: ignore[arg-type]
             project_id="project_id",
             all_yes=True,

--- a/tests/annotation_specs/test_delete_choices.py
+++ b/tests/annotation_specs/test_delete_choices.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from annofabcli.annotation_specs.delete_choices import (
+    AffectingAnnotation,
+    DeleteChoicesMain,
+    build_request_body_for_delete_choices,
+    create_comment_for_delete_choices,
+    create_confirm_message_for_delete_choices,
+    resolve_choice_deletion,
+    restriction_references_choice,
+)
+
+DATA_DIR = Path("./tests/data/annotation_specs")
+TYPE_ATTRIBUTE_ID = "71620647-98cf-48ad-b43b-4af425a24f32"
+LARGE_CHOICE_ID = "08ec927c-18e6-4bba-837a-b16de7061580"
+MEDIUM_CHOICE_ID = "b690fa1a-7b3d-4181-95d8-f5c75927c3fc"
+SMALL_CHOICE_ID = "74691a87-7962-4fa9-ba52-7cc466ecd982"
+
+
+def load_annotation_specs() -> dict[str, Any]:
+    with (DATA_DIR / "annotation_specs.json").open(encoding="utf-8") as f:
+        annotation_specs = json.load(f)
+    annotation_specs["updated_datetime"] = "2026-04-24T00:00:00+09:00"
+    return annotation_specs
+
+
+def get_type_attribute(annotation_specs: dict[str, Any]) -> dict[str, Any]:
+    return next(attribute for attribute in annotation_specs["additionals"] if attribute["additional_data_definition_id"] == TYPE_ATTRIBUTE_ID)
+
+
+class TestDeleteChoicesHelpers:
+    def test_restriction_references_choice__equalsを検出する(self) -> None:
+        annotation_specs = load_annotation_specs()
+        restriction = annotation_specs["restrictions"][-3]
+
+        assert restriction_references_choice(restriction, attribute_id=TYPE_ATTRIBUTE_ID, choice_ids={MEDIUM_CHOICE_ID}) is True
+        assert restriction_references_choice(restriction, attribute_id=TYPE_ATTRIBUTE_ID, choice_ids={LARGE_CHOICE_ID}) is False
+
+    def test_restriction_references_choice__matchesのvalueは選択肢参照として扱わない(self) -> None:
+        restriction = {
+            "additional_data_definition_id": TYPE_ATTRIBUTE_ID,
+            "condition": {
+                "value": MEDIUM_CHOICE_ID,
+                "_type": "Matches",
+            },
+        }
+
+        assert restriction_references_choice(restriction, attribute_id=TYPE_ATTRIBUTE_ID, choice_ids={MEDIUM_CHOICE_ID}) is False
+
+    def test_create_comment_for_delete_choices(self) -> None:
+        annotation_specs = load_annotation_specs()
+        resolved = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=None,
+            attribute_name_en="type",
+            choice_ids=None,
+            choice_name_ens=["medium"],
+        )
+
+        actual = create_comment_for_delete_choices(resolved)
+
+        assert "以下の選択肢を属性から削除しました。" in actual
+        assert "attribute_name_en='type', choice_name_en='medium'" in actual
+        assert "'type' EQUALS 'medium'" in actual
+
+    def test_create_confirm_message_for_delete_choices(self) -> None:
+        annotation_specs = load_annotation_specs()
+        resolved = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=None,
+            attribute_name_en="type",
+            choice_ids=None,
+            choice_name_ens=["medium"],
+        )
+
+        actual = create_confirm_message_for_delete_choices(resolved, affecting_annotations=[])
+
+        assert "以下の選択肢(1件)を属性から削除します。" in actual
+        assert "attribute_name_en='type', choice_name_en='medium'" in actual
+        assert actual.endswith("よろしいですか？")
+
+
+class TestResolveChoiceDeletion:
+    def test_resolve_choice_deletion__choice_name_enで対象を解決する(self) -> None:
+        annotation_specs = load_annotation_specs()
+
+        actual = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=None,
+            attribute_name_en="type",
+            choice_ids=None,
+            choice_name_ens=["medium"],
+        )
+
+        assert actual.target_attribute["additional_data_definition_id"] == TYPE_ATTRIBUTE_ID
+        assert [choice["choice_id"] for choice in actual.choices_to_remove] == [MEDIUM_CHOICE_ID]
+        assert actual.restriction_text_list == ["'type' EQUALS 'medium'"]
+
+    def test_resolve_choice_deletion__choice_idで対象を解決する(self) -> None:
+        annotation_specs = load_annotation_specs()
+
+        actual = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=TYPE_ATTRIBUTE_ID,
+            attribute_name_en=None,
+            choice_ids=[LARGE_CHOICE_ID],
+            choice_name_ens=None,
+        )
+
+        assert [choice["choice_id"] for choice in actual.choices_to_remove] == [LARGE_CHOICE_ID]
+
+    def test_resolve_choice_deletion__選択肢系属性でないときはエラー(self) -> None:
+        annotation_specs = load_annotation_specs()
+
+        with pytest.raises(ValueError):
+            resolve_choice_deletion(
+                annotation_specs,
+                attribute_id="54fa5e97-6f88-49a4-aeb0-a91a15d11528",
+                attribute_name_en=None,
+                choice_ids=[LARGE_CHOICE_ID],
+                choice_name_ens=None,
+            )
+
+    def test_resolve_choice_deletion__削除後の選択肢数が2件未満になるときはエラー(self) -> None:
+        annotation_specs = load_annotation_specs()
+
+        with pytest.raises(ValueError):
+            resolve_choice_deletion(
+                annotation_specs,
+                attribute_id=TYPE_ATTRIBUTE_ID,
+                attribute_name_en=None,
+                choice_ids=[MEDIUM_CHOICE_ID, SMALL_CHOICE_ID],
+                choice_name_ens=None,
+            )
+
+    def test_resolve_choice_deletion__defaultを削除するときはunsafe_defaultsが必要(self) -> None:
+        annotation_specs = load_annotation_specs()
+        get_type_attribute(annotation_specs)["default"] = LARGE_CHOICE_ID
+
+        with pytest.raises(ValueError):
+            resolve_choice_deletion(
+                annotation_specs,
+                attribute_id=TYPE_ATTRIBUTE_ID,
+                attribute_name_en=None,
+                choice_ids=[LARGE_CHOICE_ID],
+                choice_name_ens=None,
+                unsafe_defaults=False,
+            )
+
+    def test_resolve_choice_deletion__unsafe_defaultsならdefaultの削除を許可する(self) -> None:
+        annotation_specs = load_annotation_specs()
+        get_type_attribute(annotation_specs)["default"] = LARGE_CHOICE_ID
+
+        actual = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=TYPE_ATTRIBUTE_ID,
+            attribute_name_en=None,
+            choice_ids=[LARGE_CHOICE_ID],
+            choice_name_ens=None,
+            unsafe_defaults=True,
+        )
+
+        assert [choice["choice_id"] for choice in actual.choices_to_remove] == [LARGE_CHOICE_ID]
+
+
+class TestBuildRequestBodyForDeleteChoices:
+    def test_build_request_body_for_delete_choices__関連制約も削除する(self) -> None:
+        annotation_specs = load_annotation_specs()
+        resolved = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=None,
+            attribute_name_en="type",
+            choice_ids=None,
+            choice_name_ens=["medium"],
+        )
+
+        actual = build_request_body_for_delete_choices(annotation_specs, resolved_deletion=resolved, unsafe_defaults=False, comment=None)
+
+        updated_attribute = get_type_attribute(actual)
+        assert [choice["choice_id"] for choice in updated_attribute["choices"]] == [LARGE_CHOICE_ID, SMALL_CHOICE_ID]
+        assert all(not restriction_references_choice(restriction, attribute_id=TYPE_ATTRIBUTE_ID, choice_ids={MEDIUM_CHOICE_ID}) for restriction in actual["restrictions"])
+        assert actual["last_updated_datetime"] == "2026-04-24T00:00:00+09:00"
+        assert "以下の選択肢を属性から削除しました。" in actual["comment"]
+
+    def test_build_request_body_for_delete_choices__unsafe_defaultsならdefaultを解除する(self) -> None:
+        annotation_specs = load_annotation_specs()
+        get_type_attribute(annotation_specs)["default"] = LARGE_CHOICE_ID
+        resolved = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=TYPE_ATTRIBUTE_ID,
+            attribute_name_en=None,
+            choice_ids=[LARGE_CHOICE_ID],
+            choice_name_ens=None,
+            unsafe_defaults=True,
+        )
+
+        actual = build_request_body_for_delete_choices(annotation_specs, resolved_deletion=resolved, unsafe_defaults=True, comment=None)
+
+        assert get_type_attribute(actual)["default"] == ""
+
+    def test_build_request_body_for_delete_choices__custom_comment(self) -> None:
+        annotation_specs = load_annotation_specs()
+        resolved = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=None,
+            attribute_name_en="type",
+            choice_ids=None,
+            choice_name_ens=["medium"],
+        )
+
+        actual = build_request_body_for_delete_choices(annotation_specs, resolved_deletion=resolved, unsafe_defaults=False, comment="custom")
+
+        assert actual["comment"] == "custom"
+
+    def test_build_request_body_for_delete_choices__元のアノテーション仕様は変更しない(self) -> None:
+        annotation_specs = load_annotation_specs()
+        old_annotation_specs = copy.deepcopy(annotation_specs)
+        resolved = resolve_choice_deletion(
+            annotation_specs,
+            attribute_id=None,
+            attribute_name_en="type",
+            choice_ids=None,
+            choice_name_ens=["medium"],
+        )
+
+        build_request_body_for_delete_choices(annotation_specs, resolved_deletion=resolved, unsafe_defaults=False, comment=None)
+
+        assert annotation_specs == old_annotation_specs
+
+
+class TestDeleteChoicesMain:
+    def test_validate_deletion__既存アノテーションに影響するときは許可オプションを案内する(self, caplog: pytest.LogCaptureFixture) -> None:
+        obj = DeleteChoicesMain(
+            service=None,  # type: ignore[arg-type]
+            project_id="project_id",
+            all_yes=True,
+            allow_affecting_annotations=False,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            actual = obj.validate_deletion(
+                [
+                    AffectingAnnotation(
+                        attribute_name_en="type",
+                        choice_name_en="medium",
+                        annotation_count=3,
+                    )
+                ]
+            )
+
+        assert actual is False
+        assert "--allow_affecting_annotations" in caplog.text


### PR DESCRIPTION
- Implemented delete_attributes command to remove attributes from specified labels, including handling of related restrictions and existing annotations.
- Implemented delete_choices command to remove choices from choice-based attributes, with checks for default values and existing annotations.
- Updated command reference documentation for both commands.
- Added unit tests for delete_attributes and delete_choices functionalities, ensuring proper handling of edge cases and validation.
- Refactored existing code to accommodate new commands and improve maintainability.