### PR TITLE
`annotation_specs list_annotation_import_info`: 出力する情報に日本語名も含める

### DIFF
--- a/annofabcli/annotation_specs/list_annotation_import_info.py
+++ b/annofabcli/annotation_specs/list_annotation_import_info.py
@@ -7,7 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from annofabapi.util.annotation_specs import get_attribute_name_en, get_choice_name_en, get_label_name_en
+from annofabapi.models import Lang
+from annofabapi.util.annotation_specs import get_attribute_name_en, get_choice_name_en, get_label_name_en, get_message_with_lang
 from pydantic import BaseModel, ConfigDict
 
 import annofabcli.common.cli
@@ -31,6 +32,8 @@ class AnnotationImportChoice(BaseModel):
 
     choice_name_en: str
     """選択肢名（英語）。"""
+    choice_name_ja: str
+    """選択肢名（日本語）。"""
 
 
 class AnnotationImportAttribute(BaseModel):
@@ -40,6 +43,8 @@ class AnnotationImportAttribute(BaseModel):
 
     attribute_name_en: str
     """属性名（英語）。"""
+    attribute_name_ja: str
+    """属性名（日本語）。"""
     attribute_type: str
     """属性の種類。"""
     choices: list[AnnotationImportChoice]
@@ -53,6 +58,8 @@ class AnnotationImportLabel(BaseModel):
 
     label_name_en: str
     """ラベル名（英語）。"""
+    label_name_ja: str
+    """ラベル名（日本語）。"""
     annotation_type: str
     """ラベルの種類。"""
     attributes: list[AnnotationImportAttribute]
@@ -75,6 +82,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
         return [
             AnnotationImportChoice(
                 choice_name_en=get_choice_name_en(choice),
+                choice_name_ja=get_message_with_lang(choice["name"], Lang.JA_JP),
             )
             for choice in attribute["choices"]
         ]
