### PR TITLE
`annotation_specs list_annotation_import_info`: 新規作成

### DIFF
--- a/annofabcli/annotation_specs/list_annotation_import_info.py
+++ b/annofabcli/annotation_specs/list_annotation_import_info.py
@@ -143,7 +143,7 @@ class PrintAnnotationImportInfo(CommandLine):
             annotation_specs, _ = self.service.api.get_annotation_specs(args.project_id, query_params={"history_id": history_id, "v": "3"})
 
         elif args.annotation_specs_json_file is not None:
-            with args.annotation_specs_json_file.open() as f:
+            with args.annotation_specs_json_file.open(encoding="utf-8") as f:
                 annotation_specs = json.load(f)
 
         else:

--- a/annofabcli/annotation_specs/list_annotation_import_info.py
+++ b/annofabcli/annotation_specs/list_annotation_import_info.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from annofabapi.models import Lang
+from annofabapi.util.annotation_specs import InternationalizationMessage, get_message_with_lang
+from pydantic import BaseModel, ConfigDict
+
+import annofabcli.common.cli
+from annofabcli.common.cli import (
+    COMMAND_LINE_ERROR_STATUS_CODE,
+    ArgumentParser,
+    CommandLine,
+    build_annofabapi_resource_and_login,
+)
+from annofabcli.common.enums import OutputFormat
+from annofabcli.common.facade import AnnofabApiFacade
+from annofabcli.common.utils import print_according_to_format
+
+logger = logging.getLogger(__name__)
+
+
+class AnnotationImportChoice(BaseModel):
+    """annotation importで指定できる選択肢情報。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    choice_name_en: str
+    """選択肢名（英語）。"""
+
+
+class AnnotationImportAttribute(BaseModel):
+    """annotation importで指定できる属性情報。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    attribute_name_en: str
+    """属性名（英語）。"""
+    attribute_type: str
+    """属性の種類。"""
+    choices: list[AnnotationImportChoice]
+    """属性で指定できる選択肢情報。"""
+
+
+class AnnotationImportLabel(BaseModel):
+    """annotation importで指定できるラベル情報。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    label_name_en: str
+    """ラベル名（英語）。"""
+    annotation_type: str
+    """ラベルの種類。"""
+    attributes: list[AnnotationImportAttribute]
+    """ラベルに指定できる属性情報。"""
+
+
+def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> list[AnnotationImportLabel]:
+    """アノテーション仕様からannotation import用の情報一覧を生成します。
+
+    Args:
+        annotation_specs_v3: APIから取得したアノテーション仕様情報（v3版）。
+
+    Returns:
+        annotation import用の情報一覧。
+    """
+
+    dict_attribute = {attribute["additional_data_definition_id"]: attribute for attribute in annotation_specs_v3["additionals"]}
+
+    def get_required_english_name(name: InternationalizationMessage) -> str:
+        result = get_message_with_lang(name, lang=Lang.EN_US)
+        if result is None:
+            raise ValueError("アノテーション仕様に英語名が存在しません。")
+        return result
+
+    def create_choice_list(attribute: dict[str, Any]) -> list[AnnotationImportChoice]:
+        return [
+            AnnotationImportChoice(
+                choice_name_en=get_required_english_name(choice["name"]),
+            )
+            for choice in attribute["choices"]
+        ]
+
+    def create_attribute_list(label: dict[str, Any]) -> list[AnnotationImportAttribute]:
+        result = []
+        for attribute_id in label["additional_data_definitions"]:
+            attribute = dict_attribute[attribute_id]
+            result.append(
+                AnnotationImportAttribute(
+                    attribute_name_en=get_required_english_name(attribute["name"]),
+                    attribute_type=attribute["type"],
+                    choices=create_choice_list(attribute),
+                )
+            )
+        return result
+
+    return [
+        AnnotationImportLabel(
+            label_name_en=get_required_english_name(label["label_name"]),
+            annotation_type=label["annotation_type"],
+            attributes=create_attribute_list(label),
+        )
+        for label in annotation_specs_v3["labels"]
+    ]
+
+
+class PrintAnnotationImportInfo(CommandLine):
+    """annotation import用のアノテーション仕様情報を出力します。"""
+
+    COMMON_MESSAGE = "annofabcli annotation_specs list_annotation_import_info: error:"
+
+    def print_annotation_import_info(self, annotation_specs_v3: dict[str, Any], output_format: OutputFormat, output: str | None = None) -> None:
+        import_info_list = create_annotation_import_info_list(annotation_specs_v3)
+        logger.info(f"{len(import_info_list)} 件のラベル情報を出力します。")
+        print_according_to_format(
+            [import_info.model_dump() for import_info in import_info_list],
+            format=output_format,
+            output=output,
+        )
+
+    def get_history_id_from_before_index(self, project_id: str, before: int) -> str | None:
+        histories, _ = self.service.api.get_annotation_specs_histories(project_id)
+        if before + 1 > len(histories):
+            logger.warning(f"アノテーション仕様の履歴は{len(histories)}個のため、最新より{before}個前のアノテーション仕様は見つかりませんでした。")
+            return None
+        history = histories[-(before + 1)]
+        logger.info(f"{history['updated_datetime']}のアノテーション仕様を出力します。 :: history_id='{history['history_id']}', comment='{history['comment']}'")
+        return history["history_id"]
+
+    def main(self) -> None:
+        args = self.args
+
+        if args.project_id is not None:
+            if args.before is not None:
+                history_id = self.get_history_id_from_before_index(args.project_id, args.before)
+                if history_id is None:
+                    print(  # noqa: T201
+                        f"{self.COMMON_MESSAGE} argument --before: 最新より{args.before}個前のアノテーション仕様は見つかりませんでした。",
+                        file=sys.stderr,
+                    )
+                    sys.exit(COMMAND_LINE_ERROR_STATUS_CODE)
+            else:
+                history_id = args.history_id
+
+            annotation_specs, _ = self.service.api.get_annotation_specs(args.project_id, query_params={"history_id": history_id, "v": "3"})
+
+        elif args.annotation_specs_json_file is not None:
+            with args.annotation_specs_json_file.open() as f:
+                annotation_specs = json.load(f)
+
+        else:
+            raise RuntimeError("'--project_id'か'--annotation_specs_json_file'のどちらかを指定する必要があります。")
+
+        self.print_annotation_import_info(annotation_specs, output_format=OutputFormat(args.format), output=args.output)
+
+
+def parse_args(parser: argparse.ArgumentParser) -> None:
+    argument_parser = ArgumentParser(parser)
+
+    required_group = parser.add_mutually_exclusive_group(required=True)
+    required_group.add_argument("-p", "--project_id", help="対象のプロジェクトのproject_idを指定します。APIで取得したアノテーション仕様情報を元に出力します。")
+    required_group.add_argument(
+        "--annotation_specs_json_file",
+        type=Path,
+        help="指定したアノテーション仕様のJSONファイルを指定します。JSONファイルに記載された情報を元に出力します。ただしアノテーション仕様の ``format_version`` は ``3`` である必要があります。",
+    )
+
+    old_annotation_specs_group = parser.add_mutually_exclusive_group()
+    old_annotation_specs_group.add_argument(
+        "--history_id",
+        type=str,
+        help=(
+            "出力したいアノテーション仕様のhistory_idを指定してください。 "
+            "history_idは ``annotation_specs list_history`` コマンドで確認できます。 "
+            "指定しない場合は、最新のアノテーション仕様が出力されます。 "
+        ),
+    )
+
+    old_annotation_specs_group.add_argument(
+        "--before",
+        type=annofabcli.common.cli.non_negative_int,
+        help=(
+            "出力したい過去のアノテーション仕様が、最新よりいくつ前のアノテーション仕様であるかを指定してください。  "
+            "たとえば ``1`` を指定した場合、最新より1個前のアノテーション仕様を出力します。 "
+            "指定しない場合は、最新のアノテーション仕様が出力されます。 "
+        ),
+    )
+
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        choices=[OutputFormat.JSON.value, OutputFormat.PRETTY_JSON.value],
+        default=OutputFormat.JSON.value,
+        help="出力フォーマット",
+    )
+
+    argument_parser.add_output()
+
+    parser.set_defaults(subcommand_func=main)
+
+
+def main(args: argparse.Namespace) -> None:
+    service = build_annofabapi_resource_and_login(args)
+    facade = AnnofabApiFacade(service)
+    PrintAnnotationImportInfo(service, facade, args).main()
+
+
+def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
+    subcommand_name = "list_annotation_import_info"
+
+    subcommand_help = "annotation import 用のラベル名、属性名、選択肢名、種類を出力します。"
+
+    parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help)
+    parse_args(parser)
+    return parser

--- a/annofabcli/annotation_specs/list_annotation_import_info.py
+++ b/annofabcli/annotation_specs/list_annotation_import_info.py
@@ -7,8 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from annofabapi.models import Lang
-from annofabapi.util.annotation_specs import InternationalizationMessage, get_message_with_lang
+from annofabapi.util.annotation_specs import get_attribute_name_en, get_choice_name_en, get_label_name_en
 from pydantic import BaseModel, ConfigDict
 
 import annofabcli.common.cli
@@ -72,16 +71,10 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
 
     dict_attribute = {attribute["additional_data_definition_id"]: attribute for attribute in annotation_specs_v3["additionals"]}
 
-    def get_required_english_name(name: InternationalizationMessage) -> str:
-        result = get_message_with_lang(name, lang=Lang.EN_US)
-        if result is None:
-            raise ValueError("アノテーション仕様に英語名が存在しません。")
-        return result
-
     def create_choice_list(attribute: dict[str, Any]) -> list[AnnotationImportChoice]:
         return [
             AnnotationImportChoice(
-                choice_name_en=get_required_english_name(choice["name"]),
+                choice_name_en=get_choice_name_en(choice),
             )
             for choice in attribute["choices"]
         ]
@@ -92,7 +85,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
             attribute = dict_attribute[attribute_id]
             result.append(
                 AnnotationImportAttribute(
-                    attribute_name_en=get_required_english_name(attribute["name"]),
+                    attribute_name_en=get_attribute_name_en(attribute),
                     attribute_type=attribute["type"],
                     choices=create_choice_list(attribute),
                 )
@@ -101,7 +94,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
 
     return [
         AnnotationImportLabel(
-            label_name_en=get_required_english_name(label["label_name"]),
+            label_name_en=get_label_name_en(label),
             annotation_type=label["annotation_type"],
             attributes=create_attribute_list(label),
         )
@@ -214,7 +207,7 @@ def main(args: argparse.Namespace) -> None:
 def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse.ArgumentParser:
     subcommand_name = "list_annotation_import_info"
 
-    subcommand_help = "annotation import 用のラベル名、属性名、選択肢名、種類を出力します。"
+    subcommand_help = "アノテーションをimportする際に参照すべき情報（ラベル、属性、選択肢）のみを出力します。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help)
     parse_args(parser)

--- a/annofabcli/annotation_specs/subcommand_annotation_specs.py
+++ b/annofabcli/annotation_specs/subcommand_annotation_specs.py
@@ -16,6 +16,7 @@ import annofabcli.annotation_specs.delete_labels
 import annofabcli.annotation_specs.diff_annotation_specs
 import annofabcli.annotation_specs.export_annotation_specs
 import annofabcli.annotation_specs.import_annotation_specs
+import annofabcli.annotation_specs.list_annotation_import_info
 import annofabcli.annotation_specs.list_annotation_specs_attribute
 import annofabcli.annotation_specs.list_annotation_specs_choice
 import annofabcli.annotation_specs.list_annotation_specs_history
@@ -57,6 +58,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     annofabcli.annotation_specs.diff_annotation_specs.add_parser(subparsers)
     annofabcli.annotation_specs.export_annotation_specs.add_parser(subparsers)
     annofabcli.annotation_specs.import_annotation_specs.add_parser(subparsers)
+    annofabcli.annotation_specs.list_annotation_import_info.add_parser(subparsers)
     annofabcli.annotation_specs.list_annotation_specs_attribute.add_parser(subparsers)
     annofabcli.annotation_specs.list_annotation_specs_choice.add_parser(subparsers)
     annofabcli.annotation_specs.list_annotation_specs_history.add_parser(subparsers)

--- a/docs/command_reference/annotation_specs/index.rst
+++ b/docs/command_reference/annotation_specs/index.rst
@@ -31,6 +31,7 @@ Available Commands
    diff
    export
    import
+   list_annotation_import_info
    list_attribute
    list_choice
    list_history

--- a/docs/command_reference/annotation_specs/list_annotation_import_info.rst
+++ b/docs/command_reference/annotation_specs/list_annotation_import_info.rst
@@ -7,7 +7,7 @@ Description
 アノテーションをimportする際に参照すべき情報（ラベル、属性、選択肢）のみを出力します。
 
 ``annotation import`` のJSONに指定するラベル名、属性名、選択肢名を確認するためのコマンドです。
-日本語名、色情報、ID、キーバインドなど、``annotation import`` で直接参照しない情報は出力しません。
+日本語名、色情報、ID、キーバインドなど、 ``annotation import`` で直接参照しない情報は出力しません。
 
 
 Examples
@@ -20,8 +20,8 @@ Examples
 
     $ annofabcli annotation_specs list_annotation_import_info --project_id prj1 --format pretty_json
 
-デフォルトでは最新のアノテーション仕様を出力します。過去のアノテーション仕様を出力する場合は、``--before`` または ``--history_id`` を指定してください。
-history_idは、`annofabcli annotation_specs list_history <../annotation_specs/list_history.html>`_ コマンドで取得できます。
+デフォルトでは最新のアノテーション仕様を出力します。過去のアノテーション仕様を出力する場合は、 ``--before`` または ``--history_id`` を指定してください。
+history_idは、 `annofabcli annotation_specs list_history <../annotation_specs/list_history.html>`_ コマンドで取得できます。
 
 以下のコマンドは、最新より1つ前のアノテーション仕様を出力します。
 
@@ -36,15 +36,6 @@ history_idは、`annofabcli annotation_specs list_history <../annotation_specs/l
 
     $ annofabcli annotation_specs list_annotation_import_info --project_id prj1 --history_id xxx
 
-
-アノテーション仕様JSONファイルを元に出力する
-----------------------------------------------------
-
-.. code-block::
-
-    $ annofabcli annotation_specs list_annotation_import_info \
-    --annotation_specs_json_file annotation_specs.json \
-    --format pretty_json
 
 
 出力結果
@@ -88,13 +79,13 @@ JSON出力
     ]
 
 
-* ``label_name_en`` : ラベル名（英語）。``annotation import`` の ``label`` に指定する値です。
+* ``label_name_en`` : ラベル名（英語）。 ``annotation import`` の ``label`` に指定する値です。
 * ``annotation_type`` : アノテーションの種類。Web APIの `AnnotationType <https://annofab.com/docs/api/#tag/x-data-types/AnnotationType>`_ に対応しています。
 * ``attributes`` : ラベルに指定できる属性情報の配列です。
-* ``attribute_name_en`` : 属性名（英語）。``annotation import`` の ``attributes`` のキーに指定する値です。
+* ``attribute_name_en`` : 属性名（英語）。 ``annotation import`` の ``attributes`` のキーに指定する値です。
 * ``attribute_type`` : 属性の種類。WebAPIの ``AdditionalDataDefinitionType`` に対応しています。
 * ``choices`` : 選択肢情報の配列です。属性の種類がラジオボタンまたはドロップダウン以外の場合は空配列です。
-* ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、``annotation import`` の ``attributes`` の値として指定する値です。
+* ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、 ``annotation import`` の ``attributes`` の値として指定する値です。
 
 
 Usage Details

--- a/docs/command_reference/annotation_specs/list_annotation_import_info.rst
+++ b/docs/command_reference/annotation_specs/list_annotation_import_info.rst
@@ -1,0 +1,107 @@
+=======================================================
+annotation_specs list_annotation_import_info
+=======================================================
+
+Description
+=================================
+アノテーションをimportする際に参照すべき情報（ラベル、属性、選択肢）のみを出力します。
+
+``annotation import`` のJSONに指定するラベル名、属性名、選択肢名を確認するためのコマンドです。
+日本語名、色情報、ID、キーバインドなど、``annotation import`` で直接参照しない情報は出力しません。
+
+
+Examples
+=================================
+
+基本的な使い方
+--------------------------
+
+.. code-block::
+
+    $ annofabcli annotation_specs list_annotation_import_info --project_id prj1 --format pretty_json
+
+デフォルトでは最新のアノテーション仕様を出力します。過去のアノテーション仕様を出力する場合は、``--before`` または ``--history_id`` を指定してください。
+history_idは、`annofabcli annotation_specs list_history <../annotation_specs/list_history.html>`_ コマンドで取得できます。
+
+以下のコマンドは、最新より1つ前のアノテーション仕様を出力します。
+
+.. code-block::
+
+    $ annofabcli annotation_specs list_annotation_import_info --project_id prj1 --before 1
+
+
+以下のコマンドは、history_idが"xxx"のアノテーション仕様を出力します。
+
+.. code-block::
+
+    $ annofabcli annotation_specs list_annotation_import_info --project_id prj1 --history_id xxx
+
+
+アノテーション仕様JSONファイルを元に出力する
+----------------------------------------------------
+
+.. code-block::
+
+    $ annofabcli annotation_specs list_annotation_import_info \
+    --annotation_specs_json_file annotation_specs.json \
+    --format pretty_json
+
+
+出力結果
+=================================
+
+JSON出力
+----------------------------------------------
+
+.. code-block::
+
+    $ annofabcli annotation_specs list_annotation_import_info --project_id prj1 --format pretty_json --output out.json
+
+
+.. code-block::
+    :caption: out.json
+
+    [
+        {
+            "label_name_en": "car",
+            "annotation_type": "bounding_box",
+            "attributes": [
+                {
+                    "attribute_name_en": "occluded",
+                    "attribute_type": "flag",
+                    "choices": []
+                },
+                {
+                    "attribute_name_en": "direction",
+                    "attribute_type": "select",
+                    "choices": [
+                        {
+                            "choice_name_en": "front"
+                        },
+                        {
+                            "choice_name_en": "side"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+
+
+* ``label_name_en`` : ラベル名（英語）。``annotation import`` の ``label`` に指定する値です。
+* ``annotation_type`` : アノテーションの種類。Web APIの `AnnotationType <https://annofab.com/docs/api/#tag/x-data-types/AnnotationType>`_ に対応しています。
+* ``attributes`` : ラベルに指定できる属性情報の配列です。
+* ``attribute_name_en`` : 属性名（英語）。``annotation import`` の ``attributes`` のキーに指定する値です。
+* ``attribute_type`` : 属性の種類。WebAPIの ``AdditionalDataDefinitionType`` に対応しています。
+* ``choices`` : 選択肢情報の配列です。属性の種類がラジオボタンまたはドロップダウン以外の場合は空配列です。
+* ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、``annotation import`` の ``attributes`` の値として指定する値です。
+
+
+Usage Details
+=================================
+
+.. argparse::
+   :ref: annofabcli.annotation_specs.list_annotation_import_info.add_parser
+   :prog: annofabcli annotation_specs list_annotation_import_info
+   :nosubcommands:
+   :nodefaultconst:

--- a/docs/command_reference/annotation_specs/list_annotation_import_info.rst
+++ b/docs/command_reference/annotation_specs/list_annotation_import_info.rst
@@ -82,10 +82,12 @@ JSON出力
 * ``label_name_en`` : ラベル名（英語）。 ``annotation import`` の ``label`` に指定する値です。
 * ``annotation_type`` : アノテーションの種類。Web APIの `AnnotationType <https://annofab.com/docs/api/#tag/x-data-types/AnnotationType>`_ に対応しています。
 * ``attributes`` : ラベルに指定できる属性情報の配列です。
-* ``attribute_name_en`` : 属性名（英語）。 ``annotation import`` の ``attributes`` のキーに指定する値です。
-* ``attribute_type`` : 属性の種類。WebAPIの ``AdditionalDataDefinitionType`` に対応しています。
-* ``choices`` : 選択肢情報の配列です。属性の種類がラジオボタンまたはドロップダウン以外の場合は空配列です。
-* ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、 ``annotation import`` の ``attributes`` の値として指定する値です。
+
+  * ``attribute_name_en`` : 属性名（英語）。 ``annotation import`` の ``attributes`` のキーに指定する値です。
+  * ``attribute_type`` : 属性の種類。WebAPIの ``AdditionalDataDefinitionType`` に対応しています。
+  * ``choices`` : 選択肢情報の配列です。属性の種類がラジオボタンまたはドロップダウン以外の場合は空配列です。
+
+    * ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、 ``annotation import`` の ``attributes`` の値として指定する値です。
 
 
 Usage Details

--- a/tests/annotation_specs/test_list_annotation_import_info.py
+++ b/tests/annotation_specs/test_list_annotation_import_info.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from annofabcli.annotation_specs.list_annotation_import_info import create_annotation_import_info_list
+
+DATA_DIR = Path("./tests/data/annotation_specs")
+
+
+def test_create_annotation_import_info_listはimportに必要な情報を出力する() -> None:
+    with (DATA_DIR / "annotation_specs.json").open(encoding="utf-8") as f:
+        annotation_specs = json.load(f)
+
+    actual = create_annotation_import_info_list(annotation_specs)
+
+    car_label = next(e for e in actual if e.label_name_en == "car")
+    assert car_label.annotation_type == "bounding_box"
+    assert [e.attribute_name_en for e in car_label.attributes] == ["comment", "link", "type", "unclear"]
+
+    type_attribute = next(e for e in car_label.attributes if e.attribute_name_en == "type")
+    assert type_attribute.attribute_type == "select"
+    assert [e.choice_name_en for e in type_attribute.choices] == ["large", "medium", "small"]
+
+
+def test_create_annotation_import_info_listは属性がないラベルも出力する() -> None:
+    with (DATA_DIR / "annotation_specs.json").open(encoding="utf-8") as f:
+        annotation_specs = json.load(f)
+
+    actual = create_annotation_import_info_list(annotation_specs)
+
+    bike_label = next(e for e in actual if e.label_name_en == "bike")
+    assert bike_label.annotation_type == "bounding_box"
+    assert bike_label.attributes == []


### PR DESCRIPTION
アノテーションをインポートする際に必要なアノテーション仕様の情報を出力します。
LLMに渡す前提です。