### PR TITLE
`task list_all_added_task_history`: `--latest_task `オプションを追加しました。

### DIFF
--- a/annofabcli/task/list_all_tasks_added_task_history.py
+++ b/annofabcli/task/list_all_tasks_added_task_history.py
@@ -61,15 +61,15 @@ class ListAllTasksAddedTaskHistoryMain:
 
         return task_list
 
-    def load_task_list(self, task_json_path: Path | None, temp_dir: Path | None) -> list[dict[str, Any]]:
+    def load_task_list(self, task_json_path: Path | None, temp_dir: Path | None, *, is_latest: bool) -> list[dict[str, Any]]:
         if task_json_path is None:
             # `NamedTemporaryFile`を使わない理由: Windowsで`PermissionError`が発生するため
             # https://qiita.com/yuji38kwmt/items/c6f50e1fc03dafdcdda0 参考
             if temp_dir is not None:
-                task_json_path = self.downloading_obj.download_task_json_to_dir(self.project_id, temp_dir)
+                task_json_path = self.downloading_obj.download_task_json_to_dir(self.project_id, temp_dir, is_latest=is_latest)
             else:
                 with tempfile.TemporaryDirectory() as str_temp_dir:
-                    task_json_path = self.downloading_obj.download_task_json_to_dir(self.project_id, Path(str_temp_dir))
+                    task_json_path = self.downloading_obj.download_task_json_to_dir(self.project_id, Path(str_temp_dir), is_latest=is_latest)
                     with task_json_path.open(encoding="utf-8") as f:
                         return json.load(f)
 
@@ -126,12 +126,14 @@ class ListAllTasksAddedTaskHistoryMain:
         task_id_list: list[str] | None,
         task_query: TaskQuery | None,
         temp_dir: Path | None,
+        *,
+        is_latest_task: bool,
         start_date_list: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """
         タスク履歴情報を加えたタスク一覧を取得する。
         """
-        task_list = self.load_task_list(task_json_path, temp_dir)
+        task_list = self.load_task_list(task_json_path, temp_dir, is_latest=is_latest_task)
         task_history_dict = self.load_task_history_dict(task_history_json_path, temp_dir)
 
         filtered_task_list = self.filter_task_list(task_list, task_id_list=task_id_list, task_query=task_query)
@@ -149,7 +151,7 @@ class ListAllTasksAddedTaskHistory(CommandLine):
     @staticmethod
     def validate(args: argparse.Namespace) -> bool:
         COMMON_MESSAGE = "annofabcli task list_all_added_task_history: error:"  # noqa: N806
-        if (args.task_json is None and args.task_history_json is not None) or (args.task_json is not None and args.task_history_json is None):
+        if not args.latest_task and ((args.task_json is None and args.task_history_json is not None) or (args.task_json is not None and args.task_history_json is None)):
             print(  # noqa: T201
                 f"{COMMON_MESSAGE} '--task_json'と'--task_history_json'の両方を指定する必要があります。",
                 file=sys.stderr,
@@ -165,6 +167,9 @@ class ListAllTasksAddedTaskHistory(CommandLine):
 
         project_id = args.project_id
 
+        if args.latest_task:
+            logger.warning("タスク全件ファイルのみを最新化します。タスク履歴に関する列は、タスク履歴全件ファイルの時点の情報です。")
+
         task_id_list = annofabcli.common.cli.get_list_from_args(args.task_id) if args.task_id is not None else None
         task_query = TaskQuery.from_dict(annofabcli.common.cli.get_json_from_args(args.task_query)) if args.task_query is not None else None
 
@@ -178,6 +183,7 @@ class ListAllTasksAddedTaskHistory(CommandLine):
             task_id_list=task_id_list,
             task_query=task_query,
             temp_dir=temp_dir,
+            is_latest_task=args.latest_task,
             start_date_list=start_date_list,
         )
 
@@ -197,11 +203,20 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
     argument_parser.add_task_query()
     argument_parser.add_task_id(required=False)
 
