### PR TITLE
`annotation_specs list_annotation_import_info` : `read_only`も出力するようにしました。

### DIFF
--- a/annofabcli/annotation_specs/list_annotation_import_info.py
+++ b/annofabcli/annotation_specs/list_annotation_import_info.py
@@ -47,6 +47,8 @@ class AnnotationImportAttribute(BaseModel):
     """属性名（日本語）。"""
     attribute_type: str
     """属性の種類。"""
+    read_only: bool
+    """読み込み専用の属性か否か。"""
     choices: list[AnnotationImportChoice]
     """属性で指定できる選択肢情報。"""
 
@@ -102,6 +104,7 @@ def create_annotation_import_info_list(annotation_specs_v3: dict[str, Any]) -> l
                     attribute_name_en=get_attribute_name_en(attribute),
                     attribute_name_ja=get_japanese_message(cast(InternationalizationMessage, attribute["name"])),
                     attribute_type=attribute["type"],
+                    read_only=attribute["read_only"],
                     choices=create_choice_list(attribute),
                 )
             )

--- a/docs/command_reference/annotation_specs/list_annotation_import_info.rst
+++ b/docs/command_reference/annotation_specs/list_annotation_import_info.rst
@@ -8,7 +8,7 @@ Description
 
 ``annotation import`` のJSONに指定するラベル名、属性名、選択肢名を確認するためのコマンドです。
 日本語名は、プロンプトや変換処理を書く際の参考情報として出力します。
-色情報、ID、キーバインドなど、 ``annotation import`` で直接参照しない情報は出力しません。
+色情報、ID、キーバインドなど、 ``annotation import`` で直接参照せず、インポートデータを作成する際の判断にも不要な情報は出力しません。
 
 
 Examples
@@ -63,12 +63,14 @@ JSON出力
                     "attribute_name_en": "occluded",
                     "attribute_name_ja": "遮蔽",
                     "attribute_type": "flag",
+                    "read_only": false,
                     "choices": []
                 },
                 {
                     "attribute_name_en": "direction",
                     "attribute_name_ja": "向き",
                     "attribute_type": "select",
+                    "read_only": false,
                     "choices": [
                         {
                             "choice_name_en": "front",
@@ -93,6 +95,7 @@ JSON出力
   * ``attribute_name_en`` : 属性名（英語）。 ``annotation import`` の ``attributes`` のキーに指定する値です。
   * ``attribute_name_ja`` : 属性名（日本語）。プロンプトや変換処理を書く際の参考情報です。
   * ``attribute_type`` : 属性の種類。WebAPIの ``AdditionalDataDefinitionType`` に対応しています。
+  * ``read_only`` : 読み込み専用の属性か否か。
   * ``choices`` : 選択肢情報の配列です。属性の種類がラジオボタンまたはドロップダウン以外の場合は空配列です。
 
     * ``choice_name_en`` : 選択肢名（英語）。属性の種類がラジオボタンまたはドロップダウンの場合に、 ``annotation import`` の ``attributes`` の値として指定する値です。

--- a/tests/annotation_specs/test_list_annotation_import_info.py
+++ b/tests/annotation_specs/test_list_annotation_import_info.py
@@ -11,6 +11,7 @@ DATA_DIR = Path("./tests/data/annotation_specs")
 def test_create_annotation_import_info_listはimportに必要な情報を出力する() -> None:
     with (DATA_DIR / "annotation_specs.json").open(encoding="utf-8") as f:
         annotation_specs = json.load(f)
+    annotation_specs["additionals"][0]["read_only"] = True
 
     actual = create_annotation_import_info_list(annotation_specs)
 
@@ -19,6 +20,7 @@ def test_create_annotation_import_info_listはimportに必要な情報を出力�
     assert car_label.annotation_type == "bounding_box"
     assert [e.attribute_name_en for e in car_label.attributes] == ["comment", "link", "type", "unclear"]
     assert [e.attribute_name_ja for e in car_label.attributes] == ["comment", "link", "type", "unclear"]
+    assert [e.read_only for e in car_label.attributes] == [True, False, False, False]
 
     type_attribute = next(e for e in car_label.attributes if e.attribute_name_en == "type")
     assert type_attribute.attribute_type == "select"


### PR DESCRIPTION
… related documentation