### PR TITLE
`annotation import`: `BoundingBox`など2次元座標の値が小数の場合は、`round`で`int`に変換するようにしました。

### DIFF
--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -610,6 +610,13 @@ class ImportAnnotationMain(CommandLineWithConfirm):
             )
             return False
 
+        if not self.change_operator_to_me and not can_put_annotation(task, self.service.api.account_id):
+            logger.debug(
+                f"{logger_prefix}タスクは、過去に誰かに割り当てられたタスクで、現在の担当者が自分自身でないため、アノテーションのインポートをスキップします。"
+                f"担当者を自分自身に変更してアノテーションを登録する場合は `--change_operator_to_me` を指定してください。"
+            )
+            return False
+
         if not self.confirm_processing(f"task_id='{task_id}'のタスク（phase={task['phase']}, status={task['status']}）にアノテーションをインポートしますか？"):
             return False
 
@@ -617,25 +624,16 @@ class ImportAnnotationMain(CommandLineWithConfirm):
 
         old_account_id: str | None = None
         changed_operator = False
-        if self.change_operator_to_me:
-            if not can_put_annotation(task, self.service.api.account_id):
-                logger.debug(f"{logger_prefix}担当者を自分自身に変更します。")
-                old_account_id = task["account_id"]
-                task = self.service.wrapper.change_task_operator(
-                    self.project_id,
-                    task_id,
-                    operator_account_id=self.service.api.account_id,
-                    last_updated_datetime=task["updated_datetime"],
-                )
-                changed_operator = True
-
-        else:  # noqa: PLR5501
-            if not can_put_annotation(task, self.service.api.account_id):
-                logger.debug(
-                    f"タスク'{task_id}'は、過去に誰かに割り当てられたタスクで、現在の担当者が自分自身でないため、アノテーションのインポートをスキップします。"
-                    f"担当者を自分自身に変更してアノテーションを登録する場合は `--change_operator_to_me` を指定してください。"
-                )
-                return False
+        if self.change_operator_to_me and not can_put_annotation(task, self.service.api.account_id):
+            logger.debug(f"{logger_prefix}担当者を自分自身に変更します。")
+            old_account_id = task["account_id"]
+            task = self.service.wrapper.change_task_operator(
+                self.project_id,
+                task_id,
+                operator_account_id=self.service.api.account_id,
+                last_updated_datetime=task["updated_datetime"],
+            )
+            changed_operator = True
 
         success_input_data_count, success_annotation_count = self.put_annotation_for_task(task_parser)
         logger.info(

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -136,6 +136,52 @@ def get_3dpc_segment_data_uri(annotation_data: dict[str, Any]) -> str:
     return str(path.relative_to(path.parts[0]))
 
 
+def _round_coordinate_value(value: object) -> object:
+    if isinstance(value, float):
+        return round(value)
+    return value
+
+
+def _round_point_coordinates(point: dict[str, Any]) -> None:
+    for coordinate_key in ["x", "y"]:
+        if coordinate_key in point:
+            point[coordinate_key] = _round_coordinate_value(point[coordinate_key])
+
+
+def round_2d_annotation_coordinates(annotation_data: dict[str, Any]) -> dict[str, Any]:
+    """
+    2D画像アノテーションの座標値を整数に丸めます。
+
+    Args:
+        annotation_data: Simple Annotationのdata。
+
+    Returns:
+        座標値を丸めたSimple Annotationのdata。引数のdictは変更しません。
+    """
+    result = copy.deepcopy(annotation_data)
+    annotation_type = result.get("_type")
+
+    if annotation_type == "BoundingBox":
+        for point_key in ["left_top", "right_bottom"]:
+            point = result.get(point_key)
+            if isinstance(point, dict):
+                _round_point_coordinates(point)
+
+    elif annotation_type == "Points":
+        points = result.get("points")
+        if isinstance(points, list):
+            for point in points:
+                if isinstance(point, dict):
+                    _round_point_coordinates(point)
+
+    elif annotation_type == "SinglePoint":
+        point = result.get("point")
+        if isinstance(point, dict):
+            _round_point_coordinates(point)
+
+    return result
+
+
 class AnnotationConverter:
     """
     Simpleアノテーションを、`put_annotation` API(v2)のリクエストボディに変換するクラスです。
@@ -347,7 +393,7 @@ class AnnotationConverter:
                 result["body"] = {"_type": "Outer", "path": s3_path}
 
         else:
-            result["body"] = {"_type": "Inner", "data": detail.data}
+            result["body"] = {"_type": "Inner", "data": round_2d_annotation_coordinates(detail.data)}
         return result
 
     def convert_annotation_details(

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -144,8 +144,7 @@ def _round_coordinate_value(value: object) -> object:
 
 def _round_point_coordinates(point: dict[str, Any]) -> None:
     for coordinate_key in ["x", "y"]:
-        if coordinate_key in point:
-            point[coordinate_key] = _round_coordinate_value(point[coordinate_key])
+        point[coordinate_key] = _round_coordinate_value(point[coordinate_key])
 
 
 def round_2d_annotation_coordinates(annotation_data: dict[str, Any]) -> dict[str, Any]:
@@ -158,7 +157,7 @@ def round_2d_annotation_coordinates(annotation_data: dict[str, Any]) -> dict[str
     Returns:
         座標値を丸めたSimple Annotationのdata。引数のdictは変更しません。
     """
-    annotation_type = annotation_data.get("_type")
+    annotation_type = annotation_data["_type"]
     if annotation_type not in {"BoundingBox", "Points", "SinglePoint"}:
         return annotation_data
 
@@ -166,21 +165,14 @@ def round_2d_annotation_coordinates(annotation_data: dict[str, Any]) -> dict[str
 
     if annotation_type == "BoundingBox":
         for point_key in ["left_top", "right_bottom"]:
-            point = result.get(point_key)
-            if isinstance(point, dict):
-                _round_point_coordinates(point)
+            _round_point_coordinates(result[point_key])
 
     elif annotation_type == "Points":
-        points = result.get("points")
-        if isinstance(points, list):
-            for point in points:
-                if isinstance(point, dict):
-                    _round_point_coordinates(point)
+        for point in result["points"]:
+            _round_point_coordinates(point)
 
     elif annotation_type == "SinglePoint":
-        point = result.get("point")
-        if isinstance(point, dict):
-            _round_point_coordinates(point)
+        _round_point_coordinates(result["point"])
 
     return result
 

--- a/annofabcli/annotation/import_annotation.py
+++ b/annofabcli/annotation/import_annotation.py
@@ -158,8 +158,11 @@ def round_2d_annotation_coordinates(annotation_data: dict[str, Any]) -> dict[str
     Returns:
         座標値を丸めたSimple Annotationのdata。引数のdictは変更しません。
     """
+    annotation_type = annotation_data.get("_type")
+    if annotation_type not in {"BoundingBox", "Points", "SinglePoint"}:
+        return annotation_data
+
     result = copy.deepcopy(annotation_data)
-    annotation_type = result.get("_type")
 
     if annotation_type == "BoundingBox":
         for point_key in ["left_top", "right_bottom"]:

--- a/docs/command_reference/annotation/import.rst
+++ b/docs/command_reference/annotation/import.rst
@@ -34,6 +34,10 @@ Examples
 
 .. note::
 
+    ``BoundingBox`` 、 ``Points`` 、 ``SinglePoint`` の2D座標値（ ``x`` , ``y`` ）に小数が指定された場合は、 ``round`` で整数に丸めてインポートします。
+
+.. note::
+
     `annotation_specs list_annotation_import_info <../annotation_specs/list_annotation_import_info.html>`_ コマンドの出力結果をCoding Agentに渡すと、インポート先プロジェクトで利用できるラベル名、属性名、選択肢名を踏まえて、アノテーションを効率よく変換するスクリプトを書きやすくなります。
 
 .. code-block::

--- a/docs/command_reference/annotation/import.rst
+++ b/docs/command_reference/annotation/import.rst
@@ -34,7 +34,7 @@ Examples
 
 .. note::
 
-    ``annotation_specs list_annotation_import_info`` コマンドの出力結果をCoding Agentに渡すと、インポート先プロジェクトで利用できるラベル名、属性名、選択肢名を踏まえて、アノテーションを効率よく変換するスクリプトを書きやすくなります。
+    `annotation_specs list_annotation_import_info <../annotation_specs/list_annotation_import_info.html>`_ コマンドの出力結果をCoding Agentに渡すと、インポート先プロジェクトで利用できるラベル名、属性名、選択肢名を踏まえて、アノテーションを効率よく変換するスクリプトを書きやすくなります。
 
 .. code-block::
     :caption: {input_data_id}.json

--- a/docs/command_reference/annotation/import.rst
+++ b/docs/command_reference/annotation/import.rst
@@ -32,6 +32,10 @@ Examples
 
 ``{input_data_id}.json`` のサンプルは以下の通りです。詳細は https://annofab.readme.io/docs/annotation-format を参照してください。
 
+.. note::
+
+    ``annotation_specs list_annotation_import_info`` コマンドの出力結果をCoding Agentに渡すと、インポート先プロジェクトで利用できるラベル名、属性名、選択肢名を踏まえて、アノテーションを効率よく変換するスクリプトを書きやすくなります。
+
 .. code-block::
     :caption: {input_data_id}.json
 

--- a/tests/annotation/test_import_annotation.py
+++ b/tests/annotation/test_import_annotation.py
@@ -259,6 +259,34 @@ class Test__AnnotationConverter:
         assert actual["editor_props"] == expected["editor_props"]
         assert actual["body"] == expected["body"]
 
+    def test__convert_annotation_detail__2d座標値がfloatならroundでintに変換する(self):
+        converter = AnnotationConverter(project, annotation_specs, is_strict=False, service=service)
+
+        bbox_detail = ImportedSimpleAnnotationDetail(
+            label="car",
+            data={"left_top": {"x": 10.4, "y": 7.5}, "right_bottom": {"x": 36.6, "y": 36.0}, "_type": "BoundingBox"},
+            attributes={},
+        )
+        actual_bbox = converter.convert_annotation_detail(SimpleAnnotationDirParser(Path("foo.json")), bbox_detail)
+        assert actual_bbox["body"]["data"] == {"left_top": {"x": 10, "y": 8}, "right_bottom": {"x": 37, "y": 36}, "_type": "BoundingBox"}
+        assert bbox_detail.data["left_top"]["x"] == 10.4
+
+        points_detail = ImportedSimpleAnnotationDetail(
+            label="white_line",
+            data={"points": [{"x": 1.2, "y": 2.8}, {"x": 3.0, "y": 4.4}], "_type": "Points"},
+            attributes={},
+        )
+        actual_points = converter.convert_annotation_detail(SimpleAnnotationDirParser(Path("foo.json")), points_detail)
+        assert actual_points["body"]["data"] == {"points": [{"x": 1, "y": 3}, {"x": 3, "y": 4}], "_type": "Points"}
+
+        single_point_detail = ImportedSimpleAnnotationDetail(
+            label="car",
+            data={"point": {"x": 5.5, "y": 6.1}, "_type": "SinglePoint"},
+            attributes={},
+        )
+        actual_single_point = converter.convert_annotation_detail(SimpleAnnotationDirParser(Path("foo.json")), single_point_detail)
+        assert actual_single_point["body"]["data"] == {"point": {"x": 6, "y": 6}, "_type": "SinglePoint"}
+
     def test__convert_annotation_detail__default_editor_propsを設定する(self):
         converter = AnnotationConverter(
             project,

--- a/tests/annotation/test_import_annotation.py
+++ b/tests/annotation/test_import_annotation.py
@@ -1,27 +1,143 @@
 import json
 from pathlib import Path
+from typing import Any, cast
 
 import annofabapi
 import pytest
+from annofabapi.models import TaskStatus
 from annofabapi.parser import (
     SimpleAnnotationDirParser,
+    SimpleAnnotationParserByTask,
 )
 from pydantic import ValidationError
 
+import annofabcli.annotation.import_annotation
 from annofabcli.annotation.editor_props import validate_editor_props_for_cli
-from annofabcli.annotation.import_annotation import AnnotationConverter, ImportedSimpleAnnotation, ImportedSimpleAnnotationDetail
+from annofabcli.annotation.import_annotation import AnnotationConverter, ImportAnnotationMain, ImportedSimpleAnnotation, ImportedSimpleAnnotationDetail
 
 service = annofabapi.build()
 
 annotation_specs = json.loads(Path("tests/data/annotation/import_annotation/annotation_specs.json").read_text(encoding="utf-8"))
 
-project = {
+project: dict[str, Any] = {
     "project_id": "9804e9a1-9485-48cf-91a6-e71e810771a4",
     "input_data_type": "image",
     "configuration": {
         "plugin_id": None,
     },
 }
+
+
+class _FakeApi:
+    account_id = "account_id"
+
+
+class _FakeWrapper:
+    def __init__(self, task: dict[str, Any]) -> None:
+        self.task = task
+
+    def get_task_or_none(self, _project_id: str, _task_id: str) -> dict[str, Any]:
+        return self.task
+
+
+class _FakeService:
+    def __init__(self, task: dict[str, Any]) -> None:
+        self.api = _FakeApi()
+        self.wrapper = _FakeWrapper(task)
+
+
+class _FakeTaskParser:
+    task_id = "task_id"
+
+
+class _TestImportAnnotationMain(ImportAnnotationMain):
+    def __init__(
+        self,
+        service: annofabapi.Resource,
+        *,
+        project_id: str,
+        all_yes: bool,
+        change_operator_to_me: bool,
+        is_merge: bool,
+        is_overwrite: bool,
+        include_complete_task: bool,
+        include_break_task: bool,
+        include_on_hold_task: bool,
+        converter: AnnotationConverter,
+    ) -> None:
+        super().__init__(
+            service,
+            project_id=project_id,
+            all_yes=all_yes,
+            change_operator_to_me=change_operator_to_me,
+            is_merge=is_merge,
+            is_overwrite=is_overwrite,
+            include_complete_task=include_complete_task,
+            include_break_task=include_break_task,
+            include_on_hold_task=include_on_hold_task,
+            converter=converter,
+        )
+        self.confirm_processing_called = False
+        self.put_annotation_for_task_called = False
+
+    def confirm_processing(self, confirm_message: str) -> bool:
+        self.confirm_processing_called = True
+        return super().confirm_processing(confirm_message)
+
+    def put_annotation_for_task(self, _task_parser: SimpleAnnotationParserByTask) -> tuple[int, int]:
+        self.put_annotation_for_task_called = True
+        return 1, 1
+
+
+def _create_import_annotation_main(*, task: dict[str, Any], change_operator_to_me: bool = False) -> _TestImportAnnotationMain:
+    return _TestImportAnnotationMain(
+        cast(annofabapi.Resource, _FakeService(task)),
+        project_id=project["project_id"],
+        all_yes=True,
+        change_operator_to_me=change_operator_to_me,
+        is_merge=False,
+        is_overwrite=True,
+        include_complete_task=False,
+        include_break_task=False,
+        include_on_hold_task=False,
+        converter=cast(AnnotationConverter, None),
+    )
+
+
+class Test__ImportAnnotationMain:
+    def test__execute_task__担当者を変更しないと登録できない場合は問い合わせ前にスキップする(self, monkeypatch):
+        monkeypatch.setattr(annofabcli.annotation.import_annotation, "can_put_annotation", lambda *_args, **_kwargs: False)
+        task = {
+            "task_id": "task_id",
+            "phase": "annotation",
+            "status": TaskStatus.NOT_STARTED.value,
+            "account_id": "other_account_id",
+            "updated_datetime": "2026-07-30T00:00:00.000+09:00",
+        }
+        obj = _create_import_annotation_main(task=task, change_operator_to_me=False)
+
+        actual = obj.execute_task(cast(SimpleAnnotationParserByTask, _FakeTaskParser()))
+
+        assert not actual
+        assert not obj.confirm_processing_called
+        assert not obj.put_annotation_for_task_called
+
+    def test__execute_task__担当者を変更する場合は問い合わせ後にインポートする(self, monkeypatch):
+        monkeypatch.setattr(annofabcli.annotation.import_annotation, "can_put_annotation", lambda *_args, **_kwargs: True)
+        task = {
+            "task_id": "task_id",
+            "phase": "annotation",
+            "status": TaskStatus.NOT_STARTED.value,
+            "account_id": "account_id",
+            "updated_datetime": "2026-07-30T00:00:00.000+09:00",
+        }
+        obj = _create_import_annotation_main(task=task, change_operator_to_me=False)
+
+        actual = obj.execute_task(cast(SimpleAnnotationParserByTask, _FakeTaskParser()))
+
+        assert actual
+        assert obj.confirm_processing_called
+        assert obj.put_annotation_for_task_called
 
 
 class Test__AnnotationConverter:

--- a/tests/annotation/test_import_annotation.py
+++ b/tests/annotation/test_import_annotation.py
@@ -122,7 +122,7 @@ class Test__ImportAnnotationMain:
         assert not obj.confirm_processing_called
         assert not obj.put_annotation_for_task_called
 
-    def test__execute_task__担当者を変更する場合は問い合わせ後にインポートする(self, monkeypatch):
+    def test__execute_task__担当者を変更しなくても登録できる場合は問い合わせ後にインポートする(self, monkeypatch):
         monkeypatch.setattr(annofabcli.annotation.import_annotation, "can_put_annotation", lambda *_args, **_kwargs: True)
         task = {
             "task_id": "task_id",


### PR DESCRIPTION
# 背景
* `putAnnotation` APIでは、`BoundingBox`などの座標値は整数しか受け付けていません。便利になるように、小数の場合は`round`で整数に変換するようにしました。

# その他の変更
* 担当者を変えてから問い合わせるのでなく、問い合わせてから担当者を変更するようにしました。