-    parser.add_argument(
+    task_source_group = parser.add_mutually_exclusive_group()
+
+    task_source_group.add_argument(
         "--task_json",
         type=str,
         help="タスク情報が記載されたJSONファイルのパスを指定すると、JSONに記載された情報を元に出力します。指定しない場合はJSONファイルをダウンロードします。\n"
         "JSONファイルは ``$ annofabcli task download`` コマンドで取得できます。",
+    )
+
+    task_source_group.add_argument(
+        "--latest_task",
+        action="store_true",
+        help="タスク全件ファイルを最新化してからダウンロードします。タスク履歴全件ファイルは更新されないため、タスク履歴に関する列は最新ではありません。"
+        "タスク全件ファイルの更新には、データ数に応じて数分から数十分かかります。",
     )
 
     parser.add_argument(

--- a/annofabcli/task/list_all_tasks_added_task_history.py
+++ b/annofabcli/task/list_all_tasks_added_task_history.py
@@ -207,7 +207,7 @@ def parse_args(parser: argparse.ArgumentParser) -> None:
 
     task_source_group.add_argument(
         "--task_json",
-        type=str,
+        type=Path,
         help="タスク情報が記載されたJSONファイルのパスを指定すると、JSONに記載された情報を元に出力します。指定しない場合はJSONファイルをダウンロードします。\n"
         "JSONファイルは ``$ annofabcli task download`` コマンドで取得できます。",
     )

--- a/docs/command_reference/task/list_all_added_task_history.rst
+++ b/docs/command_reference/task/list_all_added_task_history.rst
@@ -9,7 +9,8 @@ Description
 
 .. note::
 
-    出力されるタスクは、コマンドを実行した日の02:00(JST)頃の状態です。
+    出力されるタスクとタスク履歴に関する列は、それぞれの全件ファイルの時点の状態です。
+    タスク履歴全件ファイルは更新できないため、最新のタスク履歴情報は出力できません。
     
 
 
@@ -35,6 +36,22 @@ Examples
     --task_json task.json --task_history_json task_history.json
 
 タスク全件ファイルは `annofabcli task download <../task/download.html>`_ コマンド、タスク履歴全件ファイルは、`annofabcli task_history download <../task_history/download.html>`_ コマンドでダウンロードできます。
+
+
+タスク全件ファイルのみ最新化する
+----------------------------------------------
+
+``--latest_task`` を指定すると、タスク全件ファイルを最新化してからダウンロードします。
+このオプションは、最新のタスクのステータスやメタデータで絞り込む場合に利用できます。
+
+ただし、タスク履歴全件ファイルは更新されません。作業時間、担当者、到達日時などのタスク履歴に関する列は最新ではなく、``completed_datetime`` のようにタスクとタスク履歴の両方を用いる列も最新性を保証しません。
+
+.. code-block::
+
+    $ annofabcli task list_all_added_task_history --project_id prj1 --output task.csv \
+     --latest_task
+
+``--task_history_json`` を指定して、利用するタスク履歴全件ファイルを固定することもできます。``--latest_task`` と ``--task_json`` は同時に指定できません。
 
 
 タスクの絞り込み

--- a/tests/task/test_list_all_tasks_added_task_history.py
+++ b/tests/task/test_list_all_tasks_added_task_history.py
@@ -1,0 +1,20 @@
+import json
+from unittest.mock import MagicMock
+
+from annofabcli.task.list_all_tasks_added_task_history import ListAllTasksAddedTaskHistoryMain
+
+
+def test_load_task_list_updates_task_json_when_latest_task_is_specified(tmp_path):
+    task_json_path = tmp_path / "task.json"
+    task_list = [{"task_id": "task-1"}]
+    task_json_path.write_text(json.dumps(task_list), encoding="utf-8")
+
+    main_obj = ListAllTasksAddedTaskHistoryMain(MagicMock(), "project-1")
+    downloading_obj = MagicMock()
+    downloading_obj.download_task_json_to_dir.return_value = task_json_path
+    main_obj.downloading_obj = downloading_obj
+
+    actual = main_obj.load_task_list(task_json_path=None, temp_dir=tmp_path, is_latest=True)
+
+    assert actual == task_list
+    downloading_obj.download_task_json_to_dir.assert_called_once_with("project-1", tmp_path, is_latest=True)


### PR DESCRIPTION
タスク履歴ファイルは更新できないので、今まで"--latest"オプションは用意していませんでした。
しかし、タスク履歴と整合性が取れなくてもタスク全件ファイルを更新したい場合もあったので、"--latest_task"という名前からタスク全件ファイルしか更新しないと分かるオプションを追加しました。