### PR TITLE
annotaton_specs: 英語名はキーでなく更新対象にしました

### DIFF
--- a/annofabcli/annotation_specs/update_attributes.py
+++ b/annofabcli/annotation_specs/update_attributes.py
@@ -44,7 +44,7 @@ class AttributeUpdateInput:
     """更新対象属性ID。"""
 
     attribute_name_en: str | None = None
-    """更新対象属性の英語名。"""
+    """更新後の属性英語名。"""
 
     attribute_name_ja: str | None = None
     """更新後の属性日本語名。"""
@@ -79,11 +79,12 @@ def validate_attribute_update_input(attribute_update_input: AttributeUpdateInput
     """
     属性更新入力を検証する。
     """
-    if (attribute_update_input.attribute_id is None) == (attribute_update_input.attribute_name_en is None):
-        raise ValueError(f"{index}件目の属性は `attribute_id` または `attribute_name_en` のどちらか一方だけ指定してください。")
+    if attribute_update_input.attribute_id is None:
+        raise ValueError(f"{index}件目の属性に `attribute_id` が指定されていません。")
 
     has_update_field = any(
         [
+            attribute_update_input.attribute_name_en is not None,
             attribute_update_input.attribute_name_ja is not None,
             attribute_update_input.keybind is not None,
             attribute_update_input.read_only is not None,
@@ -185,11 +186,6 @@ def validate_attribute_update_inputs(attribute_update_inputs: Sequence[Attribute
         duplicated_text = ", ".join(sorted(duplicated_attribute_ids))
         raise ValueError(f"入力された属性に重複した `attribute_id` があります。 :: {duplicated_text}")
 
-    duplicated_attribute_names = duplicated_set([attribute.attribute_name_en for attribute in attribute_update_inputs if attribute.attribute_name_en is not None])
-    if duplicated_attribute_names:
-        duplicated_text = ", ".join(sorted(duplicated_attribute_names))
-        raise ValueError(f"入力された属性名(英語)に重複があります。 :: {duplicated_text}")
-
 
 def resolve_attribute_update_inputs(
     annotation_specs: dict[str, Any],
@@ -205,11 +201,7 @@ def resolve_attribute_update_inputs(
     result = []
     resolved_attribute_ids: set[str] = set()
     for attribute_update_input in attribute_update_inputs:
-        if attribute_update_input.attribute_id is not None:
-            target_attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_update_input.attribute_id)
-        else:
-            assert attribute_update_input.attribute_name_en is not None
-            target_attribute = annotation_specs_accessor.get_attribute(attribute_name=attribute_update_input.attribute_name_en)
+        target_attribute = annotation_specs_accessor.get_attribute(attribute_id=attribute_update_input.attribute_id)
 
         target_attribute_id = target_attribute["additional_data_definition_id"]
         if target_attribute_id in resolved_attribute_ids:
@@ -231,6 +223,30 @@ def update_attribute_name_ja(attribute: dict[str, Any], attribute_name_ja: str) 
             return
 
     messages.append({"lang": "ja-JP", "message": attribute_name_ja})
+
+
+def update_attribute_name_en(attribute: dict[str, Any], attribute_name_en: str) -> None:
+    """
+    属性英語名を更新する。
+    """
+    messages = attribute["name"]["messages"]
+    for message in messages:
+        if message["lang"] == "en-US":
+            message["message"] = attribute_name_en
+            return
+
+    messages.append({"lang": "en-US", "message": attribute_name_en})
+
+
+def validate_attribute_name_ens_not_duplicated(additionals: Sequence[Mapping[str, Any]]) -> None:
+    """
+    属性英語名が重複していないことを検証する。
+    """
+    attribute_name_ens = [get_attribute_name_en(attribute) for attribute in additionals]
+    duplicated_attribute_name_ens = duplicated_set([name for name in attribute_name_ens if name is not None])
+    if duplicated_attribute_name_ens:
+        duplicated_text = ", ".join(sorted(duplicated_attribute_name_ens))
+        raise ValueError(f"属性名(英語)に重複があります。 :: {duplicated_text}")
 
 
 def create_comment_for_update_attributes(resolved_attribute_update_inputs: Sequence[ResolvedAttributeUpdateInput]) -> str:
@@ -257,6 +273,8 @@ def build_request_body_for_update_attributes(
         if attribute_update_input is None:
             continue
 
+        if attribute_update_input.attribute_name_en is not None:
+            update_attribute_name_en(attribute, attribute_update_input.attribute_name_en)
         if attribute_update_input.attribute_name_ja is not None:
             update_attribute_name_ja(attribute, attribute_update_input.attribute_name_ja)
         if attribute_update_input.keybind is not None:
@@ -265,6 +283,8 @@ def build_request_body_for_update_attributes(
             attribute["read_only"] = attribute_update_input.read_only
         if attribute_update_input.has_default_value:
             attribute["default"] = parse_default_value(attribute["type"], attribute_update_input.default_value)
+
+    validate_attribute_name_ens_not_duplicated(request_body["additionals"])
 
     if comment is None:
         comment = create_comment_for_update_attributes(resolved_attribute_update_inputs)
@@ -349,6 +369,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     sample_json = [
         {
+            "attribute_id": "54fa5e97-6f88-49a4-aeb0-a91a15d11528",
             "attribute_name_en": "comment",
             "attribute_name_ja": "コメント",
             "keybind": {"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
@@ -363,8 +384,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         help=(
             "更新する属性情報のJSON配列を指定します。 ``file://`` を先頭に付けるとJSON形式のファイルを指定できます。"
-            " 各要素には ``attribute_id`` または ``attribute_name_en`` のどちらか一方が必要です。"
-            " 任意で ``attribute_name_ja`` , ``keybind`` , ``read_only`` , ``default_value`` を指定できます。"
+            " 各要素には更新対象を示す ``attribute_id`` が必要です。"
+            " 任意で更新後の ``attribute_name_en`` , ``attribute_name_ja`` , ``keybind`` , ``read_only`` , ``default_value`` を指定できます。"
             f"\n(例) ``{json.dumps(sample_json, ensure_ascii=False)}``"
         ),
     )
@@ -372,8 +393,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--attribute_csv",
         type=Path,
         help=(
-            "更新する属性情報のCSVファイルを指定します。 CSVには ``attribute_id`` または ``attribute_name_en`` 列のどちらか一方が必要です。"
-            " 任意で ``attribute_name_ja`` , ``keybind`` , ``read_only`` , ``default_value`` 列を指定できます。"
+            "更新する属性情報のCSVファイルを指定します。 CSVには更新対象を示す ``attribute_id`` 列が必要です。"
+            " 任意で更新後の ``attribute_name_en`` , ``attribute_name_ja`` , ``keybind`` , ``read_only`` , ``default_value`` 列を指定できます。"
             " ``keybind`` 列にはJSONオブジェクト文字列を指定してください。"
         ),
     )
@@ -397,7 +418,7 @@ def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse
     """
     subcommand_name = "update_attributes"
     subcommand_help = "アノテーション仕様の既存属性情報を更新します。"
-    description = "アノテーション仕様の既存属性に設定された日本語名、キーバインド、read_only、default_value を更新します。"
+    description = "アノテーション仕様の既存属性に設定された英語名、日本語名、キーバインド、read_only、default_value を更新します。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/update_attributes.py
+++ b/annofabcli/annotation_specs/update_attributes.py
@@ -238,15 +238,21 @@ def update_attribute_name_en(attribute: dict[str, Any], attribute_name_en: str) 
     messages.append({"lang": "en-US", "message": attribute_name_en})
 
 
-def validate_attribute_name_ens_not_duplicated(additionals: Sequence[Mapping[str, Any]]) -> None:
+def validate_attribute_name_ens_not_duplicated_in_labels(annotation_specs: Mapping[str, Any]) -> None:
     """
-    属性英語名が重複していないことを検証する。
+    ラベル内の属性英語名が重複していないことを検証する。
     """
-    attribute_name_ens = [get_attribute_name_en(attribute) for attribute in additionals]
-    duplicated_attribute_name_ens = duplicated_set([name for name in attribute_name_ens if name is not None])
-    if duplicated_attribute_name_ens:
-        duplicated_text = ", ".join(sorted(duplicated_attribute_name_ens))
-        raise ValueError(f"属性名(英語)に重複があります。 :: {duplicated_text}")
+    attributes_by_id = {attribute["additional_data_definition_id"]: attribute for attribute in annotation_specs["additionals"]}
+    for label in annotation_specs["labels"]:
+        attribute_name_ens = []
+        for attribute_id in label["additional_data_definitions"]:
+            attribute = attributes_by_id.get(attribute_id)
+            if attribute is not None:
+                attribute_name_ens.append(get_attribute_name_en(attribute))
+        duplicated_attribute_name_ens = duplicated_set([name for name in attribute_name_ens if name is not None])
+        if duplicated_attribute_name_ens:
+            duplicated_text = ", ".join(sorted(duplicated_attribute_name_ens))
+            raise ValueError(f"ラベル内の属性名(英語)に重複があります。 :: label_id='{label['label_id']}', attribute_name_en={duplicated_text}")
 
 
 def create_comment_for_update_attributes(resolved_attribute_update_inputs: Sequence[ResolvedAttributeUpdateInput]) -> str:
@@ -284,7 +290,7 @@ def build_request_body_for_update_attributes(
         if attribute_update_input.has_default_value:
             attribute["default"] = parse_default_value(attribute["type"], attribute_update_input.default_value)
 
-    validate_attribute_name_ens_not_duplicated(request_body["additionals"])
+    validate_attribute_name_ens_not_duplicated_in_labels(request_body)
 
     if comment is None:
         comment = create_comment_for_update_attributes(resolved_attribute_update_inputs)

--- a/annofabcli/annotation_specs/update_attributes.py
+++ b/annofabcli/annotation_specs/update_attributes.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import annofabapi
 import pandas
-from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_attribute_name_en
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_attribute_name_en, get_message_with_lang
 
 import annofabcli.common.cli
 from annofabcli.annotation_specs.add_attribute import parse_default_value
@@ -216,26 +216,28 @@ def update_attribute_name_ja(attribute: dict[str, Any], attribute_name_ja: str) 
     """
     属性日本語名を更新する。
     """
-    messages = attribute["name"]["messages"]
-    for message in messages:
+    if get_message_with_lang(attribute["name"], "ja-JP") is None:
+        attribute["name"]["messages"].append({"lang": "ja-JP", "message": attribute_name_ja})
+        return
+
+    for message in attribute["name"]["messages"]:
         if message["lang"] == "ja-JP":
             message["message"] = attribute_name_ja
             return
-
-    messages.append({"lang": "ja-JP", "message": attribute_name_ja})
 
 
 def update_attribute_name_en(attribute: dict[str, Any], attribute_name_en: str) -> None:
     """
     属性英語名を更新する。
     """
-    messages = attribute["name"]["messages"]
-    for message in messages:
+    if get_message_with_lang(attribute["name"], "en-US") is None:
+        attribute["name"]["messages"].append({"lang": "en-US", "message": attribute_name_en})
+        return
+
+    for message in attribute["name"]["messages"]:
         if message["lang"] == "en-US":
             message["message"] = attribute_name_en
             return
-
-    messages.append({"lang": "en-US", "message": attribute_name_en})
 
 
 def validate_attribute_name_ens_not_duplicated_in_labels(annotation_specs: Mapping[str, Any]) -> None:

--- a/annofabcli/annotation_specs/update_attributes.py
+++ b/annofabcli/annotation_specs/update_attributes.py
@@ -259,8 +259,17 @@ def create_comment_for_update_attributes(resolved_attribute_update_inputs: Seque
     """
     属性更新時のデフォルトコメントを生成する。
     """
-    attribute_names = [get_attribute_name_en(attribute_input.target_attribute) for attribute_input in resolved_attribute_update_inputs]
-    return f"以下の属性情報を更新しました。\n対象属性: {', '.join(attribute_names)}"
+    attribute_texts = []
+    for attribute_input in resolved_attribute_update_inputs:
+        attribute_id = attribute_input.target_attribute["additional_data_definition_id"]
+        old_attribute_name_en = get_attribute_name_en(attribute_input.target_attribute)
+        new_attribute_name_en = attribute_input.attribute_update_input.attribute_name_en
+        if new_attribute_name_en is not None and new_attribute_name_en != old_attribute_name_en:
+            attribute_text = f"attribute_id='{attribute_id}', attribute_name_en='{old_attribute_name_en}' -> '{new_attribute_name_en}'"
+        else:
+            attribute_text = f"attribute_id='{attribute_id}', attribute_name_en='{old_attribute_name_en}'"
+        attribute_texts.append(attribute_text)
+    return f"以下の属性情報を更新しました。\n対象属性: {', '.join(attribute_texts)}"
 
 
 def build_request_body_for_update_attributes(

--- a/annofabcli/annotation_specs/update_choices.py
+++ b/annofabcli/annotation_specs/update_choices.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import annofabapi
 import pandas
-from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_attribute_name_en, get_choice_name_en
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_attribute_name_en, get_choice_name_en, get_message_with_lang
 
 import annofabcli.common.cli
 from annofabcli.annotation_specs.add_labels import parse_keybind_in_csv
@@ -215,26 +215,28 @@ def update_choice_name_ja(choice: dict[str, Any], choice_name_ja: str) -> None:
     """
     選択肢日本語名を更新する。
     """
-    messages = choice["name"]["messages"]
-    for message in messages:
+    if get_message_with_lang(choice["name"], "ja-JP") is None:
+        choice["name"]["messages"].append({"lang": "ja-JP", "message": choice_name_ja})
+        return
+
+    for message in choice["name"]["messages"]:
         if message["lang"] == "ja-JP":
             message["message"] = choice_name_ja
             return
-
-    messages.append({"lang": "ja-JP", "message": choice_name_ja})
 
 
 def update_choice_name_en(choice: dict[str, Any], choice_name_en: str) -> None:
     """
     選択肢英語名を更新する。
     """
-    messages = choice["name"]["messages"]
-    for message in messages:
+    if get_message_with_lang(choice["name"], "en-US") is None:
+        choice["name"]["messages"].append({"lang": "en-US", "message": choice_name_en})
+        return
+
+    for message in choice["name"]["messages"]:
         if message["lang"] == "en-US":
             message["message"] = choice_name_en
             return
-
-    messages.append({"lang": "en-US", "message": choice_name_en})
 
 
 def validate_choice_name_ens_not_duplicated(target_attribute: Mapping[str, Any]) -> None:

--- a/annofabcli/annotation_specs/update_choices.py
+++ b/annofabcli/annotation_specs/update_choices.py
@@ -41,7 +41,7 @@ class ChoiceUpdateInput:
     """更新対象選択肢ID。"""
 
     choice_name_en: str | None = None
-    """更新対象選択肢の英語名。"""
+    """更新後の選択肢英語名。"""
 
     choice_name_ja: str | None = None
     """更新後の選択肢日本語名。"""
@@ -73,10 +73,10 @@ def validate_choice_update_input(choice_update_input: ChoiceUpdateInput, *, inde
     """
     選択肢更新入力を検証する。
     """
-    if (choice_update_input.choice_id is None) == (choice_update_input.choice_name_en is None):
-        raise ValueError(f"{index}件目の選択肢は `choice_id` または `choice_name_en` のどちらか一方だけ指定してください。")
+    if choice_update_input.choice_id is None:
+        raise ValueError(f"{index}件目の選択肢に `choice_id` が指定されていません。")
 
-    if choice_update_input.choice_name_ja is None and not choice_update_input.has_keybind:
+    if choice_update_input.choice_name_en is None and choice_update_input.choice_name_ja is None and not choice_update_input.has_keybind:
         raise ValueError(f"{index}件目の選択肢に更新するフィールドが指定されていません。")
 
 
@@ -164,29 +164,15 @@ def validate_choice_update_inputs(choice_update_inputs: Sequence[ChoiceUpdateInp
         duplicated_text = ", ".join(sorted(duplicated_choice_ids))
         raise ValueError(f"入力された選択肢に重複した `choice_id` があります。 :: {duplicated_text}")
 
-    duplicated_choice_names = duplicated_set([choice.choice_name_en for choice in choice_update_inputs if choice.choice_name_en is not None])
-    if duplicated_choice_names:
-        duplicated_text = ", ".join(sorted(duplicated_choice_names))
-        raise ValueError(f"入力された選択肢名(英語)に重複があります。 :: {duplicated_text}")
-
 
 def get_target_choice(target_attribute: Mapping[str, Any], choice_update_input: ChoiceUpdateInput) -> Mapping[str, Any]:
     """
     選択肢更新入力から更新対象選択肢を取得する。
     """
     choices = target_attribute["choices"]
-    if choice_update_input.choice_id is not None:
-        matched_choices = [choice for choice in choices if choice["choice_id"] == choice_update_input.choice_id]
-        if len(matched_choices) == 0:
-            raise ValueError(f"選択肢情報が見つかりませんでした。 :: choice_id='{choice_update_input.choice_id}'")
-        return matched_choices[0]
-
-    assert choice_update_input.choice_name_en is not None
-    matched_choices = [choice for choice in choices if get_choice_name_en(choice) == choice_update_input.choice_name_en]
+    matched_choices = [choice for choice in choices if choice["choice_id"] == choice_update_input.choice_id]
     if len(matched_choices) == 0:
-        raise ValueError(f"選択肢情報が見つかりませんでした。 :: choice_name_en='{choice_update_input.choice_name_en}'")
-    if len(matched_choices) > 1:
-        raise ValueError(f"選択肢情報が複数（{len(matched_choices)}件）見つかりました。 :: choice_name_en='{choice_update_input.choice_name_en}'")
+        raise ValueError(f"選択肢情報が見つかりませんでした。 :: choice_id='{choice_update_input.choice_id}'")
     return matched_choices[0]
 
 
@@ -238,6 +224,30 @@ def update_choice_name_ja(choice: dict[str, Any], choice_name_ja: str) -> None:
     messages.append({"lang": "ja-JP", "message": choice_name_ja})
 
 
+def update_choice_name_en(choice: dict[str, Any], choice_name_en: str) -> None:
+    """
+    選択肢英語名を更新する。
+    """
+    messages = choice["name"]["messages"]
+    for message in messages:
+        if message["lang"] == "en-US":
+            message["message"] = choice_name_en
+            return
+
+    messages.append({"lang": "en-US", "message": choice_name_en})
+
+
+def validate_choice_name_ens_not_duplicated(target_attribute: Mapping[str, Any]) -> None:
+    """
+    属性内の選択肢英語名が重複していないことを検証する。
+    """
+    choice_name_ens = [get_choice_name_en(choice) for choice in target_attribute["choices"]]
+    duplicated_choice_name_ens = duplicated_set([name for name in choice_name_ens if name is not None])
+    if duplicated_choice_name_ens:
+        duplicated_text = ", ".join(sorted(duplicated_choice_name_ens))
+        raise ValueError(f"選択肢名(英語)に重複があります。 :: {duplicated_text}")
+
+
 def create_comment_for_update_choices(resolved_choice_update_inputs: Sequence[ResolvedChoiceUpdateInput]) -> str:
     """
     選択肢更新時のデフォルトコメントを生成する。
@@ -267,10 +277,13 @@ def build_request_body_for_update_choices(
             choice_update_input = choice_input_dict.get(choice["choice_id"])
             if choice_update_input is None:
                 continue
+            if choice_update_input.choice_name_en is not None:
+                update_choice_name_en(choice, choice_update_input.choice_name_en)
             if choice_update_input.choice_name_ja is not None:
                 update_choice_name_ja(choice, choice_update_input.choice_name_ja)
             if choice_update_input.has_keybind:
                 choice["keybind"] = keybind_to_api_keybind(copy.deepcopy(choice_update_input.keybind))
+        validate_choice_name_ens_not_duplicated(attribute)
         break
 
     if comment is None:
@@ -370,6 +383,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     sample_json = [
         {
+            "choice_id": "08ec927c-18e6-4bba-837a-b16de7061580",
             "choice_name_en": "large",
             "choice_name_ja": "大",
             "keybind": {"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
@@ -382,8 +396,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         help=(
             "更新する選択肢情報のJSON配列を指定します。 ``file://`` を先頭に付けるとJSON形式のファイルを指定できます。"
-            " 各要素には ``choice_id`` または ``choice_name_en`` のどちらか一方が必要です。"
-            " 任意で ``choice_name_ja`` , ``keybind`` を指定できます。 ``keybind`` に ``null`` を指定するとショートカットキーを解除します。"
+            " 各要素には更新対象を示す ``choice_id`` が必要です。"
+            " 任意で更新後の ``choice_name_en`` , ``choice_name_ja`` , ``keybind`` を指定できます。 ``keybind`` に ``null`` を指定するとショートカットキーを解除します。"
             f"\n(例) ``{json.dumps(sample_json, ensure_ascii=False)}``"
         ),
     )
@@ -391,8 +405,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--choice_csv",
         type=Path,
         help=(
-            "更新する選択肢情報のCSVファイルを指定します。 CSVには ``choice_id`` または ``choice_name_en`` 列のどちらか一方が必要です。"
-            " 任意で ``choice_name_ja`` , ``keybind`` 列を指定できます。"
+            "更新する選択肢情報のCSVファイルを指定します。 CSVには更新対象を示す ``choice_id`` 列が必要です。"
+            " 任意で更新後の ``choice_name_en`` , ``choice_name_ja`` , ``keybind`` 列を指定できます。"
             " ``keybind`` 列にはJSONオブジェクト文字列を指定してください。空欄の場合はショートカットキーを変更しません。"
         ),
     )
@@ -416,7 +430,7 @@ def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse
     """
     subcommand_name = "update_choices"
     subcommand_help = "アノテーション仕様の既存選択肢情報を更新します。"
-    description = "アノテーション仕様の既存選択肢に設定された日本語名、ショートカットキーを更新します。"
+    description = "アノテーション仕様の既存選択肢に設定された英語名、日本語名、ショートカットキーを更新します。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/update_labels.py
+++ b/annofabcli/annotation_specs/update_labels.py
@@ -57,7 +57,7 @@ class LabelUpdateInput:
     """更新対象ラベルID。"""
 
     label_name_en: str | None = None
-    """更新対象ラベルの英語名。"""
+    """更新後のラベル英語名。"""
 
     label_name_ja: str | None = None
     """更新後のラベル日本語名。"""
@@ -118,12 +118,13 @@ def validate_label_update_input(label_update_input: LabelUpdateInput, *, index: 
     Raises:
         ValueError: 入力値の組み合わせが不正な場合
     """
-    if (label_update_input.label_id is None) == (label_update_input.label_name_en is None):
-        raise ValueError(f"{index}件目のラベルは `label_id` または `label_name_en` のどちらか一方だけ指定してください。")
+    if label_update_input.label_id is None:
+        raise ValueError(f"{index}件目のラベルに `label_id` が指定されていません。")
 
     has_field_values_update = label_update_input.field_values is not None or label_update_input.field_values_operation is not None
     has_update_field = any(
         [
+            label_update_input.label_name_en is not None,
             label_update_input.label_name_ja is not None,
             label_update_input.color is not None,
             label_update_input.keybind is not None,
@@ -297,11 +298,6 @@ def validate_label_update_inputs(label_update_inputs: Sequence[LabelUpdateInput]
         duplicated_text = ", ".join(sorted(duplicated_label_ids))
         raise ValueError(f"入力されたラベルに重複した `label_id` があります。 :: {duplicated_text}")
 
-    duplicated_label_names = duplicated_set([label.label_name_en for label in label_update_inputs if label.label_name_en is not None])
-    if duplicated_label_names:
-        duplicated_text = ", ".join(sorted(duplicated_label_names))
-        raise ValueError(f"入力されたラベル名(英語)に重複があります。 :: {duplicated_text}")
-
 
 def resolve_label_update_inputs(
     annotation_specs: dict[str, Any],
@@ -327,11 +323,7 @@ def resolve_label_update_inputs(
     result = []
     resolved_label_ids: set[str] = set()
     for label_update_input in label_update_inputs:
-        if label_update_input.label_id is not None:
-            target_label = annotation_specs_accessor.get_label(label_id=label_update_input.label_id)
-        else:
-            assert label_update_input.label_name_en is not None
-            target_label = annotation_specs_accessor.get_label(label_name=label_update_input.label_name_en)
+        target_label = annotation_specs_accessor.get_label(label_id=label_update_input.label_id)
 
         target_label_id = target_label["label_id"]
         if target_label_id in resolved_label_ids:
@@ -357,6 +349,40 @@ def update_label_name_ja(label: dict[str, Any], label_name_ja: str) -> None:
             return
 
     messages.append({"lang": "ja-JP", "message": label_name_ja})
+
+
+def update_label_name_en(label: dict[str, Any], label_name_en: str) -> None:
+    """
+    ラベル英語名を更新する。
+
+    Args:
+        label: 更新対象ラベル
+        label_name_en: 更新後のラベル英語名
+    """
+    messages = label["label_name"]["messages"]
+    for message in messages:
+        if message["lang"] == "en-US":
+            message["message"] = label_name_en
+            return
+
+    messages.append({"lang": "en-US", "message": label_name_en})
+
+
+def validate_label_name_ens_not_duplicated(labels: Sequence[Mapping[str, Any]]) -> None:
+    """
+    ラベル英語名が重複していないことを検証する。
+
+    Args:
+        labels: 検証対象ラベル一覧
+
+    Raises:
+        ValueError: ラベル英語名が重複している場合
+    """
+    label_name_ens = [get_label_name_en(label) for label in labels]
+    duplicated_label_name_ens = duplicated_set([name for name in label_name_ens if name is not None])
+    if duplicated_label_name_ens:
+        duplicated_text = ", ".join(sorted(duplicated_label_name_ens))
+        raise ValueError(f"ラベル名(英語)に重複があります。 :: {duplicated_text}")
 
 
 def update_label_field_values(label: dict[str, Any], label_update_input: LabelUpdateInput) -> None:
@@ -422,6 +448,8 @@ def build_request_body_for_update_labels(
         if label_update_input is None:
             continue
 
+        if label_update_input.label_name_en is not None:
+            update_label_name_en(label, label_update_input.label_name_en)
         if label_update_input.label_name_ja is not None:
             update_label_name_ja(label, label_update_input.label_name_ja)
         if label_update_input.color is not None:
@@ -429,6 +457,8 @@ def build_request_body_for_update_labels(
         if label_update_input.keybind is not None:
             label["keybind"] = keybind_to_api_keybind(copy.deepcopy(label_update_input.keybind))
         update_label_field_values(label, label_update_input)
+
+    validate_label_name_ens_not_duplicated(request_body["labels"])
 
     if comment is None:
         comment = create_comment_for_update_labels(resolved_label_update_inputs)
@@ -523,6 +553,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     sample_json = [
         {
+            "label_id": "car_label_id",
             "label_name_en": "car",
             "label_name_ja": "車",
             "color": "#123456",
@@ -537,8 +568,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         help=(
             "更新するラベル情報のJSON配列を指定します。 ``file://`` を先頭に付けるとJSON形式のファイルを指定できます。"
-            " 各要素には ``label_id`` または ``label_name_en`` のどちらか一方が必要です。"
-            " 任意で ``label_name_ja`` , ``color`` , ``keybind`` , ``field_values`` , ``field_values_operation`` を指定できます。"
+            " 各要素には更新対象を示す ``label_id`` が必要です。"
+            " 任意で更新後の ``label_name_en`` , ``label_name_ja`` , ``color`` , ``keybind`` , ``field_values`` , ``field_values_operation`` を指定できます。"
             f"\n(例) ``{json.dumps(sample_json, ensure_ascii=False)}``"
         ),
     )
@@ -546,8 +577,8 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
         "--label_csv",
         type=Path,
         help=(
-            "更新するラベル情報のCSVファイルを指定します。 CSVには ``label_id`` または ``label_name_en`` 列のどちらか一方が必要です。"
-            " 任意で ``label_name_ja`` , ``color`` , ``keybind`` , ``field_values`` , ``field_values_operation`` 列を指定できます。"
+            "更新するラベル情報のCSVファイルを指定します。 CSVには更新対象を示す ``label_id`` 列が必要です。"
+            " 任意で更新後の ``label_name_en`` , ``label_name_ja`` , ``color`` , ``keybind`` , ``field_values`` , ``field_values_operation`` 列を指定できます。"
             " ``keybind`` 列と ``field_values`` 列にはJSONオブジェクト文字列を指定してください。"
         ),
     )
@@ -580,7 +611,7 @@ def add_parser(subparsers: argparse._SubParsersAction | None = None) -> argparse
     """
     subcommand_name = "update_labels"
     subcommand_help = "アノテーション仕様の既存ラベル情報を更新します。"
-    description = "アノテーション仕様の既存ラベルに設定された日本語名、色、キーバインド、field_values を更新します。"
+    description = "アノテーション仕様の既存ラベルに設定された英語名、日本語名、色、キーバインド、field_values を更新します。"
 
     parser = annofabcli.common.cli.add_parser(subparsers, subcommand_name, subcommand_help, description=description)
     parse_args(parser)

--- a/annofabcli/annotation_specs/update_labels.py
+++ b/annofabcli/annotation_specs/update_labels.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, cast
 
 import annofabapi
 import pandas
-from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_label_name_en
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_label_name_en, get_message_with_lang
 
 import annofabcli.common.cli
 from annofabcli.annotation_specs.add_labels import parse_field_values_in_csv, parse_keybind_in_csv
@@ -342,13 +342,14 @@ def update_label_name_ja(label: dict[str, Any], label_name_ja: str) -> None:
         label: 更新対象ラベル
         label_name_ja: 更新後のラベル日本語名
     """
-    messages = label["label_name"]["messages"]
-    for message in messages:
+    if get_message_with_lang(label["label_name"], "ja-JP") is None:
+        label["label_name"]["messages"].append({"lang": "ja-JP", "message": label_name_ja})
+        return
+
+    for message in label["label_name"]["messages"]:
         if message["lang"] == "ja-JP":
             message["message"] = label_name_ja
             return
-
-    messages.append({"lang": "ja-JP", "message": label_name_ja})
 
 
 def update_label_name_en(label: dict[str, Any], label_name_en: str) -> None:
@@ -359,13 +360,14 @@ def update_label_name_en(label: dict[str, Any], label_name_en: str) -> None:
         label: 更新対象ラベル
         label_name_en: 更新後のラベル英語名
     """
-    messages = label["label_name"]["messages"]
-    for message in messages:
+    if get_message_with_lang(label["label_name"], "en-US") is None:
+        label["label_name"]["messages"].append({"lang": "en-US", "message": label_name_en})
+        return
+
+    for message in label["label_name"]["messages"]:
         if message["lang"] == "en-US":
             message["message"] = label_name_en
             return
-
-    messages.append({"lang": "en-US", "message": label_name_en})
 
 
 def validate_label_name_ens_not_duplicated(labels: Sequence[Mapping[str, Any]]) -> None:

--- a/annofabcli/annotation_specs/utils.py
+++ b/annofabcli/annotation_specs/utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
-from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
+from annofabapi.util.annotation_specs import STR_LANG, AnnotationSpecsAccessor, InternationalizationMessage, get_message_with_lang
 
 
 def create_name(message_en: str, message_ja: str | None = None) -> dict[str, Any]:
@@ -23,6 +23,23 @@ def create_name(message_en: str, message_ja: str | None = None) -> dict[str, Any
         message_ja = message_en
     messages.append({"lang": "ja-JP", "message": message_ja})
     return {"messages": messages, "default_lang": "ja-JP"}
+
+
+def update_message(internationalization_message: dict[str, Any], *, lang: str, message: str) -> None:
+    """
+    Annofabの多言語メッセージを更新する。
+
+    Args:
+        internationalization_message: Annofabの多言語メッセージ形式のdict
+        lang: 更新対象の言語コード
+        message: 更新後のメッセージ
+    """
+    if get_message_with_lang(cast(InternationalizationMessage, internationalization_message), lang=cast(STR_LANG, lang)) is None:
+        internationalization_message["messages"].append({"lang": lang, "message": message})
+        return
+
+    matched_message = next(value for value in internationalization_message["messages"] if value["lang"] == lang)
+    matched_message["message"] = message
 
 
 def get_target_labels(

--- a/docs/command_reference/annotation_specs/update_attributes.rst
+++ b/docs/command_reference/annotation_specs/update_attributes.rst
@@ -4,9 +4,9 @@ annotation_specs update_attributes
 
 Description
 =================================
-アノテーション仕様の既存属性に設定された日本語名、キーバインド、 ``read_only`` 、 ``default_value`` を更新します。
+アノテーション仕様の既存属性に設定された英語名、日本語名、キーバインド、 ``read_only`` 、 ``default_value`` を更新します。
 
-``attribute_id`` 、属性名(英語)、属性種類、選択肢、所属先ラベルは既存アノテーションへの影響を避けるため更新できません。
+``attribute_id`` 、属性種類、選択肢、所属先ラベルは既存アノテーションへの影響を避けるため更新できません。
 
 
 Examples
@@ -20,6 +20,7 @@ JSON形式で指定する場合
 
     [
         {
+            "attribute_id": "54fa5e97-6f88-49a4-aeb0-a91a15d11528",
             "attribute_name_en": "comment",
             "attribute_name_ja": "コメント",
             "keybind": {
@@ -55,11 +56,11 @@ JSON形式で指定する場合
       - 必須
       - 説明
     * - ``attribute_id``
-      - 条件付き必須
-      - 更新対象属性の ``attribute_id`` 。 ``attribute_name_en`` とどちらか一方を指定してください。
+      - 必須
+      - 更新対象属性の ``attribute_id`` 。
     * - ``attribute_name_en``
-      - 条件付き必須
-      - 更新対象属性の英語名。 ``attribute_id`` とどちらか一方を指定してください。この値自体は更新されません。
+      - 任意
+      - 更新後の属性英語名。
     * - ``attribute_name_ja``
       - 任意
       - 更新後の属性日本語名。
@@ -81,7 +82,7 @@ CSV形式で指定する場合
     :caption: attributes.csv
 
     attribute_id,attribute_name_en,attribute_name_ja,keybind,read_only,default_value
-    ,comment,コメント,"{""alt"": false, ""code"": ""Digit1"", ""ctrl"": true, ""shift"": false}",false,確認済み
+    54fa5e97-6f88-49a4-aeb0-a91a15d11528,comment,コメント,"{""alt"": false, ""code"": ""Digit1"", ""ctrl"": true, ""shift"": false}",false,確認済み
     f12a0b59-dfce-4241-bb87-4b2c0259fc6f,,,,true,true
 
 

--- a/docs/command_reference/annotation_specs/update_choices.rst
+++ b/docs/command_reference/annotation_specs/update_choices.rst
@@ -4,9 +4,9 @@ annotation_specs update_choices
 
 Description
 =================================
-アノテーション仕様の既存選択肢に設定された日本語名、ショートカットキーを更新します。
+アノテーション仕様の既存選択肢に設定された英語名、日本語名、ショートカットキーを更新します。
 
-``choice_id`` 、選択肢名(英語)、選択肢の並び順、属性の ``default_value`` は更新できません。
+``choice_id`` 、選択肢の並び順、属性の ``default_value`` は更新できません。
 選択肢の並び順を変更したい場合は :doc:`reorder_choices` を、属性の ``default_value`` を変更したい場合は :doc:`update_attributes` を利用してください。
 
 
@@ -21,6 +21,7 @@ JSON形式で指定する場合
 
     [
         {
+            "choice_id": "08ec927c-18e6-4bba-837a-b16de7061580",
             "choice_name_en": "large",
             "choice_name_ja": "大",
             "keybind": {
@@ -54,11 +55,11 @@ JSON形式で指定する場合
       - 必須
       - 説明
     * - ``choice_id``
-      - 条件付き必須
-      - 更新対象選択肢の ``choice_id`` 。 ``choice_name_en`` とどちらか一方を指定してください。
+      - 必須
+      - 更新対象選択肢の ``choice_id`` 。
     * - ``choice_name_en``
-      - 条件付き必須
-      - 更新対象選択肢の英語名。 ``choice_id`` とどちらか一方を指定してください。この値自体は更新されません。
+      - 任意
+      - 更新後の選択肢英語名。
     * - ``choice_name_ja``
       - 任意
       - 更新後の選択肢日本語名。
@@ -74,7 +75,7 @@ CSV形式で指定する場合
     :caption: choices.csv
 
     choice_id,choice_name_en,choice_name_ja,keybind
-    ,large,大,"{""alt"": false, ""code"": ""Digit1"", ""ctrl"": true, ""shift"": false}"
+    08ec927c-18e6-4bba-837a-b16de7061580,large,大,"{""alt"": false, ""code"": ""Digit1"", ""ctrl"": true, ""shift"": false}"
     74691a87-7962-4fa9-ba52-7cc466ecd982,,小,
 
 

--- a/docs/command_reference/annotation_specs/update_labels.rst
+++ b/docs/command_reference/annotation_specs/update_labels.rst
@@ -4,9 +4,9 @@ annotation_specs update_labels
 
 Description
 =================================
-アノテーション仕様の既存ラベルに設定された日本語名、色、キーバインド、 ``field_values`` を更新します。
+アノテーション仕様の既存ラベルに設定された英語名、日本語名、色、キーバインド、 ``field_values`` を更新します。
 
-``label_id`` 、ラベル名(英語)、アノテーション種類は既存アノテーションへの影響を避けるため更新できません。
+``label_id`` 、アノテーション種類は既存アノテーションへの影響を避けるため更新できません。
 
 
 Examples
@@ -20,6 +20,7 @@ JSON形式で指定する場合
 
     [
         {
+            "label_id": "car_label_id",
             "label_name_en": "car",
             "label_name_ja": "車",
             "color": "#123456",
@@ -61,11 +62,11 @@ JSON形式で指定する場合
       - 必須
       - 説明
     * - ``label_id``
-      - 条件付き必須
-      - 更新対象ラベルの ``label_id`` 。 ``label_name_en`` とどちらか一方を指定してください。
+      - 必須
+      - 更新対象ラベルの ``label_id`` 。
     * - ``label_name_en``
-      - 条件付き必須
-      - 更新対象ラベルの英語名。 ``label_id`` とどちらか一方を指定してください。この値自体は更新されません。
+      - 任意
+      - 更新後のラベル英語名。
     * - ``label_name_ja``
       - 任意
       - 更新後のラベル日本語名。
@@ -90,7 +91,7 @@ CSV形式で指定する場合
     :caption: labels.csv
 
     label_id,label_name_en,label_name_ja,color,keybind,field_values,field_values_operation
-    ,car,車,#123456,"{""alt"": false, ""code"": ""Digit1"", ""ctrl"": true, ""shift"": false}","{""margin_of_error_tolerance"": {""max_pixel"": 5, ""_type"": ""MarginOfErrorTolerance""}}",
+    car_label_id,car,車,#123456,"{""alt"": false, ""code"": ""Digit1"", ""ctrl"": true, ""shift"": false}","{""margin_of_error_tolerance"": {""max_pixel"": 5, ""_type"": ""MarginOfErrorTolerance""}}",
     bike,,,,,,replace
 
 

--- a/tests/annotation_specs/test_update_attributes.py
+++ b/tests/annotation_specs/test_update_attributes.py
@@ -16,6 +16,8 @@ from annofabcli.annotation_specs.update_attributes import (
 )
 
 data_dir = Path("./tests/data/annotation_specs")
+COMMENT_ATTRIBUTE_ID = "54fa5e97-6f88-49a4-aeb0-a91a15d11528"
+UNCLEAR_ATTRIBUTE_ID = "f12a0b59-dfce-4241-bb87-4b2c0259fc6f"
 
 
 @pytest.fixture
@@ -32,7 +34,8 @@ class TestBuildRequestBodyForUpdateAttributes:
             annotation_specs,
             attribute_update_inputs=[
                 AttributeUpdateInput(
-                    attribute_name_en="comment",
+                    attribute_id=COMMENT_ATTRIBUTE_ID,
+                    attribute_name_en="remark",
                     attribute_name_ja="コメント",
                     keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
                     read_only=True,
@@ -40,7 +43,7 @@ class TestBuildRequestBodyForUpdateAttributes:
                     has_default_value=True,
                 ),
                 AttributeUpdateInput(
-                    attribute_id="f12a0b59-dfce-4241-bb87-4b2c0259fc6f",
+                    attribute_id=UNCLEAR_ATTRIBUTE_ID,
                     default_value="true",
                     has_default_value=True,
                 ),
@@ -53,17 +56,17 @@ class TestBuildRequestBodyForUpdateAttributes:
             comment=None,
         )
 
-        comment_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == "54fa5e97-6f88-49a4-aeb0-a91a15d11528")
+        comment_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == COMMENT_ATTRIBUTE_ID)
         assert comment_attribute["name"]["messages"] == [
             {"lang": "ja-JP", "message": "コメント"},
-            {"lang": "en-US", "message": "comment"},
+            {"lang": "en-US", "message": "remark"},
         ]
         assert comment_attribute["type"] == "comment"
         assert comment_attribute["read_only"] is True
         assert comment_attribute["keybind"] == [{"alt": False, "code": "Digit1", "ctrl": True, "shift": False}]
         assert comment_attribute["default"] == "確認済み"
 
-        unclear_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == "f12a0b59-dfce-4241-bb87-4b2c0259fc6f")
+        unclear_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == UNCLEAR_ATTRIBUTE_ID)
         assert unclear_attribute["default"] is True
         assert actual["comment"].startswith("以下の属性情報を更新しました。")
         assert actual["last_updated_datetime"] == "2026-04-24T00:00:00+09:00"
@@ -74,7 +77,7 @@ class TestBuildRequestBodyForUpdateAttributes:
     def test_build_request_body_for_update_attributes__custom_comment(self, annotation_specs: dict) -> None:
         resolved_inputs = resolve_attribute_update_inputs(
             annotation_specs,
-            attribute_update_inputs=[AttributeUpdateInput(attribute_name_en="comment", attribute_name_ja="コメント")],
+            attribute_update_inputs=[AttributeUpdateInput(attribute_id=COMMENT_ATTRIBUTE_ID, attribute_name_ja="コメント")],
         )
 
         actual = build_request_body_for_update_attributes(
@@ -96,7 +99,7 @@ class TestBuildRequestBodyForUpdateAttributes:
         }
         resolved_inputs = resolve_attribute_update_inputs(
             annotation_specs,
-            attribute_update_inputs=[AttributeUpdateInput(attribute_name_en="comment", attribute_name_ja="コメント")],
+            attribute_update_inputs=[AttributeUpdateInput(attribute_id=COMMENT_ATTRIBUTE_ID, attribute_name_en="remark", attribute_name_ja="コメント")],
         )
 
         actual = build_request_body_for_update_attributes(
@@ -105,10 +108,10 @@ class TestBuildRequestBodyForUpdateAttributes:
             comment=None,
         )
 
-        comment_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == "54fa5e97-6f88-49a4-aeb0-a91a15d11528")
+        comment_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == COMMENT_ATTRIBUTE_ID)
         assert comment_attribute["name"] == {
             "messages": [
-                {"lang": "en-US", "message": "comment"},
+                {"lang": "en-US", "message": "remark"},
                 {"lang": "ja-JP", "message": "コメント"},
                 {"lang": "fr-FR", "message": "commentaire"},
             ],
@@ -120,7 +123,7 @@ class TestBuildRequestBodyForUpdateAttributes:
             annotation_specs,
             attribute_update_inputs=[
                 AttributeUpdateInput(
-                    attribute_id="f12a0b59-dfce-4241-bb87-4b2c0259fc6f",
+                    attribute_id=UNCLEAR_ATTRIBUTE_ID,
                     default_value="yes",
                     has_default_value=True,
                 )
@@ -140,16 +143,16 @@ class TestResolveAttributeUpdateInputs:
         with pytest.raises(ValueError):
             resolve_attribute_update_inputs(
                 annotation_specs,
-                attribute_update_inputs=[AttributeUpdateInput(attribute_name_en="not-found", attribute_name_ja="dummy")],
+                attribute_update_inputs=[AttributeUpdateInput(attribute_id="not-found", attribute_name_ja="dummy")],
             )
 
-    def test_resolve_attribute_update_inputs__same_attribute_by_different_keys(self, annotation_specs: dict) -> None:
+    def test_resolve_attribute_update_inputs__same_attribute(self, annotation_specs: dict) -> None:
         with pytest.raises(ValueError):
             resolve_attribute_update_inputs(
                 annotation_specs,
                 attribute_update_inputs=[
-                    AttributeUpdateInput(attribute_id="54fa5e97-6f88-49a4-aeb0-a91a15d11528", attribute_name_ja="コメント"),
-                    AttributeUpdateInput(attribute_name_en="comment", read_only=True),
+                    AttributeUpdateInput(attribute_id=COMMENT_ATTRIBUTE_ID, attribute_name_ja="コメント"),
+                    AttributeUpdateInput(attribute_id=COMMENT_ATTRIBUTE_ID, read_only=True),
                 ],
             )
 
@@ -172,15 +175,16 @@ class TestAttributeUpdateInputs:
 class TestReadAttributes:
     def test_read_attributes_json(self) -> None:
         actual = read_attributes_json(
-            '[{"attribute_name_en":"comment","attribute_name_ja":"コメント",'
+            f'[{{"attribute_id":"{COMMENT_ATTRIBUTE_ID}","attribute_name_en":"remark","attribute_name_ja":"コメント",'
             '"keybind":{"alt":false,"code":"Digit1","ctrl":true,"shift":false},'
             '"read_only":true,"default_value":"確認済み"},'
-            '{"attribute_id":"f12a0b59-dfce-4241-bb87-4b2c0259fc6f","default_value":true}]'
+            f'{{"attribute_id":"{UNCLEAR_ATTRIBUTE_ID}","default_value":true}}]'
         )
 
         assert actual == [
             AttributeUpdateInput(
-                attribute_name_en="comment",
+                attribute_id=COMMENT_ATTRIBUTE_ID,
+                attribute_name_en="remark",
                 attribute_name_ja="コメント",
                 keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
                 read_only=True,
@@ -188,7 +192,7 @@ class TestReadAttributes:
                 has_default_value=True,
             ),
             AttributeUpdateInput(
-                attribute_id="f12a0b59-dfce-4241-bb87-4b2c0259fc6f",
+                attribute_id=UNCLEAR_ATTRIBUTE_ID,
                 default_value=True,
                 has_default_value=True,
             ),
@@ -207,13 +211,14 @@ class TestReadAttributes:
         df = pandas.DataFrame(
             [
                 {
-                    "attribute_name_en": "comment",
+                    "attribute_id": COMMENT_ATTRIBUTE_ID,
+                    "attribute_name_en": "remark",
                     "attribute_name_ja": "コメント",
                     "keybind": '{"alt": false, "code": "Digit1", "ctrl": true, "shift": false}',
                     "read_only": "true",
                     "default_value": "確認済み",
                 },
-                {"attribute_id": "f12a0b59-dfce-4241-bb87-4b2c0259fc6f", "default_value": "true"},
+                {"attribute_id": UNCLEAR_ATTRIBUTE_ID, "default_value": "true"},
             ]
         )
         df.to_csv(csv_path, index=False)
@@ -222,7 +227,8 @@ class TestReadAttributes:
 
         assert actual == [
             AttributeUpdateInput(
-                attribute_name_en="comment",
+                attribute_id=COMMENT_ATTRIBUTE_ID,
+                attribute_name_en="remark",
                 attribute_name_ja="コメント",
                 keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
                 read_only=True,
@@ -230,7 +236,7 @@ class TestReadAttributes:
                 has_default_value=True,
             ),
             AttributeUpdateInput(
-                attribute_id="f12a0b59-dfce-4241-bb87-4b2c0259fc6f",
+                attribute_id=UNCLEAR_ATTRIBUTE_ID,
                 default_value="true",
                 has_default_value=True,
             ),

--- a/tests/annotation_specs/test_update_attributes.py
+++ b/tests/annotation_specs/test_update_attributes.py
@@ -69,6 +69,8 @@ class TestBuildRequestBodyForUpdateAttributes:
         unclear_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == UNCLEAR_ATTRIBUTE_ID)
         assert unclear_attribute["default"] is True
         assert actual["comment"].startswith("以下の属性情報を更新しました。")
+        assert f"attribute_id='{COMMENT_ATTRIBUTE_ID}', attribute_name_en='comment' -> 'remark'" in actual["comment"]
+        assert f"attribute_id='{UNCLEAR_ATTRIBUTE_ID}', attribute_name_en='unclear'" in actual["comment"]
         assert actual["last_updated_datetime"] == "2026-04-24T00:00:00+09:00"
 
         car_label = next(label for label in actual["labels"] if label["label_id"] == "car_label_id")

--- a/tests/annotation_specs/test_update_attributes.py
+++ b/tests/annotation_specs/test_update_attributes.py
@@ -137,6 +137,41 @@ class TestBuildRequestBodyForUpdateAttributes:
                 comment=None,
             )
 
+    def test_build_request_body_for_update_attributes__同じラベル内で属性名英語が重複していたらエラー(self, annotation_specs: dict) -> None:
+        resolved_inputs = resolve_attribute_update_inputs(
+            annotation_specs,
+            attribute_update_inputs=[AttributeUpdateInput(attribute_id=UNCLEAR_ATTRIBUTE_ID, attribute_name_en="comment")],
+        )
+
+        with pytest.raises(ValueError):
+            build_request_body_for_update_attributes(
+                annotation_specs,
+                resolved_attribute_update_inputs=resolved_inputs,
+                comment=None,
+            )
+
+    def test_build_request_body_for_update_attributes__異なるラベルなら属性名英語が重複していてもよい(self, annotation_specs: dict) -> None:
+        bike_label = next(label for label in annotation_specs["labels"] if label["label_id"] == "40f7796b-3722-4eed-9c0c-04a27f9165d2")
+        bike_label["additional_data_definitions"] = [UNCLEAR_ATTRIBUTE_ID]
+        car_label = next(label for label in annotation_specs["labels"] if label["label_id"] == "car_label_id")
+        car_label["additional_data_definitions"] = [COMMENT_ATTRIBUTE_ID]
+        resolved_inputs = resolve_attribute_update_inputs(
+            annotation_specs,
+            attribute_update_inputs=[AttributeUpdateInput(attribute_id=UNCLEAR_ATTRIBUTE_ID, attribute_name_en="comment")],
+        )
+
+        actual = build_request_body_for_update_attributes(
+            annotation_specs,
+            resolved_attribute_update_inputs=resolved_inputs,
+            comment=None,
+        )
+
+        unclear_attribute = next(additional for additional in actual["additionals"] if additional["additional_data_definition_id"] == UNCLEAR_ATTRIBUTE_ID)
+        assert unclear_attribute["name"]["messages"] == [
+            {"lang": "ja-JP", "message": "unclear"},
+            {"lang": "en-US", "message": "comment"},
+        ]
+
 
 class TestResolveAttributeUpdateInputs:
     def test_resolve_attribute_update_inputs__attribute_not_found(self, annotation_specs: dict) -> None:

--- a/tests/annotation_specs/test_update_choices.py
+++ b/tests/annotation_specs/test_update_choices.py
@@ -39,7 +39,8 @@ class TestBuildRequestBodyForUpdateChoices:
             attribute_name_en="type",
             choice_update_inputs=[
                 ChoiceUpdateInput(
-                    choice_name_en="large",
+                    choice_id=LARGE_CHOICE_ID,
+                    choice_name_en="big",
                     choice_name_ja="大",
                     keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
                     has_keybind=True,
@@ -54,7 +55,7 @@ class TestBuildRequestBodyForUpdateChoices:
         large_choice = next(choice for choice in type_attribute["choices"] if choice["choice_id"] == LARGE_CHOICE_ID)
         assert large_choice["name"]["messages"] == [
             {"lang": "ja-JP", "message": "大"},
-            {"lang": "en-US", "message": "large"},
+            {"lang": "en-US", "message": "big"},
         ]
         assert large_choice["keybind"] == [{"alt": False, "code": "Digit1", "ctrl": True, "shift": False}]
 
@@ -69,7 +70,7 @@ class TestBuildRequestBodyForUpdateChoices:
             annotation_specs,
             attribute_id=None,
             attribute_name_en="type",
-            choice_update_inputs=[ChoiceUpdateInput(choice_name_en="large", choice_name_ja="大")],
+            choice_update_inputs=[ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, choice_name_ja="大")],
         )
 
         actual = build_request_body_for_update_choices(annotation_specs, resolved_choice_update_inputs=resolved_inputs, comment="custom")
@@ -90,7 +91,7 @@ class TestBuildRequestBodyForUpdateChoices:
             annotation_specs,
             attribute_id=None,
             attribute_name_en="type",
-            choice_update_inputs=[ChoiceUpdateInput(choice_name_en="large", choice_name_ja="大")],
+            choice_update_inputs=[ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, choice_name_en="big", choice_name_ja="大")],
         )
 
         actual = build_request_body_for_update_choices(annotation_specs, resolved_choice_update_inputs=resolved_inputs, comment=None)
@@ -99,7 +100,7 @@ class TestBuildRequestBodyForUpdateChoices:
         large_choice = next(choice for choice in type_attribute["choices"] if choice["choice_id"] == LARGE_CHOICE_ID)
         assert large_choice["name"] == {
             "messages": [
-                {"lang": "en-US", "message": "large"},
+                {"lang": "en-US", "message": "big"},
                 {"lang": "ja-JP", "message": "大"},
                 {"lang": "fr-FR", "message": "grand"},
             ],
@@ -112,7 +113,7 @@ class TestBuildRequestBodyForUpdateChoices:
             annotation_specs,
             attribute_id=None,
             attribute_name_en="type",
-            choice_update_inputs=[ChoiceUpdateInput(choice_name_en="large", choice_name_ja="大")],
+            choice_update_inputs=[ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, choice_name_ja="大")],
         )
 
         build_request_body_for_update_choices(annotation_specs, resolved_choice_update_inputs=resolved_inputs, comment=None)
@@ -126,7 +127,7 @@ class TestResolveChoiceUpdateInputs:
             annotation_specs,
             attribute_id=TYPE_ATTRIBUTE_ID,
             attribute_name_en=None,
-            choice_update_inputs=[ChoiceUpdateInput(choice_name_en="large", choice_name_ja="大")],
+            choice_update_inputs=[ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, choice_name_ja="大")],
         )
 
         assert actual[0].target_attribute["additional_data_definition_id"] == TYPE_ATTRIBUTE_ID
@@ -138,7 +139,7 @@ class TestResolveChoiceUpdateInputs:
                 annotation_specs,
                 attribute_id="54fa5e97-6f88-49a4-aeb0-a91a15d11528",
                 attribute_name_en=None,
-                choice_update_inputs=[ChoiceUpdateInput(choice_name_en="large", choice_name_ja="大")],
+                choice_update_inputs=[ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, choice_name_ja="大")],
             )
 
     def test_resolve_choice_update_inputs__choice_not_found(self, annotation_specs: dict[str, Any]) -> None:
@@ -147,10 +148,10 @@ class TestResolveChoiceUpdateInputs:
                 annotation_specs,
                 attribute_id=None,
                 attribute_name_en="type",
-                choice_update_inputs=[ChoiceUpdateInput(choice_name_en="not-found", choice_name_ja="なし")],
+                choice_update_inputs=[ChoiceUpdateInput(choice_id="not-found", choice_name_ja="なし")],
             )
 
-    def test_resolve_choice_update_inputs__same_choice_by_different_keys(self, annotation_specs: dict[str, Any]) -> None:
+    def test_resolve_choice_update_inputs__same_choice(self, annotation_specs: dict[str, Any]) -> None:
         with pytest.raises(ValueError):
             resolve_choice_update_inputs(
                 annotation_specs,
@@ -158,7 +159,7 @@ class TestResolveChoiceUpdateInputs:
                 attribute_name_en="type",
                 choice_update_inputs=[
                     ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, choice_name_ja="大"),
-                    ChoiceUpdateInput(choice_name_en="large", keybind=None, has_keybind=True),
+                    ChoiceUpdateInput(choice_id=LARGE_CHOICE_ID, keybind=None, has_keybind=True),
                 ],
             )
 
@@ -181,12 +182,13 @@ class TestChoiceUpdateInputs:
 class TestReadChoices:
     def test_read_choices_json(self) -> None:
         actual = read_choices_json(
-            f'[{{"choice_name_en":"large","choice_name_ja":"大","keybind":{{"alt":false,"code":"Digit1","ctrl":true,"shift":false}}}},{{"choice_id":"{SMALL_CHOICE_ID}","keybind":null}}]'
+            f'[{{"choice_id":"{LARGE_CHOICE_ID}","choice_name_en":"big","choice_name_ja":"大","keybind":{{"alt":false,"code":"Digit1","ctrl":true,"shift":false}}}},{{"choice_id":"{SMALL_CHOICE_ID}","keybind":null}}]'
         )
 
         assert actual == [
             ChoiceUpdateInput(
-                choice_name_en="large",
+                choice_id=LARGE_CHOICE_ID,
+                choice_name_en="big",
                 choice_name_ja="大",
                 keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
                 has_keybind=True,
@@ -207,6 +209,7 @@ class TestReadChoices:
         df = pandas.DataFrame(
             [
                 {
+                    "choice_id": LARGE_CHOICE_ID,
                     "choice_name_en": "large",
                     "choice_name_ja": "大",
                     "keybind": '{"alt": false, "code": "Digit1", "ctrl": true, "shift": false}',
@@ -220,6 +223,7 @@ class TestReadChoices:
 
         assert actual == [
             ChoiceUpdateInput(
+                choice_id=LARGE_CHOICE_ID,
                 choice_name_en="large",
                 choice_name_ja="大",
                 keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
@@ -230,7 +234,7 @@ class TestReadChoices:
 
     def test_read_choices_csv__invalid_keybind(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "choices.csv"
-        df = pandas.DataFrame([{"choice_name_en": "large", "keybind": "invalid"}])
+        df = pandas.DataFrame([{"choice_id": LARGE_CHOICE_ID, "keybind": "invalid"}])
         df.to_csv(csv_path, index=False)
 
         with pytest.raises(ValueError):

--- a/tests/annotation_specs/test_update_labels.py
+++ b/tests/annotation_specs/test_update_labels.py
@@ -16,6 +16,8 @@ from annofabcli.annotation_specs.update_labels import (
 )
 
 data_dir = Path("./tests/data/annotation_specs")
+CAR_LABEL_ID = "car_label_id"
+BIKE_LABEL_ID = "40f7796b-3722-4eed-9c0c-04a27f9165d2"
 
 
 @pytest.fixture
@@ -38,7 +40,8 @@ class TestBuildRequestBodyForUpdateLabels:
             annotation_specs,
             label_update_inputs=[
                 LabelUpdateInput(
-                    label_name_en="car",
+                    label_id=CAR_LABEL_ID,
+                    label_name_en="vehicle",
                     label_name_ja="車",
                     color="#123456",
                     keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
@@ -52,7 +55,7 @@ class TestBuildRequestBodyForUpdateLabels:
                         }
                     },
                 ),
-                LabelUpdateInput(label_id="40f7796b-3722-4eed-9c0c-04a27f9165d2", field_values_operation="replace"),
+                LabelUpdateInput(label_id=BIKE_LABEL_ID, field_values_operation="replace"),
             ],
         )
 
@@ -62,10 +65,10 @@ class TestBuildRequestBodyForUpdateLabels:
             comment=None,
         )
 
-        car_label = next(label for label in actual["labels"] if label["label_id"] == "car_label_id")
+        car_label = next(label for label in actual["labels"] if label["label_id"] == CAR_LABEL_ID)
         assert car_label["label_name"]["messages"] == [
             {"lang": "ja-JP", "message": "車"},
-            {"lang": "en-US", "message": "car"},
+            {"lang": "en-US", "message": "vehicle"},
         ]
         assert car_label["annotation_type"] == "bounding_box"
         assert car_label["color"] == {"red": 18, "green": 52, "blue": 86}
@@ -84,7 +87,7 @@ class TestBuildRequestBodyForUpdateLabels:
             },
         }
 
-        bike_label = next(label for label in actual["labels"] if label["label_id"] == "40f7796b-3722-4eed-9c0c-04a27f9165d2")
+        bike_label = next(label for label in actual["labels"] if label["label_id"] == BIKE_LABEL_ID)
         assert bike_label["field_values"] == {}
         assert actual["comment"].startswith("以下のラベル情報を更新しました。")
         assert actual["last_updated_datetime"] == "2026-04-24T00:00:00+09:00"
@@ -94,7 +97,7 @@ class TestBuildRequestBodyForUpdateLabels:
             annotation_specs,
             label_update_inputs=[
                 LabelUpdateInput(
-                    label_name_en="car",
+                    label_id=CAR_LABEL_ID,
                     field_values={"display_line_direction": {"_type": "DisplayLineDirection", "value": True}},
                     field_values_operation="replace",
                 )
@@ -107,7 +110,7 @@ class TestBuildRequestBodyForUpdateLabels:
             comment="custom",
         )
 
-        car_label = next(label for label in actual["labels"] if label["label_id"] == "car_label_id")
+        car_label = next(label for label in actual["labels"] if label["label_id"] == CAR_LABEL_ID)
         assert car_label["field_values"] == {"display_line_direction": {"_type": "DisplayLineDirection", "value": True}}
         assert actual["comment"] == "custom"
 
@@ -122,7 +125,7 @@ class TestBuildRequestBodyForUpdateLabels:
         }
         resolved_inputs = resolve_label_update_inputs(
             annotation_specs,
-            label_update_inputs=[LabelUpdateInput(label_name_en="car", label_name_ja="車")],
+            label_update_inputs=[LabelUpdateInput(label_id=CAR_LABEL_ID, label_name_en="vehicle", label_name_ja="車")],
         )
 
         actual = build_request_body_for_update_labels(
@@ -131,10 +134,10 @@ class TestBuildRequestBodyForUpdateLabels:
             comment=None,
         )
 
-        car_label = next(label for label in actual["labels"] if label["label_id"] == "car_label_id")
+        car_label = next(label for label in actual["labels"] if label["label_id"] == CAR_LABEL_ID)
         assert car_label["label_name"] == {
             "messages": [
-                {"lang": "en-US", "message": "car"},
+                {"lang": "en-US", "message": "vehicle"},
                 {"lang": "ja-JP", "message": "車"},
                 {"lang": "fr-FR", "message": "voiture"},
             ],
@@ -144,7 +147,7 @@ class TestBuildRequestBodyForUpdateLabels:
     def test_build_request_body_for_update_labels__invalid_color(self, annotation_specs: dict) -> None:
         resolved_inputs = resolve_label_update_inputs(
             annotation_specs,
-            label_update_inputs=[LabelUpdateInput(label_name_en="car", color="red")],
+            label_update_inputs=[LabelUpdateInput(label_id=CAR_LABEL_ID, color="red")],
         )
 
         with pytest.raises(ValueError):
@@ -160,16 +163,16 @@ class TestResolveLabelUpdateInputs:
         with pytest.raises(ValueError):
             resolve_label_update_inputs(
                 annotation_specs,
-                label_update_inputs=[LabelUpdateInput(label_name_en="not-found", label_name_ja="dummy")],
+                label_update_inputs=[LabelUpdateInput(label_id="not-found", label_name_ja="dummy")],
             )
 
-    def test_resolve_label_update_inputs__same_label_by_different_keys(self, annotation_specs: dict) -> None:
+    def test_resolve_label_update_inputs__same_label(self, annotation_specs: dict) -> None:
         with pytest.raises(ValueError):
             resolve_label_update_inputs(
                 annotation_specs,
                 label_update_inputs=[
-                    LabelUpdateInput(label_id="car_label_id", label_name_ja="車"),
-                    LabelUpdateInput(label_name_en="car", color="#123456"),
+                    LabelUpdateInput(label_id=CAR_LABEL_ID, label_name_ja="車"),
+                    LabelUpdateInput(label_id=CAR_LABEL_ID, color="#123456"),
                 ],
             )
 
@@ -192,7 +195,7 @@ class TestLabelUpdateInputs:
 class TestReadLabels:
     def test_read_labels_json(self) -> None:
         actual = read_labels_json(
-            '[{"label_name_en":"car","label_name_ja":"車","color":"#123456",'
+            f'[{{"label_id":"{CAR_LABEL_ID}","label_name_en":"vehicle","label_name_ja":"車","color":"#123456",'
             '"keybind":{"alt":false,"code":"Digit1","ctrl":true,"shift":false},'
             '"field_values":{"margin_of_error_tolerance":{"max_pixel":5,"_type":"MarginOfErrorTolerance"}}},'
             '{"label_id":"bike","field_values_operation":"replace"}]'
@@ -200,7 +203,8 @@ class TestReadLabels:
 
         assert actual == [
             LabelUpdateInput(
-                label_name_en="car",
+                label_id=CAR_LABEL_ID,
+                label_name_en="vehicle",
                 label_name_ja="車",
                 color="#123456",
                 keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},
@@ -219,14 +223,15 @@ class TestReadLabels:
 
     def test_read_labels_json__field_values_operation_merge_requires_field_values(self) -> None:
         with pytest.raises(ValueError):
-            read_labels_json('[{"label_name_en":"car","field_values_operation":"merge"}]')
+            read_labels_json(f'[{{"label_id":"{CAR_LABEL_ID}","field_values_operation":"merge"}}]')
 
     def test_read_labels_csv(self, tmp_path: Path) -> None:
         csv_path = tmp_path / "labels.csv"
         df = pandas.DataFrame(
             [
                 {
-                    "label_name_en": "car",
+                    "label_id": CAR_LABEL_ID,
+                    "label_name_en": "vehicle",
                     "label_name_ja": "車",
                     "color": "#123456",
                     "keybind": '{"alt": false, "code": "Digit1", "ctrl": true, "shift": false}',
@@ -241,7 +246,8 @@ class TestReadLabels:
 
         assert actual == [
             LabelUpdateInput(
-                label_name_en="car",
+                label_id=CAR_LABEL_ID,
+                label_name_en="vehicle",
                 label_name_ja="車",
                 color="#123456",
                 keybind={"alt": False, "code": "Digit1", "ctrl": True, "shift": False},


### PR DESCRIPTION
英語名も更新したいケースがあるので、英語名をキーからはずし更新対象にしました。
更新する際は、常にIDが必要になりました。