@@ -86,6 +94,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
             result.append(
                 AnnotationImportAttribute(
                     attribute_name_en=get_attribute_name_en(attribute),
+                    attribute_name_ja=get_message_with_lang(attribute["name"], Lang.JA_JP),
                     attribute_type=attribute["type"],
                     choices=create_choice_list(attribute),
                 )
@@ -95,6 +104,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
     return [
         AnnotationImportLabel(
             label_name_en=get_label_name_en(label),
+            label_name_ja=get_message_with_lang(label["label_name"], Lang.JA_JP),
             annotation_type=label["annotation_type"],
             attributes=create_attribute_list(label),
         )

--- a/annofabcli/annotation_specs/list_annotation_import_info.py
+++ b/annofabcli/annotation_specs/list_annotation_import_info.py
@@ -5,10 +5,10 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from annofabapi.models import Lang
-from annofabapi.util.annotation_specs import get_attribute_name_en, get_choice_name_en, get_label_name_en, get_message_with_lang
+from annofabapi.util.annotation_specs import InternationalizationMessage, get_attribute_name_en, get_choice_name_en, get_label_name_en, get_message_with_lang
 from pydantic import BaseModel, ConfigDict
 
 import annofabcli.common.cli
@@ -66,6 +66,12 @@ class AnnotationImportLabel(BaseModel):
     """ラベルに指定できる属性情報。"""
 
 
+def get_japanese_message(message: InternationalizationMessage) -> str:
+    result = get_message_with_lang(message, Lang.JA_JP)
+    assert result is not None
+    return result
+
+
 def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> list[AnnotationImportLabel]:
     """アノテーション仕様からannotation import用の情報一覧を生成します。
 
@@ -82,7 +88,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
         return [
             AnnotationImportChoice(
                 choice_name_en=get_choice_name_en(choice),
-                choice_name_ja=get_message_with_lang(choice["name"], Lang.JA_JP),
+                choice_name_ja=get_japanese_message(cast(InternationalizationMessage, choice["name"])),
             )
             for choice in attribute["choices"]
         ]
@@ -94,7 +100,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
             result.append(
                 AnnotationImportAttribute(
                     attribute_name_en=get_attribute_name_en(attribute),
-                    attribute_name_ja=get_message_with_lang(attribute["name"], Lang.JA_JP),
+                    attribute_name_ja=get_japanese_message(cast(InternationalizationMessage, attribute["name"])),
                     attribute_type=attribute["type"],
                     choices=create_choice_list(attribute),
                 )
@@ -104,7 +110,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
     return [
         AnnotationImportLabel(
             label_name_en=get_label_name_en(label),
-            label_name_ja=get_message_with_lang(label["label_name"], Lang.JA_JP),
+            label_name_ja=get_japanese_message(cast(InternationalizationMessage, label["label_name"])),
             annotation_type=label["annotation_type"],
             attributes=create_attribute_list(label),
         )

--- a/docs/command_reference/annotation_specs/list_annotation_import_info.rst
+++ b/docs/command_reference/annotation_specs/list_annotation_import_info.rst
@@ -7,7 +7,8 @@ Description
 アノテーションをimportする際に参照すべき情報（ラベル、属性、選択肢）のみを出力します。
 
 ``annotation import`` のJSONに指定するラベル名、属性名、選択肢名を確認するためのコマンドです。
-日本語名、色情報、ID、キーバインドなど、 ``annotation import`` で直接参照しない情報は出力しません。
+日本語名は、プロンプトや変換処理を書く際の参考情報として出力します。
+色情報、ID、キーバインドなど、 ``annotation import`` で直接参照しない情報は出力しません。
 
 
 Examples
@@ -55,22 +56,27 @@ JSON出力
     [
         {
             "label_name_en": "car",
+            "label_name_ja": "車",
             "annotation_type": "bounding_box",
             "attributes": [
                 {
                     "attribute_name_en": "occluded",
+                    "attribute_name_ja": "遮蔽",
                     "attribute_type": "flag",
                     "choices": []
                 },
                 {
                     "attribute_name_en": "direction",
+                    "attribute_name_ja": "向き",
                     "attribute_type": "select",
                     "choices": [
                         {
-                            "choice_name_en": "front"
+                            "choice_name_en": "front",
+                            "choice_name_ja": "前"
                         },
                         {
-                            "choice_name_en": "side"
+                            "choice_name_en": "side",
+                            "choice_name_ja": "横"
                         }
                     ]
                 }
@@ -80,14 +86,17 @@ JSON出力
 
 
 * ``label_name_en`` : ラベル名（英語）。 ``annotation import`` の ``label`` に指定する値です。
+* ``label_name_ja`` : ラベル名（日本語）。プロンプトや変換処理を書く際の参考情報です。
 * ``annotation_type`` : アノテーションの種類。Web APIの `AnnotationType <https://annofab.com/docs/api/#tag/x-data-types/AnnotationType>`_ に対応しています。
 * ``attributes`` : ラベルに指定できる属性情報の配列です。
 
   * ``attribute_name_en`` : 属性名（英語）。 ``annotation import`` の ``attributes`` のキーに指定する値です。
+  * ``attribute_name_ja`` : 属性名（日本語）。プロンプトや変換処理を書く際の参考情報です。
   * ``attribute_type`` : 属性の種類。WebAPIの ``AdditionalDataDefinitionType`` に対応しています。
   * ``choices`` : 選択肢情報の配列です。属性の種類がラジオボタンまたはドロップダウン以外の場合は空配列です。
 
     * ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、 ``annotation import`` の ``attributes`` の値として指定する値です。
+    * ``choice_name_ja`` : 選択肢名（日本語）。プロンプトや変換処理を書く際の参考情報です。
 
 
 Usage Details

--- a/tests/annotation_specs/test_list_annotation_import_info.py
+++ b/tests/annotation_specs/test_list_annotation_import_info.py
@@ -15,12 +15,15 @@ def test_create_annotation_import_info_listはimportに必要な情報を出力�
     actual = create_annotation_import_info_list(annotation_specs)
 
     car_label = next(e for e in actual if e.label_name_en == "car")
+    assert car_label.label_name_ja == "car"
     assert car_label.annotation_type == "bounding_box"
     assert [e.attribute_name_en for e in car_label.attributes] == ["comment", "link", "type", "unclear"]
+    assert [e.attribute_name_ja for e in car_label.attributes] == ["comment", "link", "type", "unclear"]
 
     type_attribute = next(e for e in car_label.attributes if e.attribute_name_en == "type")
     assert type_attribute.attribute_type == "select"
     assert [e.choice_name_en for e in type_attribute.choices] == ["large", "medium", "small"]
+    assert [e.choice_name_ja for e in type_attribute.choices] == ["large", "medium", "small"]
 
 
 def test_create_annotation_import_info_listは属性がないラベルも出力する() -> None:
@@ -30,5 +33,6 @@ def test_create_annotation_import_info_listは属性がないラベルも出力�
     actual = create_annotation_import_info_list(annotation_specs)
 
     bike_label = next(e for e in actual if e.label_name_en == "bike")
+    assert bike_label.label_name_ja == "bike"
     assert bike_label.annotation_type == "bounding_box"
     assert bike_label.attributes == []


### PR DESCRIPTION

## 変更内容

`annotation_specs list_annotation_import_info` の出力に、日本語名を追加しました。

- ラベル情報に `label_name_ja` を追加
- 属性情報に `attribute_name_ja` を追加
- 選択肢情報に `choice_name_ja` を追加

## 背景

`annotation import` で指定する値は英語名ですが、Coding AgentやLLMに変換処理を依頼する際、プロンプト上では日本語名を参照するケースがあります。

日本語名を出力に含めることで、ラベル名・属性名・選択肢名の対応関係を把握しやすくし、アノテーション変換スクリプトやプロンプトを作成しやすくします。

## 確認内容

- `make format`
- `make lint`
- `uv run pytest tests/annotation_specs/test_list_annotation_import_info.py`